### PR TITLE
Slight change in allowedIps usage

### DIFF
--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -10,7 +10,7 @@ spec:
   type: "LoadBalancer"
 {{- if .Values.gitAuth.allowedIps }}
   loadBalancerSourceRanges:
-    {{ .Values.gitAuth.allowedIps | toYaml }}
+    {{- .Values.gitAuth.allowedIps | toYaml | nindent 2 -}}
 {{- end }}
   selector:
     name: {{ .Release.Name }}-jumpserver


### PR DESCRIPTION
Got errors while using `allowedIps` while using [this syntax](https://github.com/wunderio/charts/pull/38)

```
Error: YAML parse error on silta-cluster/templates/sshd-jumpserver.yaml: error converting YAML to JSON: yaml: line 11: did not find expected key
Error: UPGRADE FAILED: YAML parse error on silta-cluster/templates/sshd-jumpserver.yaml: error converting YAML to JSON: yaml: line 11: did not find expected key
```

this change fixes the issue.