### PR TITLE
SLT-272: Set resources for the release remover.

### DIFF
--- a/silta-cluster/templates/deployment-remover.yaml
+++ b/silta-cluster/templates/deployment-remover.yaml
@@ -62,3 +62,10 @@ spec:
             value: {{ required "A valid .Values.gke.computeZone entry required!" .Values.gke.computeZone | quote }}
           - name: GCLOUD_CLUSTER_NAME
             value: {{ required "A valid .Values.gke.clusterName entry required!" .Values.gke.clusterName | quote }}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100M
+          requests:
+            cpu: 100m
+            memory: 100M


### PR DESCRIPTION
It's generally best to have dedicated resources for everything. 

I have set the same requests and limits on the deployed kubernetes resources, everything seems to work fine, eventually we could even set those values even lower.