### PR TITLE
Fix missing plugin errors on deployments with new modules enabled.

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -148,6 +148,7 @@ php:
         drush updatedb -y
         if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
           drush config-import -y
+          drush cr
         fi
       else
         printf "\e[33mNo reference data found, please install Drupal or import a database dump. See release information for instructions.\e[0m\n"
@@ -169,6 +170,7 @@ php:
         drush updatedb -y
         if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
           drush config-import -y
+          drush cr
         fi
       fi
 


### PR DESCRIPTION
Config import might bring in new plugins that requires caches to be cleared. (Monitored regular WSOD after deployments).

Solution: Add cache clear after config import.