### PR TITLE
SLT-258: Deploy chart repository to Google Cloud Storage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,50 @@
-version: 2
+version: 2.1
+
+orbs:
+  silta: silta/silta@0.1
+
 jobs:
-  build:
-    docker:
-      - image: wunderio/silta-circleci:v0.1
+  validate:
+    executor: silta/silta
 
     steps:
       - checkout
-
       - run: helm lint drupal/
 
+  deploy:
+    executor: silta/silta
+
+    steps:
+      - checkout
+      - run:
+          name: Build charts
+          command: |
+            set -o xtrace
+
+            mkdir -p /tmp/charts
+            for CHARTFILE in `find . -name Chart.yaml`
+            do
+              CHART=`dirname $CHARTFILE`
+              helm dependency build $CHART
+              helm package $CHART --destination /tmp/charts
+
+              helm repo index /tmp/charts --url https://wunderio.github.io/charts/
+            done
+
+      - silta/gcloud-login
+
+      - run:
+          name: Deploy to Google Cloud Storage
+          command: |
+            gsutil -m rsync -d -r . gs://charts.wdr.io
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - validate
+      - deploy:
+          context: global_nonprod
+#          filters:
+#            branches:
+#              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: Deploy to Google Cloud Storage
           command: |
-            gsutil -m rsync -d -r . gs://charts.wdr.io
+            gsutil -m rsync -d -r /tmp/charts gs://charts.wdr.io
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,6 @@ workflows:
       - validate
       - deploy:
           context: global_nonprod
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
           command: |
             set -o xtrace
 
+            helm repo add wunder-charts https://wunderio.github.io/charts
+
             mkdir -p /tmp/charts
             for CHARTFILE in `find . -name Chart.yaml`
             do

--- a/silta-cluster/requirements.lock
+++ b/silta-cluster/requirements.lock
@@ -3,8 +3,8 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 0.1.5
 - name: ambassador
-  repository: https://www.getambassador.io
-  version: 0.40.2
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 2.9.0
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 4.3.1
@@ -17,5 +17,5 @@ dependencies:
 - name: csi-rclone
   repository: https://wunderio.github.io/charts/
   version: 0.1.0
-digest: sha256:1b1beab35186dfb47c90f5979a52dd769fa27e5585f82ba3f6122ced71d3b470
-generated: 2019-06-12T13:36:09.625004218Z
+digest: sha256:bc852752d651709a7621daacea85cf01171dc5d5e3cef483dc4492f7641ba1d2
+generated: "2019-06-24T15:53:57.649056+02:00"

--- a/silta-cluster/requirements.yaml
+++ b/silta-cluster/requirements.yaml
@@ -4,8 +4,8 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: nfs-server-provisioner.enabled
 - name: ambassador
-  version: 0.40.x
-  repository: https://www.getambassador.io
+  version: 2.9.x
+  repository: https://kubernetes-charts.storage.googleapis.com/
 - name: redis
   version: 4.3.x
   repository: https://kubernetes-charts.storage.googleapis.com/

--- a/silta-cluster/templates/splash.yaml
+++ b/silta-cluster/templates/splash.yaml
@@ -19,12 +19,7 @@ metadata:
       rewrite: /robots/deny/robots.txt
       service: {{ .Release.Name }}-splash:80
       precedence: 10
-      ---
-      apiVersion: ambassador/v0
-      kind: Module
-      name: ambassador
-      config:
-        use_remote_address: true
+
 spec:
   type: NodePort
   ports:

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -1,6 +1,22 @@
 # Main domain of the cluster.
 clusterDomain: "silta.wdr.io"
 
+ambassador:
+  service:
+    https:
+      enabled: false
+    annotations:
+      getambassador.io/config: |
+        ---
+        apiVersion: ambassador/v1
+        kind: Module
+        name: ambassador
+        config:
+          service_port: 8080
+          use_remote_address: true
+  adminService:
+    create: true
+
 nfs-server-provisioner:
   enabled: true
   persistence:

--- a/simple/requirements.lock
+++ b/simple/requirements.lock
@@ -1,0 +1,3 @@
+dependencies: []
+digest: sha256:a4028ef6b5df0ba52501af1116d232a75056093f30ddf3b725e34fff764048c2
+generated: "2019-06-24T15:39:13.7446+02:00"


### PR DESCRIPTION
NOTE: this PR includes an upgrade to the latest version of ambassador, which is now hosted in the stable Helm charts repository. I haven't tested it, I just wanted the chart repository deployment to work.

This is the first step towards moving away from using Github pages to host the charts repository. That is still functioning, but the charts are now additionally available from http://charts.wdr.io