### PR TITLE
Change order of drush operations and add drush entup command

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -111,11 +111,13 @@ php:
   # This is run every time a new environment is upgraded.
   postupgrade:
     command: |
+      drush cache-rebuild
       drush updatedb -n
       if [ -f config/sync/core.extension.yml ]; then
         drush config-import -n
       fi
-      drush cr
+      drush entity-updates -n
+      
 
   # Pass additional environment variables to all php containers as key-value pairs.
   env: {}


### PR DESCRIPTION
I propose to clear the cache as first thing after the deployment, then updatedb, then config import, then drush entity-updates, which updates the entity schema if needed.

This same order has been in use in projects and it seems to have worked well for our needs.