### PR TITLE
Clear drush caches after config-import on postupgrade and when creating a new environment

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -177,6 +177,7 @@ php:
         drush updatedb -y
         if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
           drush config-import -y
+          drush cc drush
           drush cr
         fi
       fi

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -130,6 +130,7 @@ php:
 
   # Post-installation hook.
   # This is run every time a new environment is created.
+  # The drush cache-clear is to avoid potential issues if updated code introduces new custom entities
   postinstall:
     command: |
       if [ -f reference-data/db.sql.gz ]; then
@@ -170,6 +171,7 @@ php:
 
   # Post-upgrade hook.
   # This is run every time a new environment is upgraded.
+  # The drush cache-clear is to avoid potential upgrade issues if updated code introduces new custom entities
   postupgrade:
     command: |
       if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -155,6 +155,7 @@ php:
         drush updatedb -y
         if [ -f $DRUPAL_CONFIG_PATH/core.extension.yml ]; then
           drush config-import -y
+          drush cc drush
           drush cr
         fi
       else


### PR DESCRIPTION
Use-case from client project why this is needed:
Database fails after succesful config-import if there is a new custom entity unless drush caches are cleared.

* New environment from reference data if drush caches not cleared: https://app.circleci.com/jobs/github/wunderio/client-fi-sfs-ovk-drupal/691
* Success with drush caches cleared: https://app.circleci.com/jobs/github/wunderio/client-fi-sfs-ovk-drupal/699

There should be no unwanted side-effects with some additional cache-clearing

PS. Credits for @mitrpaka for pointing out we may need to clear drush caches.