### PR TITLE
SLT-281: Enable limiting jumpserver access by ip.

### DIFF
--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -8,6 +8,10 @@ spec:
     - name: ssh
       port: 22
   type: "LoadBalancer"
+{{- if .Values.gitAuth.allowedIps }}
+  loadBalancerSourceRanges:
+    {{ .Values.gitAuth.allowedIps | toYaml }}
+{{- end }}
   selector:
     name: {{ .Release.Name }}-jumpserver
 ---

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -45,6 +45,7 @@ gitAuth:
   host: 'github.com'
   organisation: ''
   apiToken: ''
+  allowedIps: []
 
 # Deployment remover
 deploymentRemover:


### PR DESCRIPTION
This turned out to be a lot easier than I was expecting. See https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/ for the full documentation.

Once this is committed, we can simply restrict access by adding the IP of our VPN in the values file like this:
```
gitAuth:
  allowedIps:
  - 1.2.3.4/32
  - 5.6.7.8/32
```