### PR TITLE
Set default values for autoscaling, including metrics.

### DIFF
--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -111,10 +111,14 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ $.Release.Name }}-{{ $index }}
-  minReplicas: {{ default 1 $service.autoscaling.minReplicas }}
-  maxReplicas: {{ default 3 $service.autoscaling.maxReplicas }}
+  minReplicas: {{ default $.Values.serviceDefaults.autoscaling.minReplicas $service.autoscaling.minReplicas }}
+  maxReplicas: {{ default $.Values.serviceDefaults.autoscaling.maxReplicas $service.autoscaling.maxReplicas }}
   metrics:
+    {{ if $service.autoscaling.metrics }}
     {{- toYaml $service.autoscaling.metrics | nindent 4 }}
+    {{ else }}
+    {{- toYaml $.Values.serviceDefaults.autoscaling.metrics | nindent 4 }}
+    {{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/frontend/tests/services-deployment_test.yaml
+++ b/frontend/tests/services-deployment_test.yaml
@@ -188,3 +188,64 @@ tests:
             key: bar
             operator: Equal
             value: baz
+
+  - it: can autoscale with default values
+    set:
+      services.foo:
+        image: 'bar'
+        autoscaling:
+          enabled: true
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: HorizontalPodAutoscaler
+      - documentIndex: 1
+        equal:
+          path: spec.minReplicas
+          value: 1
+      - documentIndex: 1
+        equal:
+          path: spec.maxReplicas
+          value: 3
+      - documentIndex: 1
+        contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              targetAverageUtilization: 80
+
+  - it: can override autoscale values
+    set:
+      services.foo:
+        image: 'bar'
+        autoscaling:
+          enabled: true
+          minReplicas: 5
+          maxReplicas: 7
+          metrics:
+            - type: Resource
+              resource:
+                name: cpu
+                targetAverageUtilization: 100
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: HorizontalPodAutoscaler
+      - documentIndex: 1
+        equal:
+          path: spec.minReplicas
+          value: 5
+      - documentIndex: 1
+        equal:
+          path: spec.maxReplicas
+          value: 7
+      - documentIndex: 1
+        contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              targetAverageUtilization: 100

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -165,6 +165,15 @@ serviceDefaults:
       memory: 64Mi
     limits:
       memory: 256Mi
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          targetAverageUtilization: 80
 
 elasticsearch:
   enabled: false


### PR DESCRIPTION
We already have default values for minReplicas and maxReplicas, but not for the metrics. We need those to have a working autoscaler, and we don't want to replicate the cpu usage threshold of 80% everywhere.