### PR TITLE
enableServiceLinks for drupal and frontend containers

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.5
+version: 0.3.6
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/shell-deployment.yaml
+++ b/drupal/templates/shell-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- include "drupal.release_labels" . | nindent 8 }}
         service: shell
     spec:
+      enableServiceLinks: {{ default false .Values.shell.enableServiceLinks }}
       containers:
       - name: shell
         image: {{ .Values.shell.image | quote }}

--- a/drupal/templates/shell-deployment.yaml
+++ b/drupal/templates/shell-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         {{- include "drupal.release_labels" . | nindent 8 }}
         service: shell
     spec:
-      enableServiceLinks: {{ default false .Values.shell.enableServiceLinks }}
+      enableServiceLinks: false
       containers:
       - name: shell
         image: {{ .Values.shell.image | quote }}

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.2.14
+version: 0.2.15
 apiVersion: v2
 dependencies:
 - name: elasticsearch

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -17,6 +17,7 @@ spec:
         {{ include "frontend.release_labels" $ | indent 8 }}
         deployment: frontend-{{ $index }}
     spec:
+      enableServiceLinks: {{ default false  $service.enableServiceLinks }}
       containers:
       - name: {{ $index }}
         image: {{ $service.image | quote }}

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         {{ include "frontend.release_labels" $ | indent 8 }}
         deployment: frontend-{{ $index }}
     spec:
-      enableServiceLinks: {{ default false  $service.enableServiceLinks }}
+      enableServiceLinks: false
       containers:
       - name: {{ $index }}
         image: {{ $service.image | quote }}


### PR DESCRIPTION
Removes service environment variables in shell pod (ssh does not work due to 1000 env variable limitation).

https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables