### PR TITLE
SLT-438 schema validation for silta.yml

### DIFF
--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -1,0 +1,68 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "clusterDomain": { "type": "string" },
+    "projectName": { "type": "string" },
+    "environmentName": { "type": "string" },
+    "imagePullSecrets": { "type": "array" },
+    "app": { "type": "string" },
+
+    "replicas": { "type": "integer" },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "exposeDomains": { "type": "array", "items": { "type": "object"}},
+    "domainPrefixes": { "type": "array", "items": { "type": "string"}},
+    "ssl": { "type": "object" },
+
+    "nginx": { "type": "object" },
+    "php": { "type": "object" },
+    "shell": { "type": "object" },
+    "mounts": { "type": "object" },
+
+    "referenceData": { "type": "object" },
+    "gdprDump": { "type": "object" },
+    "backup": { "type": "object" },
+
+    "mariadb": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "varnish": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "elasticsearch": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "memcached": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "mailhog": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "smtp": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -1,5 +1,16 @@
 {
   "type": "object",
+  "if": {
+    "properties": { "environmentName": { "const": "production" }}
+  },
+  "then": {
+    "properties": {
+      "mailhog": {
+        "$comment": "Mailhog should not be enabled in production",
+        "properties": { "enabled": { "const": false }}
+      }
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "clusterDomain": { "type": "string" },

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -8,6 +8,32 @@
       "mailhog": {
         "$comment": "Mailhog should not be enabled in production",
         "properties": { "enabled": { "const": false }}
+      },
+      "php": {
+        "properties": {
+          "resources": {
+            "properties": {
+              "requests": {
+                "properties": {
+                  "cpu": { "type": "string", "not": { "const": "1m"}}
+                }
+              }
+            }
+          }
+        }
+      },
+      "nginx": {
+        "properties": {
+          "resources": {
+            "properties": {
+              "requests": {
+                "properties": {
+                  "cpu": { "type": "string", "not": { "const": "1m"}}
+                }
+              }
+            }
+          }
+        }
       }
     }
   },

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -45,7 +45,7 @@ autoscaling:
 #     ssl:
 #       enabled: true
 #       issuer: letsencrypt-staging
-exposeDomains: {}
+exposeDomains: []
 
 # Add prefixes to the generated per-branch domains, to be used for projects that need to respond
 # on multiple domains, for example using Drupal's domain module, or using different domains for different languages.


### PR DESCRIPTION
Rather than the automated approach with https://github.com/wunderio/charts/pull/89, a manual approach would be more maintainable. Here's some basic validation, we can always add more details. Rather than going for complete coverage, I think it makes sense to focus on specific use cases. For example it doesn't make sense to validate things that would be caught by the kubernetes validation, such as putting a number of replicas that's negative.