### PR TITLE
Improve reference data creation.

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,3 +1,3 @@
 name: drupal
-version: 0.2.8
+version: 0.2.9
 

--- a/drupal/templates/post-release.yaml
+++ b/drupal/templates/post-release.yaml
@@ -23,6 +23,10 @@ spec:
         args:
         - {{ include "drupal.post-release-command" . | quote }}
         volumeMounts:
+          - name: gdpr-dump
+            mountPath: /etc/my.cnf.d/gdpr-dump.cnf
+            readOnly: true
+            subPath: gdpr-dump
           {{- include "drupal.volumeMounts" . | nindent 10 }}
           {{- if .Values.referenceData.enabled }}
           {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (not .Values.referenceData.skipMount) }}
@@ -38,7 +42,9 @@ spec:
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
       volumes:
         {{- include "drupal.volumes" . | nindent 8 }}
-
+        - name: gdpr-dump
+          configMap:
+            name: {{ .Release.Name }}-gdpr-dump
         {{- if .Values.referenceData.enabled -}}
         {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (not .Values.referenceData.skipMount) }}
         - name: reference-data-volume

--- a/drupal/templates/reference-data-cron.yaml
+++ b/drupal/templates/reference-data-cron.yaml
@@ -20,9 +20,15 @@ spec:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
               - name: reference-data-volume
                 mountPath: /app/reference-data
+              - name: gdpr-dump
+                mountPath: /etc/my.cnf.d/gdpr-dump.cnf
+                readOnly: true
+                subPath: gdpr-dump
             command: ["/bin/bash", "-c"]
             args:
-              - {{ .Values.referenceData.command | quote }}
+              - |
+                {{ include "drupal.extract-reference-data" . | nindent 16 }}
+
             resources:
               {{- .Values.php.resources | toYaml | nindent 14 }}
           restartPolicy: OnFailure
@@ -31,6 +37,9 @@ spec:
             - name: reference-data-volume
               persistentVolumeClaim:
                 claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
+            - name: gdpr-dump
+              configMap:
+                name: {{ .Release.Name }}-gdpr-dump
 
 
           {{- include "drupal.imagePullSecrets" . | nindent 10 }}

--- a/drupal/tests/drupal_postinstall_test.yaml
+++ b/drupal/tests/drupal_postinstall_test.yaml
@@ -35,11 +35,10 @@ tests:
       # Simulate a deployment on the reference environment
       environmentName: reference-environment
       referenceData.referenceEnvironment: reference-environment
-      referenceData.command: baz
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'baz'
+          pattern: 'REFERENCE_DATA_LOCATION'
 
   - it: doesn't exports reference data after deployments if disabled
     set:
@@ -47,11 +46,10 @@ tests:
       environmentName: reference-environment
       referenceData.referenceEnvironment: reference-environment
       referenceData.updateAfterDeployment: false
-      referenceData.command: baz
     asserts:
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: 'baz'
+          pattern: 'REFERENCE_DATA_LOCATION'
 
   - it: sets environment variables correctly
     set:

--- a/drupal/tests/reference_data_test.yaml
+++ b/drupal/tests/reference_data_test.yaml
@@ -57,7 +57,6 @@ tests:
         storage: 123Gi
         storageClassName: silta-shared
         schedule: '0 1 2 3 *'
-        command: "echo Hello World"
       php.env:
         foo: bar
     asserts:
@@ -99,10 +98,6 @@ tests:
       equal:
         path: spec.schedule
         value: '0 1 2 3 *'
-    - template: reference-data-cron.yaml
-      equal:
-        path: spec.jobTemplate.spec.template.spec.containers[0].args[0]
-        value: "echo Hello World"
 
     - contains:
         path: spec.template.spec.containers[0].volumeMounts

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -135,8 +135,14 @@ php:
         cat reference-data/db.sql.gz | gunzip | drush sql-cli
 
         if [ -f reference-data/public_files.tar.gz ]; then
+          # Deprecated location, only there for backward compatibility.
           echo "Importing public files"
           tar xf reference-data/public_files.tar.gz
+        else
+          if [ -f reference-data/public-files.tar ]; then
+            echo "Importing public files"
+            tar xf reference-data/public-files.tar
+          fi
         fi
 
         drush cr
@@ -234,20 +240,13 @@ referenceData:
   # Update the reference data after deployments on the reference environment.
   updateAfterDeployment: true
 
-  # The commands that is executed to export reference data.
-  command: |
-    if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
-      # NFS doesn't support replacing files, so we delete them instead.
-      rm -f reference-data/*
+  ignoreTableContent: '(cache|cache_.*|sessions|watchdog)'
 
-      # Export database dump.
-      drush sql-dump --gzip --result-file ../reference-data/db.sql
+  # Matching files will not be included in reference data.
+  ignoreFiles: '.*/(css|js|styles)/.*'
 
-      # Export public files.
-      tar cz --exclude=css --exclude=js --exclude=styles -f reference-data/public_files.tar.gz web/sites/default/files/
-    else
-      echo "Drupal is not installed, skipping reference database dump."
-    fi
+  # Files larger than this will not be included in reference data.
+  maxFileSize: '5M'
 
   storage: 1G
   storageClassName: silta-shared


### PR DESCRIPTION
This PR combines a few related changes:
- Only use gdpr-dump when taking reference data. Manual dumps are not sanitized as this has proved to be confusing and leads to potential data loss.
- Replace the configurable command for taking reference data with a dynamic command, so we can for example automatically include additional mounted volumes like private files.
- Automatically skip files larger than 5M. Some projects tend to have huge files which are problematic for deployments but not valuable for development.
- Make it possible to skip additional folders.
- Don't compress the tarball with the reference data files, it's slow and brings little or no improvement regarding file size.
- Display the content of the reference data folder, so it's visible when the file size becomes large.

These changes have been tested in the drupal-project-k8s repository. 