### PR TITLE
SLT-437: Remove CPU limits, they slow things down unnecessarily.

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -112,7 +112,6 @@ php:
       cpu: 1m
       memory: 128M
     limits:
-      cpu: 1000m
       memory: 512M
 
   # Cron tasks, each of which will be run into a dedicated temporary pod.
@@ -166,7 +165,6 @@ php:
         cpu: 500m
         memory: 512M
       limits:
-        cpu: 1000m
         memory: 512M
 
   # Post-upgrade hook.
@@ -330,7 +328,6 @@ mariadb:
         cpu: 25m
         memory: 384M
       limits:
-        cpu: 1000m
         memory: 512M
     affinity:
       nodeAffinity:
@@ -379,7 +376,6 @@ elasticsearch:
       cpu: 200m
       memory: 512Mi
     limits:
-      cpu: 1000m
       memory: 1Gi
 
   nodeAffinity:

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -126,7 +126,6 @@ services: {}
   #       cpu: 200m
   #       memory: 128Mi
   #     limits:
-  #       cpu: 1000m
   #       memory: 512Mi
 
   #   cron:
@@ -165,7 +164,6 @@ serviceDefaults:
       cpu: 1m
       memory: 64Mi
     limits:
-      cpu: 1000m
       memory: 256Mi
 
 elasticsearch:
@@ -194,7 +192,6 @@ elasticsearch:
       cpu: 200m
       memory: 512Mi
     limits:
-      cpu: 1000m
       memory: 1Gi
 
   nodeAffinity:

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -23,7 +23,6 @@ traefik:
       cpu: 50m
       memory: 128M
     limits:
-      cpu: 150m
       memory: 512M
 
 ssl:


### PR DESCRIPTION
While memory limits are needed, especially for some memory-hungry applications that tend to reserve as much as they can, CPU limits have the effect of throttling CPU activity.