### PR TITLE
DRY the drupal container

### DIFF
--- a/drupal/templates/_drupal-pod-spec.tpl
+++ b/drupal/templates/_drupal-pod-spec.tpl
@@ -1,0 +1,35 @@
+{{/* Specification for a generic drupal container */}}
+{{- define "drupal.drupal-container" }}
+image: {{ .Values.drupal.image | quote }}
+env:
+- name: DB_USER
+  value: "{{ .Values.mariadb.db.user }}"
+- name: DB_NAME
+  value: "{{ .Values.mariadb.db.name }}"
+- name: DB_HOST
+  value: {{ .Release.Name }}-mariadb
+- name: DB_PASS
+  valueFrom:
+	secretKeyRef:
+	  name: {{ .Release.Name }}-mariadb
+	  key: mariadb-password
+- name: HASH_SALT
+  valueFrom:
+	secretKeyRef:
+	  name: {{ .Release.Name }}-secrets-drupal
+	  key: hashsalt
+{{- range $key, $val := .Values.drupal.env }}
+- name: {{ $key }}
+  value: {{ $val | quote }}
+{{- end }} 
+volumeMounts:
+- name: drupal-files-volume
+  mountPath: /var/www/html/web/sites/default/files
+{{- end -}}
+
+{{/* The drupal files volume */}}
+{{- define "drupal.drupal-files-volume" }}
+- name: drupal-files-volume
+  persistentVolumeClaim:
+    claimName: {{ .Release.Name }}-public-files
+{{- end -}}

--- a/drupal/templates/_drupal-pod-spec.tpl
+++ b/drupal/templates/_drupal-pod-spec.tpl
@@ -1,5 +1,5 @@
 {{/* Specification for a generic drupal container */}}
-{{- define "drupal.drupal-container" }}
+{{- define "drupal.drupal-container" -}}
 image: {{ .Values.drupal.image | quote }}
 env:
 - name: DB_USER
@@ -10,14 +10,14 @@ env:
   value: {{ .Release.Name }}-mariadb
 - name: DB_PASS
   valueFrom:
-	secretKeyRef:
-	  name: {{ .Release.Name }}-mariadb
-	  key: mariadb-password
+    secretKeyRef:
+      name: {{ .Release.Name }}-mariadb
+      key: mariadb-password
 - name: HASH_SALT
   valueFrom:
-	secretKeyRef:
-	  name: {{ .Release.Name }}-secrets-drupal
-	  key: hashsalt
+    secretKeyRef:
+      name: {{ .Release.Name }}-secrets-drupal
+      key: hashsalt
 {{- range $key, $val := .Values.drupal.env }}
 - name: {{ $key }}
   value: {{ $val | quote }}
@@ -26,9 +26,8 @@ volumeMounts:
 - name: drupal-files-volume
   mountPath: /var/www/html/web/sites/default/files
 {{- end -}}
-
 {{/* The drupal files volume */}}
-{{- define "drupal.drupal-files-volume" }}
+{{- define "drupal.drupal-files-volume" -}}
 - name: drupal-files-volume
   persistentVolumeClaim:
     claimName: {{ .Release.Name }}-public-files

--- a/drupal/templates/cron.yaml
+++ b/drupal/templates/cron.yaml
@@ -16,18 +16,9 @@ spec:
             command:
             - drush
             - cron
-            env:
-            - name: PHP_FPM_CLEAR_ENV
-              value: "no"
-            - name: DB_USER
-              value: "{{ .Values.mariadb.db.user }}"
-            - name: DB_NAME
-              value: "{{ .Values.mariadb.db.name }}"
-            - name: DB_HOST
-              value: "{{ .Release.Name }}-mariadb"
-            - name: DB_PASS
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ .Release.Name }}-mariadb"
-                  key: mariadb-password
+{{ include "drupal.drupal-container" . | indent 12 }}
+          imagePullSecrets:
+          - name: gcr
+          volumes:
+{{ include "drupal.drupal-files-volume" . | indent 10 }}
           restartPolicy: OnFailure

--- a/drupal/templates/drupal.yaml
+++ b/drupal/templates/drupal.yaml
@@ -55,38 +55,13 @@ spec:
         - name: drupal-files-volume
           mountPath: /var/www/html/web/sites/default/files
 
-      - image: {{ .Values.drupal.image | quote }}
-        name: drupal
-        env:
-        - name: DB_USER
-          value: "{{ .Values.mariadb.db.user }}"
-        - name: DB_NAME
-          value: "{{ .Values.mariadb.db.name }}"
-        - name: DB_HOST
-          value: {{ .Release.Name }}-mariadb
-        - name: DB_PASS
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-mariadb
-              key: mariadb-password
-        - name: HASH_SALT
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-secrets-drupal
-              key: hashsalt
-      {{- range $key, $val := .Values.drupal.env }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-      {{- end }} 
+      - name: drupal
         ports:
         - containerPort: 9000
           name: drupal
-        volumeMounts:
-        - name: drupal-files-volume
-          mountPath: /var/www/html/web/sites/default/files
+{{ include "drupal.drupal-container" . | indent 8 }}
+
       imagePullSecrets:
       - name: gcr
       volumes:
-      - name: drupal-files-volume
-        persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-public-files
+{{ include "drupal.drupal-files-volume" . | indent 6 }}

--- a/drupal/templates/postinstall.yaml
+++ b/drupal/templates/postinstall.yaml
@@ -14,42 +14,14 @@ spec:
       restartPolicy: Never
       containers:
       - name: postinstall
-        image: {{ .Values.drupal.image | quote }}
         command: ["/bin/sh", "-c"]
         args:
         - cd web;
           bootstrapped=$(drush status --field=bootstrap);
           if [[ $bootstrapped = *'Success'* ]]; then drush updatedb -n; drush config-import -n; drush entity-updates -n;
           else drush site-install -n config_installer; conf_count=$(ls ../config/sync/ | wc -l); if [ $conf_count -lt 2 ]; then drush site-install minimal -y; fi; fi;
-        env:
-        - name: PHP_FPM_CLEAR_ENV
-          value: "no"
-        - name: DB_USER
-          value: "{{ .Values.mariadb.db.user }}"
-        - name: DB_NAME
-          value: "{{ .Values.mariadb.db.name }}"
-        - name: DB_HOST
-          value: "{{ .Release.Name }}-mariadb"
-        - name: DB_PASS
-          valueFrom:
-            secretKeyRef:
-              name: "{{ .Release.Name }}-mariadb"
-              key: mariadb-password
-        - name: HASH_SALT
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-secrets-drupal
-              key: hashsalt
-      {{- range $key, $val := .Values.drupal.env }}
-        - name: {{ $key }}
-          value: {{ $val | quote }}
-      {{- end }}
-        volumeMounts:
-          - name: drupal-files-volume
-            mountPath: /var/www/html/web/sites/default/files
+{{ include "drupal.drupal-container" . | indent 8 }}
       imagePullSecrets:
       - name: gcr
       volumes:
-      - name: drupal-files-volume
-        persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-public-files
+{{ include "drupal.drupal-files-volume" . | indent 6 }}


### PR DESCRIPTION
There's a lot of repetition between the drupal.yaml, postinstall.yaml and cron.yaml. We can use a helper template to DRY this.

This also seems to help with fixing the cron, the definition of which was weak compared to that of postinstall.