### PR TITLE
Use default storage for mariadb

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -9,9 +9,6 @@ drupal:
     PHP_FPM_CLEAR_ENV: "no"
 
 mariadb:
-  master:
-    persistence:
-      storageClass: standard
   replication:
     enabled: false
   rootUser:


### PR DESCRIPTION
Your values specify 'standard' as the storage mariadb should use.

'standard' is the name of the default storage class on GKE, but doesn't exist on Azure (there the default class is called 'default').

Wouldn't it be better to just not specify a storage class so the local default is used naturally?

The mariadb chart docs say:
```
    ## Persistent Volume Storage Class
    ## If defined, storageClassName: <storageClass>
    ## If set to "-", storageClassName: "", which disables dynamic provisioning
    ## If undefined (the default) or set to null, no storageClassName spec is
    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
    ##   GKE, AWS & OpenStack)
    ##
    # storageClass: "-"
```