### PR TITLE
Initial version of the silta downscaler.

### DIFF
--- a/silta-downscaler/Chart.yaml
+++ b/silta-downscaler/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "1.0"
+description: Automatically scale unused helm releases to zero
+name: downscaler
+version: 0.1.0

--- a/silta-downscaler/templates/downscaler-cron.yaml
+++ b/silta-downscaler/templates/downscaler-cron.yaml
@@ -1,0 +1,27 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-downscale-cron
+spec:
+  schedule: "*/5 * * * *"
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: downscaler
+          containers:
+          - name: downscaler-cron
+            image: wunderio/silta-downscaler
+            command: ["/bin/sh", "-c"]
+            args:
+              - node downscale
+            resources: {}
+            env:
+              - name: PLACEHOLDER_SERVICE_NAME
+                value: {{ .Release.Name }}-placeholder
+              - name: PLACEHOLDER_SERVICE_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace

--- a/silta-downscaler/templates/downscaler-ingress.yaml
+++ b/silta-downscaler/templates/downscaler-ingress.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-placeholder
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
+    ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  tls:
+  - secretName: {{ .Release.Name }}-tls
+  rules:
+  - host: {{ .Values.domain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ .Release.Name }}-placeholder
+          servicePort: 80
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-crt
+spec:
+  secretName: {{ .Release.Name }}-tls
+  dnsNames:
+  - {{ .Values.domain }}
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer
+  acme:
+    config:
+      - http01:
+          ingress: {{ .Release.Name }}-placeholder
+        domains:
+          - {{ .Values.domain }}

--- a/silta-downscaler/templates/downscaler-placeholder.yaml
+++ b/silta-downscaler/templates/downscaler-placeholder.yaml
@@ -1,0 +1,45 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ .Release.Name }}-placeholder
+spec:
+  selector:
+    matchLabels:
+      app: downscaler-placeholder
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: downscaler-placeholder
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: downscaler
+      containers:
+        - name: placeholder
+          image: wunderio/silta-downscaler
+          imagePullPolicy: "Always"
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: PLACEHOLDER_DOMAIN
+              value: {{ .Values.domain }}
+            - name: PLACEHOLDER_SERVICE_NAME
+              value: {{ .Release.Name }}-placeholder
+            - name: PLACEHOLDER_SERVICE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-placeholder
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 3000
+  selector:
+    app: downscaler-placeholder
+    release: {{ .Release.Name }}

--- a/silta-downscaler/templates/downscaler-rbac.yaml
+++ b/silta-downscaler/templates/downscaler-rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: downscaler
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: downscaler
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "update", "patch"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses", "deployments", "deployments/scale", "deployments/status"]
+    verbs: ["get", "list", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: downscaler
+subjects:
+  - kind: ServiceAccount
+    name: downscaler
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: downscaler
+  apiGroup: rbac.authorization.k8s.io

--- a/silta-downscaler/values.yaml
+++ b/silta-downscaler/values.yaml
@@ -1,0 +1,3 @@
+
+
+domain: downscaler.silta.wdr.io


### PR DESCRIPTION
This PR only defines the chart, but doesn't enable it yet.

- [x] Get basic functionality working.
- [ ] Make necessary properties configurable, and set better defaults for actual usage.
- [ ] Make this chart a subchart of the silta-cluster chart.

Most of the other changes will be in the https://github.com/wunderio/silta-downscaler repository / docker image.