### PR TITLE
Only create explicit drupal PVs if using silta-shared

### DIFF
--- a/drupal/templates/drupal-volumes.yaml
+++ b/drupal/templates/drupal-volumes.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.publicFiles.storageClassName "silta-shared"}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -16,8 +17,9 @@ spec:
     volumeHandle: {{ .Release.Name }}-public-files
     volumeAttributes:
       remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/public-files
-  {{- end }}
+  {{- end }} 
 ---
+{{- end }} 
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -33,6 +35,7 @@ spec:
       storage: {{ .Values.publicFiles.storage }}
 ---
 {{- if .Values.privateFiles.enabled }}
+{{- if eq .Values.privateFiles.storageClassName "silta-shared"}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -53,6 +56,7 @@ spec:
       remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/private-files
   {{- end }}
 ---
+{{- end }} 
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
### Problem
When values for publicFiles.storageClassName is "azure-file", then Helm upgrade fails with error:
`Error: release update-drupal-subchart failed: PersistentVolume "update-parent-chart-private-files" is invalid: spec: Required value: must specify a volume type`

### Diagnosis
#25 created explicit persistent volumes in the drupal-volumes template.

But according to https://stackoverflow.com/questions/55955646/required-value-must-specify-a-volume-type-when-statically-provisioning-pv :

> If using a provisioner, you usually don't create the PV on your own. Just create a PVC requiring that created storage class 

### Solution

Only create the PVs explicitly if using silta-shared as the storage class.