### PR TITLE
Remove silta ingress

### DIFF
--- a/drupal/templates/ingress.yaml
+++ b/drupal/templates/ingress.yaml
@@ -22,13 +22,6 @@ spec:
             backend:
               serviceName: {{ .Release.Name }}-drupal
               servicePort: 80
-    - host: {{ .Release.Name }}.{{ .Release.Namespace }}.silta.wdr.io
-      http:
-        paths:
-          - path: /
-            backend:
-              serviceName: {{ .Release.Name }}-drupal
-              servicePort: 80
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}


### PR DESCRIPTION
The dedicated ingress route for silta seems unnecessary, because the chart already allows a custom hostname to be passed as a variable.

If you'd like apps to be available to multiple hostnames, how about making the ingress.hostnames variable into an array of hostnames and iterating on that array in the ingress template.