### PR TITLE
SLT-337: Shorten domain names but keep the longest possible readable name

### DIFF
--- a/drupal/templates/_domains.tpl
+++ b/drupal/templates/_domains.tpl
@@ -1,9 +1,16 @@
-{{- define "drupal.domain" -}}
-{{ include "drupal.environmentName" . }}.{{ regexReplaceAll "[^[:alnum:]]" (.Values.projectName | default .Release.Namespace) "-" | trunc 30 | trimSuffix "-" | lower }}.{{ .Values.clusterDomain }}
-{{- end -}}
 
-{{- define "drupal.environmentName" -}}
-{{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower | trunc 50 | trimSuffix "-" }}
+
+{{- define "drupal.domain" -}}
+{{- $projectName := regexReplaceAll "[^[:alnum:]]" (.Values.projectName | default .Release.Namespace) "-"  | trimSuffix "-" | lower }}
+{{- $projectNameHash := sha256sum $projectName | trunc 3 }}
+{{- $projectName := (ge (len $projectName) 30) | ternary (print ($projectName | trunc 27) $projectNameHash ) $projectName}}
+
+{{- $environmentName := regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | trimSuffix "-" | lower }}
+{{- $environmentNameHash := sha256sum $environmentName | trunc 3 }}
+{{- $maxEnvironmentNameLength := int (sub 62 (add (len .Values.clusterDomain) (len $projectName))) }}
+{{- $environmentName := (ge (len $environmentName) $maxEnvironmentNameLength) | ternary (print ($environmentName | trunc (int (sub $maxEnvironmentNameLength 3))) $environmentNameHash) $environmentName -}}
+
+{{ $environmentName }}.{{ $projectName }}.{{ .Values.clusterDomain }}
 {{- end -}}
 
 {{- define "drupal.referenceEnvironment" -}}

--- a/drupal/tests/drupal_ingress_test.yaml
+++ b/drupal/tests/drupal_ingress_test.yaml
@@ -45,3 +45,28 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[0].backend.serviceName
           value: 'RELEASE-NAME-varnish'
+
+  - it: shortens long project names
+    set:
+      projectName: 'client-fi-longclient-longproject-backend'
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: 'release-name.client-fi-longclient-longpra6b.silta.wdr.io'
+
+  - it: shortens long branch names
+    set:
+      environmentName: 'feature/my-project-shortname-12345-with-additional-description'
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: 'feature-my-project-shortname-12345-witdb6.namespace.silta.wdr.io'
+
+  - it: shortens branch names more when project name is already long
+    set:
+      projectName: 'client-fi-longclient-longproject-backend'
+      environmentName: 'feature/my-project-shortname-12345-with-additional-description'
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: 'feature-my-projecdb6.client-fi-longclient-longpra6b.silta.wdr.io'


### PR DESCRIPTION
The helm / golang template syntax is not always very readable, so here's the logic:

Use clusterName as is (12 characters)
If projectName is longer or equal to 30 characters, truncate to 27 characters + 3 character hash.
Calculate characters left until 64, taking two dots into account: 62  - clusterNameLength - projectNameLength
If environmentName is longer, truncate with a hash.