### PR TITLE
drush cr can break build when there are configuration updates

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -172,7 +172,6 @@ php:
   postupgrade:
     command: |
       if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
-        drush cr
         drush updatedb -y
         if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
           drush config-import -y


### PR DESCRIPTION
Builds were failing with the error below. This also happened while running `drush cr` manually:
```
$ drush cr
In CheckExceptionOnInvalidReferenceBehaviorPass.php line 31:
  The service "serializer" has a dependency on a non-existent service "book.manager".  
cache:rebuild [--cache-clear [CACHE-CLEAR]] [--no-cache-clear] [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-d|--debug] [-y|--yes] [--no] [--remote-host REMOTE-HOST] [--remote-user REMOTE-USER] [-r|--root ROOT] [-l|--uri URI] [--simulate] [--pipe] [-D|--define DEFINE] [--xh-link XH-LINK] [--notify [NOTIFY]] [--druplicon] [--] <command>
```

When running `drush cim` manually, it showed there are configuration changes (on which the drush cr depended):
```
|            | core.entity_view_display.node.book.default                       | Create    |
|            | filter.format.basic_reference                                    | Create    |
|            | editor.editor.basic_reference                                    | Create    |
|            | core.extension                                                   | Update    |
|            | user.role.administrator                                          | Update    |
|            | user.role.editor                                                 | Update    |
+------------+------------------------------------------------------------------+-----------+
 Import the listed configuration changes? (yes/no) [yes]:
```

Running the updates manually, fixes the next deployment. 
My suggestion would be removing first `drush cr` from deployment upgrade process.