### PR TITLE
SLT-423: Port usage of static IP to frontend chart.

### DIFF
--- a/frontend/templates/_helpers.tpl
+++ b/frontend/templates/_helpers.tpl
@@ -16,3 +16,11 @@ release: {{ .Release.Name }}
   auth_basic_user_file /etc/nginx/.htaccess;
   {{- end }}
 {{- end }}
+
+{{- define "frontend.tolerations" -}}
+{{- range $key, $label := $ }}
+- key: {{ $key }}
+  operator: Equal
+  value: {{ $label }}
+{{- end }}
+{{- end }}

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -88,6 +88,12 @@ spec:
           persistentVolumeClaim:
             claimName: {{ $.Release.Name }}-shell-keys
         {{- end }}
+      {{ if $service.nodeSelector -}}
+      nodeSelector:
+        {{- $service.nodeSelector | toYaml | nindent 8 }}
+      tolerations:
+        {{- include "frontend.tolerations" $service.nodeSelector | nindent 8 }}
+      {{- end }}
 
 {{- if $service.autoscaling }}
 {{- if $service.autoscaling.enabled }}

--- a/frontend/tests/services-deployment_test.yaml
+++ b/frontend/tests/services-deployment_test.yaml
@@ -171,3 +171,20 @@ tests:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 4G
 
+  - it: can set nodeSelectors
+    set:
+      services.foo:
+        image: 'bar'
+        nodeSelector:
+          bar: baz
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            bar: baz
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: bar
+            operator: Equal
+            value: baz

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -134,6 +134,9 @@ services:
   #       command: echo "hello world"
   #       schedule: "~ 1 * * *"
 
+  #   nodeSelector:
+  #     cloud.google.com/gke-nodepool: static-ip
+
 # Configure the dynamically mounted volumes
 mounts:
 #  files:


### PR DESCRIPTION
This is a straight port of the equivalent functionality from the Drupal chart.