### PR TITLE
SLT-343 Set a priorityClass for silta-cluster resources

### DIFF
--- a/csi-rclone/Chart.yaml
+++ b/csi-rclone/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: CSI plugin for rclone mount
 name: csi-rclone
-version: 0.1.6
+version: 0.1.7

--- a/csi-rclone/templates/csi-controller-rclone.yaml
+++ b/csi-rclone/templates/csi-controller-rclone.yaml
@@ -18,6 +18,9 @@ spec:
         app: csi-controller-rclone
     spec:
       serviceAccountName: csi-controller-rclone
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       containers:
         - name: csi-attacher
           image: quay.io/k8scsi/csi-attacher:v1.1.1

--- a/csi-rclone/templates/csi-nodeplugin-rclone.yaml
+++ b/csi-rclone/templates/csi-nodeplugin-rclone.yaml
@@ -15,6 +15,9 @@ spec:
         app: csi-nodeplugin-rclone
     spec:
       serviceAccountName: csi-nodeplugin-rclone
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       containers:
@@ -61,9 +64,6 @@ spec:
               value: unix://plugin/csi.sock
           imagePullPolicy: "Always"
           lifecycle:
-            #preStop:
-            #  exec:
-            #    command: ["/bin/sh", "-c", "mount -t fuse.rclone | while read -r mount; do umount $(echo $mount | awk '{print $3}') ; done"]
             preStart:
               exec:
                 command: ["/bin/sh", "-c", "mount -t fuse.rclone | while read -r mount; do umount $(echo $mount | awk '{print $3}') ; done"]

--- a/csi-rclone/values.yaml
+++ b/csi-rclone/values.yaml
@@ -10,6 +10,9 @@ version: v1.2.4
 # use default parameters. You might want set this to false when using as subchart.
 defaultParams: true
 
+# Pod priority
+priorityClassName: ""
+
 # Rclone mount parameters. Anything except for remote and remotePath will be prefixed with dashes and passed into mounter. 
 params:
 

--- a/silta-cluster/templates/high-priorityclass.yaml
+++ b/silta-cluster/templates/high-priorityclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 1000000
+globalDefault: false
+description: "High priority pods"

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -4,6 +4,7 @@ clusterDomain: "silta.wdr.io"
 # https://github.com/helm/charts/blob/master/stable/traefik/values.yaml
 traefik:
   externalTrafficPolicy: Local
+  priorityClassName: "high-priority"
   rbac:
     enabled: true
   replicas: 2
@@ -38,6 +39,7 @@ ssl:
 # https://github.com/wunderio/charts/blob/master/csi-rclone/values.yaml
 csi-rclone:
   enabled: false
+  priorityClassName: "high-priority"
   # Use silta cluster gke credentials. This is used when remote type is set to "google cloud storage".
   useGkeAuth: false
   # Do not allow csi-rclone subchart to install default secret because we want to generate it ourselves.


### PR DESCRIPTION
- Creates new PriorityClass "high-priority"
- Allows providing `priorityClassName` for csi-rclone chart
- Uses `high-priority` PriorityClass for csi-rclone and traefik