### PR TITLE
Don't enforce production checks if branch is unspecified.

### DIFF
--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -1,7 +1,15 @@
 {
   "type": "object",
   "if": {
-    "properties": { "environmentName": { "const": "production" }}
+    "properties": {
+      "silta-release": {
+        "type": "object",
+        "properties": {
+          "branchName": { "const": "production"}
+        },
+        "required": ["branchName"]
+      }
+    }
   },
   "then": {
     "properties": {


### PR DESCRIPTION
Tested that it still triggers for production branches, and that it doesn't for non-production branches or for unspecified environments.