### PR TITLE
Memcached memory request matched with the maxItemMemory setting.

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -385,6 +385,9 @@ memcached:
   pdbMinAvailable: 0
   memcached:
     maxItemMemory: 128
+  resources:
+    requests:
+      memory: 128Mi
 
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml


### PR DESCRIPTION
I noticed the memcached requests less memory for container than it actually uses because of our setting.