### PR TITLE
SLT-245: Set resources for the nfs provisioner.

### DIFF
--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -12,6 +12,13 @@ nfs-server-provisioner:
     parameters:
       mountOptions:
         - vers=4.1
+  resources:
+    limits:
+      cpu: 200m
+      memory: 1G
+    requests:
+      cpu: 200m
+      memory: 1G
 
 # SSH Jumphost settings
 gitAuth:


### PR DESCRIPTION
The nfs provisioner has been unstable. Sometimes it uses a lot of memory (up to 1.8G) and seems to hold on to it forever, and it could also be that some of the issues are due to insufficient resources. Setting both requests and limits to the same value is recommended for a more consistent behavior, which in this case we really want.

Note that I applied this change to the currently deployed StatfulSet and things seem to work quite well.