### PR TITLE
SLT-459: Make cron job resources configurable

### DIFF
--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -33,7 +33,11 @@ spec:
                    exit 1
                  fi
             resources:
+              {{ if $job.resources }}
+              {{- $job.resources | toYaml | nindent 14 }}
+              {{ else }}
               {{- $.Values.php.resources | toYaml | nindent 14 }}
+              {{- end }}
           restartPolicy: Never
           nodeSelector:
             {{ if $job.nodeSelector }}

--- a/drupal/tests/drupal_cron_test.yaml
+++ b/drupal/tests/drupal_cron_test.yaml
@@ -69,13 +69,18 @@ tests:
 
   - it: uses default resource requests and limits
     set:
-      php.resources:
-        requests:
-          cpu: 123m
-          memory: 1G
-        limits:
-          cpu: 234m
-          memory: 2G
+      php:
+        # Unset cron-specific resources.
+        cron:
+          drupal:
+            resources: null
+        resources:
+          requests:
+            cpu: 123m
+            memory: 1G
+          limits:
+            cpu: 234m
+            memory: 2G
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu

--- a/drupal/tests/drupal_cron_test.yaml
+++ b/drupal/tests/drupal_cron_test.yaml
@@ -67,7 +67,7 @@ tests:
           value: "30 * * * *"
         documentIndex: 1
 
-  - it: takes resource requests and limits
+  - it: uses default resource requests and limits
     set:
       php.resources:
         requests:
@@ -90,3 +90,25 @@ tests:
           path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.memory
           value: 2G
 
+  - it: takes custom resource requests and limits
+    set:
+      php.cron.drupal.resources:
+        requests:
+          cpu: 1230m
+          memory: 10G
+        limits:
+          cpu: 2340m
+          memory: 20G
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu
+          value: 1230m
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory
+          value: 10G
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu
+          value: 2340m
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.memory
+          value: 20G

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -128,6 +128,14 @@ php:
       # Set a nodeSelector specifically for cron jobs.
       nodeSelector: {}
 
+      # Set resources specifically for cron jobs.
+      resources:
+        requests:
+          cpu: 500m
+          memory: 512M
+        limits:
+          memory: 512M
+
   # Post-installation hook.
   # This is run every time a new environment is created.
   postinstall:


### PR DESCRIPTION
Cron jobs typically use more resources, requesting those prevents a too high load on the cluster.