### PR TITLE
Remove the pod disruption budget for memcached, it prevents node upgrades

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -392,7 +392,7 @@ elasticsearch:
 memcached:
   enabled: false
   replicaCount: 1
-  pdbMinAvailable: 1
+  pdbMinAvailable: 0
   memcached:
     maxItemMemory: 128
 


### PR DESCRIPTION
Since the default values are optimised for development environments, we shouldn't require having one replica running at all times (especially when we only use a single replica). 