### PR TITLE
Simple chart: custom config block for nginx server context

### DIFF
--- a/simple/templates/configmap.yaml
+++ b/simple/templates/configmap.yaml
@@ -88,6 +88,9 @@ data:
         include fastcgi.conf;
 
         {{ include "drupal.basicauth" . | indent 6}}
+
+        # Custom configuration gets included here
+        {{- .Values.nginx.serverExtraConfig | nindent 8 -}}
          
         location = /robots.txt {
           access_log off;

--- a/simple/tests/configmap_test.yaml
+++ b/simple/tests/configmap_test.yaml
@@ -7,6 +7,18 @@ tests:
       - isKind:
           of: ConfigMap
 
+  - it: injects custom nginx configuration into server context
+    set:
+      nginx:
+        serverExtraConfig: |
+          location = /randomlocation {
+            return 418; 
+          }
+    asserts:
+    - matchRegex:
+        path: data.drupal_conf
+        pattern: "location = /randomlocation"
+
   - it: injects the nginx configuration
     set:
       nginx:

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -74,3 +74,6 @@ nginx:
   # Robots txt file blocked by default
   robotsTxt:
     allow: false
+
+  # Extra configuration block in server context. 
+  serverExtraConfig: |


### PR DESCRIPTION
This allows having custom configuration (like location {}) in server context.

```
nginx:
 serverExtraConfig: |
   location = /randomlocation {
     return 418; 
   }
```
Frontend chart has this, but slightly different solution - the config block goes above basic auth.
https://github.com/wunderio/charts/blob/master/frontend/templates/configmap.yaml#L102

Here's a related PR for drupal-k8s, https://github.com/wunderio/drupal-project-k8s/pull/185