### PR TITLE
Remove service links everywhere we can.

### DIFF
--- a/drupal/templates/backup-cron.yaml
+++ b/drupal/templates/backup-cron.yaml
@@ -16,6 +16,7 @@ spec:
     spec:
       template:
         spec:
+          enableServiceLinks: false
           containers:
           - name: backup
             {{- include "drupal.php-container" . | nindent 12 }}

--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -18,6 +18,7 @@ spec:
           labels:
             {{- include "drupal.release_labels" $ | nindent 12 }}
         spec:
+          enableServiceLinks: false
           containers:
           - name: drupal-cron
             {{- include "drupal.php-container" $ | nindent 12 }}

--- a/drupal/templates/drupal-deployment.yaml
+++ b/drupal/templates/drupal-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         # We use a checksum to redeploy the pods when the configMap changes.
         configMap-checksum: {{ include (print $.Template.BasePath "/drupal-configmap.yaml") . | sha256sum }}
     spec:
+      enableServiceLinks: false
       containers:
       # php-fpm container.
       - name: php

--- a/drupal/templates/post-release.yaml
+++ b/drupal/templates/post-release.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      enableServiceLinks: false
       containers:
       - name: post-release
         {{- include "drupal.php-container" . | nindent 8 }}

--- a/drupal/templates/reference-data-cron.yaml
+++ b/drupal/templates/reference-data-cron.yaml
@@ -15,6 +15,7 @@ spec:
     spec:
       template:
         spec:
+          enableServiceLinks: false
           containers:
           - name: reference-data-cron
             {{- include "drupal.php-container" . | nindent 12 }}

--- a/drupal/templates/varnish-deployment.yaml
+++ b/drupal/templates/varnish-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         # We use a checksum to redeploy the pods when the configMap changes.
         configMap-checksum: {{ include (print $.Template.BasePath "/varnish-configmap-vcl.yaml") . | sha256sum }}
     spec:
+      enableServiceLinks: false
       containers:
       - name: varnish
         image: wunderio/drupal-varnish:v0.1.5

--- a/frontend/templates/nginx.yaml
+++ b/frontend/templates/nginx.yaml
@@ -19,6 +19,7 @@ spec:
         # We use a checksum to redeploy the pods when the configMap changes.
         configMap-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      enableServiceLinks: false
       containers:
       # Nginx container
       - name: nginx

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -21,6 +21,7 @@ spec:
           labels:
             {{- include "frontend.release_labels" $ | nindent 12 }}
         spec:
+          enableServiceLinks: false
           containers:
           - name: {{ $jobName }}-cron
             image: {{ $service.image | quote }}

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         {{ include "drupal.release_labels" . | indent 8 }}
     spec:
+      enableServiceLinks: false
       containers:
       # Nginx container
       - name: nginx


### PR DESCRIPTION
We don't know exactly why, but the number of service links and the environment variables cause cpu activity even when containers are idle. 