### PR TITLE
SLT-299: Setting ambassador externalTrafficPolicy to Local due to repo change

### DIFF
--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -5,6 +5,7 @@ ambassador:
   service:
     https:
       enabled: false
+    externalTrafficPolicy: Local
     annotations:
       getambassador.io/config: |
         ---


### PR DESCRIPTION
We were using datawire repo before and it has `externalTrafficPolicy: Local` by default: https://github.com/datawire/ambassador/blob/3d630fb1c81ee1efa527ebd4d51df67093eb6e3e/docs/yaml/ambassador/ambassador-service.yaml#L8

but the stable allows changing that
https://github.com/helm/charts/blob/master/stable/ambassador/templates/service.yaml#L21

and defaults to ""

We need this to be `Local`