### PR TITLE
SLT-478: Set dedicated requests for the backup on referenceData cron jobs

### DIFF
--- a/drupal/templates/backup-cron.yaml
+++ b/drupal/templates/backup-cron.yaml
@@ -71,7 +71,7 @@ spec:
                 # List content of backup folder
                 ls -lh /backups/*
             resources:
-              {{- .Values.php.resources | toYaml | nindent 14 }}
+              {{- .Values.backup.resources | toYaml | nindent 14 }}
           restartPolicy: Never
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}

--- a/drupal/templates/reference-data-cron.yaml
+++ b/drupal/templates/reference-data-cron.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.referenceData.schedule | quote }}
+  schedule: {{ .Values.referenceData.schedule | replace "~" (randNumeric 1) | quote }}
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 3600
   successfulJobsHistoryLimit: 0

--- a/drupal/templates/reference-data-cron.yaml
+++ b/drupal/templates/reference-data-cron.yaml
@@ -33,7 +33,7 @@ spec:
                 {{ include "drupal.extract-reference-data" . | nindent 16 }}
 
             resources:
-              {{- .Values.php.resources | toYaml | nindent 14 }}
+              {{- .Values.referenceData.resources | toYaml | nindent 14 }}
           restartPolicy: Never
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -263,6 +263,14 @@ referenceData:
   # Skips mounting the volume outside of the reference environment, only used programmatically.
   skipMount: false
 
+  # Resources for the reference data cron job.
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 512M
+    limits:
+      memory: 512M
+
 # Parameters for sanitizing reference data with gdpr-dump.
 # Uses formatters from https://packagist.org/packages/fzaninotto/faker.
 gdprDump:
@@ -300,6 +308,14 @@ backup:
 
   # These tables will have their content ignored from the backups.
   ignoreTableContent: '(cache|cache_.*)'
+
+  # Resources for the backup cron job.
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 512M
+    limits:
+      memory: 512M
 
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -238,7 +238,7 @@ referenceData:
   referenceEnvironment: 'master'
 
   # When to automatically update the reference data.
-  schedule: '0 3 * * *'
+  schedule: '~ 3 * * *'
 
   # Update the reference data after deployments on the reference environment.
   updateAfterDeployment: true


### PR DESCRIPTION
These two cron jobs have a tendency to go over the requested resources and trigger alerts, even if they are running in the middle of the night. Having more cpu requested also guarantees a faster execution.