### PR TITLE
Add a checksum to the varnish pods to redeploy when the configMap changes.

### DIFF
--- a/drupal/templates/varnish-deployment.yaml
+++ b/drupal/templates/varnish-deployment.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
         {{- include "drupal.release_labels" . | nindent 8 }}
         service: varnish
+      annotations:
+        # We use a checksum to redeploy the pods when the configMap changes.
+        configMap-checksum: {{ include (print $.Template.BasePath "/varnish-configmap-vcl.yaml") . | sha256sum }}
     spec:
       containers:
       - name: varnish

--- a/drupal/tests/varnish_test.yaml
+++ b/drupal/tests/varnish_test.yaml
@@ -1,6 +1,7 @@
 suite: varnish deployment
 templates:
   - varnish-deployment.yaml
+  - varnish-configmap-vcl.yaml
 tests:
   - it: sets VARNISH_STORAGE_BACKEND environment variable correctly
     set:


### PR DESCRIPTION
Same checksum mechanism as we added in a few other places, just for varnish this time.