### PR TITLE
SLT-455: Support parallel cron jobs in the frontend chart

### DIFF
--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.2.12
+version: 0.2.13
 apiVersion: v2
 dependencies:
 - name: elasticsearch

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -61,7 +61,9 @@ spec:
             args:
               - |
                  set -ex
+                 echo "starting cron run"
                  {{ $job.command | nindent 18 }}
+                 echo "cron run completed"
             resources:
               {{ if $service.resources -}}
               {{ merge $service.resources $.Values.serviceDefaults.resources | toYaml | nindent 14 }}

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -10,11 +10,12 @@ metadata:
     {{- include "frontend.release_labels" $ | nindent 4 }}
 spec:
   schedule: {{ $job.schedule | replace "~" (randNumeric 1) | quote }}
-  concurrencyPolicy: Forbid
+  concurrencyPolicy: Allow
   startingDeadlineSeconds: 3600
   successfulJobsHistoryLimit: 0
   jobTemplate:
     spec:
+      parallelism: {{ default 1 $job.parallelism }}
       template:
         metadata:
           labels:

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -81,7 +81,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-          restartPolicy: Never
+          restartPolicy: OnFailure
 ---
 {{- end }}
 {{- end }}

--- a/frontend/tests/services-cron_test.yaml
+++ b/frontend/tests/services-cron_test.yaml
@@ -20,3 +20,21 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].image
           value: 'bar'
+      - equal:
+          path: spec.jobTemplate.spec.parallelism
+          value: 1
+
+  - it: can override parallelism
+    set:
+      services.foo:
+        image: 'bar'
+        cron:
+          foo:
+            command: echo "Hello world"
+            schedule: '1 2 3 * *'
+            parallelism: 3
+
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.parallelism
+          value: 3

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -132,6 +132,7 @@ services: {}
   #     example:
   #       command: echo "hello world"
   #       schedule: "~ 1 * * *"
+  #       parallelism: 1
 
   #   nodeSelector:
   #     cloud.google.com/gke-nodepool: static-ip


### PR DESCRIPTION
The default cron job configuration we had was based on the one in the Drupal chart, but we don't actually need most of the limitations (for example, Drupal cron fails if the previous cron run is not complete). Enabling more parallel jobs has shown to enable a considerable increase in throughput for some larger import tasks. 