### PR TITLE
Feature/slt 255 robots

### DIFF
--- a/drupal/templates/drupal-configmap-nginx.yaml
+++ b/drupal/templates/drupal-configmap-nginx.yaml
@@ -310,10 +310,15 @@ data:
             fastcgi_param SCRIPT_FILENAME $document_root/update.php;                                                                                       
             fastcgi_pass php;                                                                                                                              
         }                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
-                                                                                                                                                          
-        location = /robots.txt {                                                                        
-            access_log off;                                                                                                                                
-            try_files $uri @drupal-no-args;                                                                                                                
+
+        location = /robots.txt {
+          access_log off;
+          {{- if not .Values.nginx.robotsTxt.allow }}
+            add_header Content-Type text/plain;
+            return 200 'User-agent: *\nDisallow: /';
+          {{- else }}
+            try_files $uri @drupal-no-args;
+          {{- end}}
         } 
                                                                                                                                                                                                   
         location ~* ^/.well-known/ {                                                                                                                       

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -48,6 +48,10 @@ nginx:
     noauthips:
       - 10.0.0.0/8 # GKE internal IPs
 
+  # Robots txt file blocked by default
+  robotsTxt:
+    allow: false
+
 # Configuration for everything that runs in php containers.
 php:
   # The docker image to be used. This is typically passed by your CI system using the --set parameter.

--- a/silta-cluster/templates/splash.yaml
+++ b/silta-cluster/templates/splash.yaml
@@ -11,15 +11,7 @@ metadata:
       name:  {{ .Release.Name }}-splash
       prefix: /
       service: {{ .Release.Name }}-splash:80
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name:  {{ .Release.Name }}-no-robots
-      prefix: /robots.txt
-      rewrite: /robots/deny/robots.txt
-      service: {{ .Release.Name }}-splash:80
-      precedence: 10
-
+      
 spec:
   type: NodePort
   ports:

--- a/simple/templates/configmap.yaml
+++ b/simple/templates/configmap.yaml
@@ -88,7 +88,15 @@ data:
         include fastcgi.conf;
 
         {{ include "drupal.basicauth" . | indent 6}}
-                                              
+         
+        location = /robots.txt {
+          access_log off;
+          {{- if not .Values.nginx.robotsTxt.allow }}
+            add_header Content-Type text/plain;
+            return 200 'User-agent: *\nDisallow: /';
+          {{- end}}
+        } 
+
         location / {                                                                                                              
             ## Most sites won't have configured favicon
             ## and since its always grabbed, turn it off in access log

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -46,3 +46,6 @@ nginx:
     noauthips:
       - 10.0.0.0/8 # GKE internal IPs
 
+  # Robots txt file blocked by default
+  robotsTxt:
+    allow: false


### PR DESCRIPTION
Moving robots.txt rewrite from `silta-cluster` to deployments. Denied by default.

Related PR's: 
- robots.txt nginx rewrite in drupal chart (k8s test): 
  https://github.com/wunderio/drupal-project-k8s/pull/111
- Removing ambassador robots.txt mapping from silta-cluster. robots.txt nginx rewrite in drupal and simple charts:
  https://github.com/wunderio/charts/pull/27
- Removing robots.txt file from container: 
  https://github.com/wunderio/silta-splash/pull/4