### PR TITLE
Allow customising commands like postinstall & cron

### DIFF
--- a/drupal/templates/cron.yaml
+++ b/drupal/templates/cron.yaml
@@ -13,9 +13,9 @@ spec:
           containers:
           - name: drupal-cron
             image: "{{ .Values.drupal.image }}"
-            command:
-            - drush
-            - cron
+            command: ["/bin/sh", "-c"]
+            args:
+            - {{ .Values.commands.cron | quote }}
             env:
             - name: PHP_FPM_CLEAR_ENV
               value: "no"

--- a/drupal/templates/postinstall.yaml
+++ b/drupal/templates/postinstall.yaml
@@ -17,10 +17,7 @@ spec:
         image: {{ .Values.drupal.image | quote }}
         command: ["/bin/sh", "-c"]
         args:
-        - cd web;
-          bootstrapped=$(drush status --field=bootstrap);
-          if [[ $bootstrapped = *'Success'* ]]; then drush updatedb -n; drush config-import -n; drush entity-updates -n;
-          else drush site-install -n config_installer; conf_count=$(ls ../config/sync/ | wc -l); if [ $conf_count -lt 2 ]; then drush site-install minimal -y; fi; fi;
+        - {{ .Values.commands.postinstall | quote }}
         env:
         - name: PHP_FPM_CLEAR_ENV
           value: "no"

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -26,3 +26,11 @@ ingress:
 
 secrets:
     hashsalt: "template-hash-salt"
+
+commands:
+  postinstall: |
+    cd web;
+    bootstrapped=$(drush status --field=bootstrap);
+    if [[ $bootstrapped = *'Success'* ]]; then drush updatedb -n; drush config-import -n; drush entity-updates -n;
+    else drush site-install -n config_installer; conf_count=$(ls ../config/sync/ | wc -l); if [ $conf_count -lt 2 ]; then drush site-install minimal -y; fi; fi;
+  cron: drush cron


### PR DESCRIPTION
Projects vary a lot in how they install drupal, or load its configuration. Allow these command to be passed into the chart as variables.