### PR TITLE
SLT-438: schema validation for helm chart values

### DIFF
--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -1,0 +1,518 @@
+{
+  "type": "object",
+  "properties": {
+    "clusterDomain": {
+      "type": "string"
+    },
+    "projectName": {
+      "type": "string"
+    },
+    "environmentName": {
+      "type": "string"
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "app": {
+      "type": "string"
+    },
+    "replicas": {},
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minReplicas": {},
+        "maxReplicas": {},
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "resource": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "targetAverageUtilization": {}
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "exposeDomains": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false
+    },
+    "domainPrefixes": {
+      "type": "array"
+    },
+    "ssl": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "issuer": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "nginx": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "basicauth": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "credentials": {
+              "type": "object",
+              "properties": {
+                "username": {
+                  "type": "string"
+                },
+                "password": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "realipfrom": {
+          "type": "string"
+        },
+        "noauthips": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "serverExtraConfig": {
+          "type": "string"
+        },
+        "extraConfig": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "php": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "string"
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "cron": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "schedule": {
+                "type": "string"
+              },
+              "command": {
+                "type": "string"
+              },
+              "nodeSelector": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "postinstall": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "requests": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string"
+                    },
+                    "memory": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "limits": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string"
+                    },
+                    "memory": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "postupgrade": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "env": {
+          "type": "object"
+        },
+        "hashsalt": {
+          "type": "string"
+        },
+        "errorLevel": {
+          "type": "string"
+        },
+        "php_ini": {
+          "type": "object",
+          "properties": {
+            "loglevel": {
+              "type": "string"
+            },
+            "upload_max_filesize": {
+              "type": "string"
+            },
+            "post_max_size": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "drupalConfigPath": {
+          "type": "string"
+        },
+        "nodeSelector": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        },
+        "newrelic": {
+          "type": "object",
+          "properties": {
+            "license": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "shell": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "string"
+        },
+        "gitAuth": {
+          "type": "object",
+          "properties": {
+            "repositoryUrl": {
+              "type": "string"
+            },
+            "apiToken": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "mount": {
+          "type": "object",
+          "properties": {
+            "storageClassName": {
+              "type": "string"
+            },
+            "csiDriverName": {
+              "type": "string"
+            },
+            "storage": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "mounts": {
+      "type": "object",
+      "properties": {
+        "public-files": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "storage": {
+              "type": "string"
+            },
+            "mountPath": {
+              "type": "string"
+            },
+            "storageClassName": {
+              "type": "string"
+            },
+            "csiDriverName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "private-files": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "storage": {
+              "type": "string"
+            },
+            "mountPath": {
+              "type": "string"
+            },
+            "storageClassName": {
+              "type": "string"
+            },
+            "csiDriverName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "referenceData": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "referenceEnvironment": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "updateAfterDeployment": {
+          "type": "boolean"
+        },
+        "ignoreTableContent": {
+          "type": "string"
+        },
+        "ignoreFiles": {
+          "type": "string"
+        },
+        "maxFileSize": {
+          "type": "string"
+        },
+        "storage": {
+          "type": "string"
+        },
+        "storageClassName": {
+          "type": "string"
+        },
+        "csiDriverName": {
+          "type": "string"
+        },
+        "skipMount": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "gdprDump": {
+      "type": "object",
+      "properties": {
+        "users_field_data": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "object",
+              "properties": {
+                "formatter": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "pass": {
+              "type": "object",
+              "properties": {
+                "formatter": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "mail": {
+              "type": "object",
+              "properties": {
+                "formatter": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "init": {
+              "type": "object",
+              "properties": {
+                "formatter": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "backup": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "retention": {},
+        "restoreId": {},
+        "restoreCommand": {
+          "type": "string"
+        },
+        "storage": {
+          "type": "string"
+        },
+        "storageClassName": {
+          "type": "string"
+        },
+        "csiDriverName": {
+          "type": "string"
+        },
+        "ignoreTableContent": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "mariadb": {
+      "type": "object",
+      "properties": {}
+    },
+    "varnish": {
+      "type": "object",
+      "properties": {}
+    },
+    "elasticsearch": {
+      "type": "object",
+      "properties": {}
+    },
+    "memcached": {
+      "type": "object",
+      "properties": {}
+    },
+    "mailhog": {
+      "type": "object",
+      "properties": {}
+    },
+    "smtp": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -16,15 +16,21 @@
     "app": {
       "type": "string"
     },
-    "replicas": {},
+    "replicas": {
+      "type": "number"
+    },
     "autoscaling": {
       "type": "object",
       "properties": {
         "enabled": {
           "type": "boolean"
         },
-        "minReplicas": {},
-        "maxReplicas": {},
+        "minReplicas": {
+          "type": "number"
+        },
+        "maxReplicas": {
+          "type": "number"
+        },
         "metrics": {
           "type": "array",
           "items": {
@@ -39,7 +45,9 @@
                   "name": {
                     "type": "string"
                   },
-                  "targetAverageUtilization": {}
+                  "targetAverageUtilization": {
+                    "type": "number"
+                  }
                 },
                 "additionalProperties": false
               }
@@ -464,7 +472,9 @@
         "schedule": {
           "type": "string"
         },
-        "retention": {},
+        "retention": {
+          "type": "number"
+        },
         "restoreId": {},
         "restoreCommand": {
           "type": "string"

--- a/schema-generator/.gitignore
+++ b/schema-generator/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/schema-generator/generate-schema.js
+++ b/schema-generator/generate-schema.js
@@ -37,6 +37,9 @@ function generateSchema(data, path = '') {
   else if (_.isString(data)){
     schema.type = 'string';
   }
+  else if (_.isNumber(data)){
+    schema.type = 'number';
+  }
   else if (_.isArray(data)) {
     schema.type = 'array';
 

--- a/schema-generator/generate-schema.js
+++ b/schema-generator/generate-schema.js
@@ -1,0 +1,76 @@
+
+const program = require('commander');
+
+const yaml = require('js-yaml');
+const fs = require('fs');
+const _ = require('lodash');
+
+program.arguments('<chart>');
+program.parse(process.argv);
+
+try {
+  if (_.isEmpty(program.args)) {
+    program.help();
+  }
+  else {
+    const chartPath = program.args[0];
+
+    // Load the values file of the chart.
+    const data = yaml.safeLoad(fs.readFileSync(`${chartPath}/values.yaml`, 'utf8'));
+
+    const schema = generateSchema(data);
+    const schemaPath = `${chartPath}/values.schema.json`;
+
+    fs.writeFileSync(schemaPath, JSON.stringify(schema, null, 2))
+    process.stdout.write(`Generated schema at ${schemaPath}\n`)
+  }
+} catch (e) {
+  console.log(e);
+}
+
+function generateSchema(data, path = '') {
+  const schema = {};
+
+  if (_.isBoolean(data)){
+    schema.type = 'boolean';
+  }
+  else if (_.isString(data)){
+    schema.type = 'string';
+  }
+  else if (_.isArray(data)) {
+    schema.type = 'array';
+
+    if (data.length) {
+      schema.items = generateSchema(data.pop());
+    }
+  }
+  else if (_.isObject(data)) {
+    schema.type = 'object';
+    schema.properties = {};
+
+    const externalDependencies = [
+      'mariadb',
+      'memcached',
+      'varnish',
+      'elasticsearch',
+      'mailhog'
+    ];
+
+    if (!externalDependencies.some(dependency => path.match(new RegExp(dependency)))) {
+
+      for (let propertyName in data) {
+        schema.properties[propertyName] = generateSchema(data[propertyName], `${path}/${propertyName}`);
+      }
+
+      if (path.match(/(noauthips|env|cron)$/)) {
+        schema.additionalProperties = schema.properties[Object.keys(schema.properties)[0]];
+        delete schema.properties;
+      }
+      else {
+        schema.additionalProperties = false;
+      }
+    }
+  }
+
+  return schema;
+}

--- a/schema-generator/package-lock.json
+++ b/schema-generator/package-lock.json
@@ -1,0 +1,43 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "commander": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+      "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw=="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    }
+  }
+}

--- a/schema-generator/package.json
+++ b/schema-generator/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "commander": "^4.1.0",
+    "js-yaml": "^3.13.1",
+    "lodash": "^4.17.15"
+  }
+}


### PR DESCRIPTION
I finalised the code I had written last year to generate a JSON schema based on a given values file. Fortunately, this matches directly with the schema structure expected by Helm3 for values.schema.json. 

To build the generator, run `cd schema-generator && npm install`.
To generate a schema for a chart, run `node schema-generator/generate-schema.js [chart-path]`.
To see the validation in action, try the following (with helm 3):
```
helm install --dry-run --generate-name drupal/ --set foo=bar
helm install --dry-run --generate-name drupal/ --set php=7.2
```

Some questions:
- Do we want to use a fully automated approach to generating a schema, or manually keep values.schema.json up to date?
- If going with a generated approach, how do we handle structured configuration like the `services` in the frontend chart, which are not present in the chart's values.yml?