### PR TITLE
SLT-302: Make resources configurable for support services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
             do
               CHART=`dirname $CHARTFILE`
               helm lint $CHART
+              helm unittest $CHART
             done
 
   build:

--- a/csi-rclone/templates/csi-controller-rclone.yaml
+++ b/csi-rclone/templates/csi-controller-rclone.yaml
@@ -31,6 +31,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            {{- .Values.controller.attacher.resources | toYaml | nindent 12 }}
         - name: csi-cluster-driver-registrar
           image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
           args:
@@ -43,6 +45,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            {{- .Values.controller.registrar.resources | toYaml | nindent 12 }}
         - name: rclone
           image: wunderio/csi-rclone:{{- .Values.version }}
           imagePullPolicy: Always
@@ -61,6 +65,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /plugin
+          resources:
+            {{- .Values.controller.rclone.resources | toYaml | nindent 12 }}
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/csi-rclone/templates/csi-nodeplugin-rclone.yaml
+++ b/csi-rclone/templates/csi-nodeplugin-rclone.yaml
@@ -38,6 +38,8 @@ spec:
               mountPath: /plugin
             - name: registration-dir
               mountPath: /registration
+          resources:
+            {{- .Values.nodePlugin.registrar.resources | toYaml | nindent 12 }}
         - name: rclone
           securityContext:
             privileged: true
@@ -68,6 +70,8 @@ spec:
             - name: pods-mount-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: "Bidirectional"
+          resources:
+            {{- .Values.nodePlugin.rclone.resources | toYaml | nindent 12 }}
       volumes:
         - name: plugin-dir
           hostPath:

--- a/csi-rclone/tests/controller_test.yaml
+++ b/csi-rclone/tests/controller_test.yaml
@@ -1,0 +1,34 @@
+suite: Controller
+templates:
+  - csi-controller-rclone.yaml
+tests:
+  - it: is a stateful set
+    asserts:
+      - isKind:
+          of: StatefulSet
+
+  - it: can set resources
+    set:
+      controller:
+        attacher:
+          resources:
+            requests:
+              cpu: 123m
+        registrar:
+          resources:
+            requests:
+              cpu: 456m
+        rclone:
+          resources:
+            requests:
+              cpu: 789m
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 123m
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.cpu
+          value: 456m
+      - equal:
+          path: spec.template.spec.containers[2].resources.requests.cpu
+          value: 789m

--- a/csi-rclone/tests/node_plugin_test.yaml
+++ b/csi-rclone/tests/node_plugin_test.yaml
@@ -1,0 +1,27 @@
+suite: CSI Node Plugin
+templates:
+  - csi-nodeplugin-rclone.yaml
+tests:
+  - it: is a daemon
+    asserts:
+      - isKind:
+          of: DaemonSet
+
+  - it: can set resources
+    set:
+      nodePlugin:
+        registrar:
+          resources:
+            requests:
+              cpu: 123m
+        rclone:
+          resources:
+            requests:
+              cpu: 456m
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 123m
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.cpu
+          value: 456m

--- a/csi-rclone/values.yaml
+++ b/csi-rclone/values.yaml
@@ -22,3 +22,11 @@ params:
   # Default credentials of minio chart https://github.com/helm/charts/tree/master/stable/minio
   s3-access-key-id: "AKIAIOSFODNN7EXAMPLE"
   s3-secret-access-key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+controller:
+  attacher:
+    resources: {}
+  registrar:
+    resources: {}
+  rclone:
+    resources: {}

--- a/csi-rclone/values.yaml
+++ b/csi-rclone/values.yaml
@@ -23,6 +23,12 @@ params:
   s3-access-key-id: "AKIAIOSFODNN7EXAMPLE"
   s3-secret-access-key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 
+nodePlugin:
+  registrar:
+    resources: {}
+  rclone:
+    resources: {}
+
 controller:
   attacher:
     resources: {}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -202,7 +202,7 @@ referenceData:
   csiDriverName: csi-rclone
 
   # Skips mounting the volume outside of the reference environment, only used programmatically.
-  skipMounting: false
+  skipMount: false
 
 # Parameters for sanitizing reference data with gdpr-dump.
 # Uses formatters from https://packagist.org/packages/fzaninotto/faker.

--- a/silta-cluster/templates/deployment-remover.yaml
+++ b/silta-cluster/templates/deployment-remover.yaml
@@ -62,3 +62,5 @@ spec:
             value: {{ required "A valid .Values.gke.computeZone entry required!" .Values.gke.computeZone | quote }}
           - name: GCLOUD_CLUSTER_NAME
             value: {{ required "A valid .Values.gke.clusterName entry required!" .Values.gke.clusterName | quote }}
+        resources:
+          {{- .Values.deploymentRemover.resources | toYaml | nindent 10 }}

--- a/silta-cluster/templates/splash.yaml
+++ b/silta-cluster/templates/splash.yaml
@@ -11,7 +11,7 @@ metadata:
       name:  {{ .Release.Name }}-splash
       prefix: /
       service: {{ .Release.Name }}-splash:80
-      
+
 spec:
   type: NodePort
   ports:
@@ -38,6 +38,4 @@ spec:
       - image: "wunderio/silta-splash"
         name: nginx
         resources:
-          requests:
-            cpu: 10m
-            memory: 10M
+          {{- .Values.splash.resources | toYaml | nindent 10 }}

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -46,6 +46,8 @@ spec:
       - name: shell-keys
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-shell-keys
+      resources:
+        {{- .Values.gitAuth.resources | toYaml | nindent 8 }}
 
 ---
 apiVersion: v1

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -54,6 +54,8 @@ gitAuth:
   organisation: ''
   apiToken: ''
   allowedIps: []
+  # Kubernetes resource allocation.
+  resources: {}
 
 # Deployment remover
 deploymentRemover:

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -61,6 +61,8 @@ gitAuth:
 deploymentRemover:
   # Github webhooks secret
   webhooksSecret: ''
+  # Kubernetes resource allocation.
+  resources: {}
 
 # GKE Cluster settings
 gke:

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -40,6 +40,14 @@ csi-rclone:
 minio:
   enabled: false
 
+# Splash page.
+splash:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 10M
+
+
 # SSH Jumphost settings
 gitAuth:
   host: 'github.com'

--- a/simple/tests/deployment_test.yaml
+++ b/simple/tests/deployment_test.yaml
@@ -11,7 +11,7 @@ tests:
           value: 1
       - equal:
           path: metadata.labels.app
-          value: gatsby
+          value: simple
 
   - it: uses the right docker images
     set:


### PR DESCRIPTION
Support services need to have dedicated resources to make sure that they are still functioning properly when the cluster is under load. This PR only makes the resources configurable, the parameters still need to be set when creating the silta-cluster helm release.