### PR TITLE
Rebuild the Drupal cache on all deployments to handle various errors.

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -165,6 +165,7 @@ php:
   postupgrade:
     command: |
       if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
+        drush cr
         drush updatedb -y
         if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
           drush config-import -y


### PR DESCRIPTION
As discussed in Slack, this fixes a few projects that have issues with broken state after certain changes. The drawback is unnecessary cache rebuilds, but this might not be an issue.