### PR TITLE
Resource requests for frontend chart

### DIFF
--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,3 +1,3 @@
 name: frontend
-version: 0.2.3
+version: 0.2.4
 

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -64,6 +64,9 @@ nginx:
     requests:
       cpu: 5m
       memory: 10M
+    limits:
+      cpu: 5m
+      memory: 10M
 
   loglevel: error 
 
@@ -97,4 +100,11 @@ frontend:
   port: 3000
   env: {}
 
-  resources: {}
+  resources: 
+    requests:
+      cpu: 200m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+    


### PR DESCRIPTION
HPA fails with `Warning   FailedGetResourceMetric   HorizontalPodAutoscaler   missing request for cpu` when resource requests are undefined.
