### PR TITLE
Configmap checksums need to be on pods to be effective.

### DIFF
--- a/drupal/templates/drupal-deployment.yaml
+++ b/drupal/templates/drupal-deployment.yaml
@@ -4,9 +4,6 @@ metadata:
   name: {{ .Release.Name }}-drupal
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
-  annotations:
-    # We use a checksum to redeploy the pods when the configMap changes.
-    configMap-checksum: {{ include (print $.Template.BasePath "/drupal-configmap.yaml") . | sha256sum }}
 spec:
   replicas: {{ .Values.replicas }}
   selector:
@@ -20,6 +17,9 @@ spec:
       labels:
         {{- include "drupal.release_labels" . | nindent 8 }}
         deployment: drupal
+      annotations:
+        # We use a checksum to redeploy the pods when the configMap changes.
+        configMap-checksum: {{ include (print $.Template.BasePath "/drupal-configmap.yaml") . | sha256sum }}
     spec:
       containers:
       # php-fpm container.

--- a/frontend/templates/nginx.yaml
+++ b/frontend/templates/nginx.yaml
@@ -4,9 +4,6 @@ metadata:
   name: {{ .Release.Name }}-nginx
   labels:
     {{ include "frontend.release_labels" . | indent 4 }}
-  annotations:
-    # We use a checksum to redeploy the pods when the configMap changes.
-    configMap-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
   replicas: {{ .Values.nginx.replicas }}
   selector:
@@ -18,6 +15,9 @@ spec:
       labels:
         {{ include "frontend.release_labels" . | indent 8 }}
         deployment: frontend
+      annotations:
+        # We use a checksum to redeploy the pods when the configMap changes.
+        configMap-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
       # Nginx container


### PR DESCRIPTION
I realized that nginx wasn't getting restarted as needed. The cause was that the annotation for the checksum was in the wrong location. 