### PR TITLE
Removing default exposedRoute

### DIFF
--- a/frontend/templates/NOTES.txt
+++ b/frontend/templates/NOTES.txt
@@ -1,9 +1,9 @@
 Deployed {{ .Release.Name }} successfully, your site is available here:
 {{ range $index, $service := .Values.services -}}
-  {{ if default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
-  http://{{- template "frontend.domain" $ }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
+  {{ if $service.exposedRoute }}
+  http://{{- template "frontend.domain" $ }}{{ $service.exposedRoute }}
   {{- range $index, $domain := $.Values.exposeDomains }}
-  http://{{ $domain.hostname }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
+  http://{{ $domain.hostname }}{{ $service.exposedRoute }}
   {{- end -}}
   {{- end -}}
 {{- end }}

--- a/frontend/templates/configmap.yaml
+++ b/frontend/templates/configmap.yaml
@@ -96,8 +96,8 @@ data:
         } 
 
         {{- range $index, $service := .Values.services }}
-        {{ if default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}
-        location {{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }} {
+        {{ if $service.exposedRoute }}
+        location {{ $service.exposedRoute }} {
             
           {{ if $.Values.nginx.extra_conditions }}
           {{ $.Values.nginx.extra_conditions | nindent 10 }}
@@ -108,18 +108,18 @@ data:
           ## Most sites won't have configured favicon
           ## and since its always grabbed, turn it off in access log
           ## and turn off it's not-found error in the error log
-          location = {{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}/favicon.ico { access_log off; log_not_found off;  }
+          location = {{ $service.exposedRoute }}/favicon.ico { access_log off; log_not_found off;  }
 
           ## Same for apple-touch-icon files
-          location = {{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}/apple-touch-icon.png { access_log off; log_not_found off; }
-          location = {{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }}/apple-touch-icon-precomposed.png { access_log off; log_not_found off; }
+          location = {{ $service.exposedRoute }}/apple-touch-icon.png { access_log off; log_not_found off; }
+          location = {{ $service.exposedRoute }}/apple-touch-icon-precomposed.png { access_log off; log_not_found off; }
 
           ## Rather than just denying .ht* in the config, why not deny
           ## access to all .invisible files
           location ~ /\. { return 404; access_log off; log_not_found off; }
 
           # Pass the request on to frontend.
-          proxy_pass http://{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}{{ default $.Values.serviceDefaults.exposedRoute $service.exposedRoute }};
+          proxy_pass http://{{ $.Release.Name }}-{{ $index }}:{{ default $.Values.serviceDefaults.port $service.port }}{{ $service.exposedRoute }};
 
           # We expect the downsteam servers to redirect to the
           # right hostname, so don't do any rewrites here.

--- a/frontend/tests/configmap_test.yaml
+++ b/frontend/tests/configmap_test.yaml
@@ -9,12 +9,15 @@ tests:
 
   - it: injects the nginx configuration
     set:
+      services:
+        foo:
+          image: 'bar'
+          exposedRoute: '/'
       nginx:
         loglevel: 'debug'
         basicauth:
           enabled: true
         realipfrom: '1.2.3.4'
-      services.foo.image: 'bar'
     asserts:
     - template: configmap.yaml
       matchRegex:

--- a/frontend/tests/services-deployment_test.yaml
+++ b/frontend/tests/services-deployment_test.yaml
@@ -61,14 +61,14 @@ tests:
             name: ENVIRONMENT_DOMAIN
             value: release-name.namespace.silta.wdr.io
 
-  - it: uses the default port and exposed route
+  - it: uses the default port
     set:
       services:
         foo:
+          exposedRoute: '/bar'
           image: 'bar'
       serviceDefaults:
         port: 12345
-        exposedRoute: '/bar'
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -156,7 +156,6 @@ shell:
 # Provide defaults for all services.
 # Note that only keys used here can be overridden.
 serviceDefaults:
-  exposedRoute: '/'
   port: 3000
   resources:
     requests:


### PR DESCRIPTION
This removes requirement of `exposedRoute` parameter for internal containers.
Commited to master branch of existing projects to have the `exposedRoute: '/'` -  
1. Searched for projects in our organisation that are using frontend chart and also all silta.yml files containing frontend values link. 
2. Added `exposedRoute: '/'` when applicable.