### PR TITLE
Initial version of the silta downscaler.

### DIFF
--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: traefik
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 1.86.1
+  version: 1.86.2
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 10.4.4
@@ -20,5 +20,8 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io/
   version: v0.10.1
-digest: sha256:715bdf69f126e33626db52dd3decbfae911b7b4573b90ff5125e9192c81f1ae3
-generated: "2020-02-12T09:58:16.442092696Z"
+- name: silta-downscaler
+  repository: file://../silta-downscaler
+  version: 0.1.0
+digest: sha256:8f227e5cb9596b87e11a111a686a9676a23ea11a14870386c819720a0a436562
+generated: "2020-04-24T11:05:09.891956+02:00"

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.2
+version: 0.2.3
 dependencies:
 - name: traefik
   version: 1.86.x

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -31,3 +31,7 @@ dependencies:
   version: 0.10.x
   repository: https://charts.jetstack.io/
   condition: cert-manager.enabled
+- name: silta-downscaler
+  version: 0.1.0
+  repository: file://../silta-downscaler
+  condition: silta-downscaler.enabled

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -159,3 +159,5 @@ cert-manager:
   enabled: true
   email: ''
 
+silta-downscaler:
+  enabled: false

--- a/silta-downscaler/Chart.yaml
+++ b/silta-downscaler/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: "1.0"
+description: Automatically downscale helm releases
+name: silta-downscaler
+version: 0.1.0

--- a/silta-downscaler/README.md
+++ b/silta-downscaler/README.md
@@ -1,0 +1,12 @@
+# How it works
+
+- CronJob runs the following
+    - Get Ingresses with a `auto-downscale/last-update` annotation, this is used to check which should be downscaled.
+    - The `auto-downscale/services` annotation on the ingress indicates which service should be redirected to the placeholder page.
+    - The `auto-downscale/label-selector` indicates which deployments, statefulsets and cronjobs should be downscaled. This is typically set to `release=<release-name>`.
+    
+- When someone hits the placeholder
+    - Get Ingress matching current hostname
+    - Show message to user with option to re-enable
+    - TODO: Give an option to never downscale this release
+    - When upscale is ready, redirect user

--- a/silta-downscaler/README.md
+++ b/silta-downscaler/README.md
@@ -8,5 +8,4 @@
 - When someone hits the placeholder
     - Get Ingress matching current hostname
     - Show message to user with option to re-enable
-    - TODO: Give an option to never downscale this release
     - When upscale is ready, redirect user

--- a/silta-downscaler/templates/downscaler-cron.yaml
+++ b/silta-downscaler/templates/downscaler-cron.yaml
@@ -26,3 +26,7 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: metadata.namespace
+              - name: DEFAULT_MIN_AGE
+                value: {{ .Values.defaultMinAge | quote }}
+              - name: RELEASE_MIN_AGE
+                value: '{{ .Values.releaseMinAge | toJson }}'

--- a/silta-downscaler/templates/downscaler-cron.yaml
+++ b/silta-downscaler/templates/downscaler-cron.yaml
@@ -13,7 +13,7 @@ spec:
           serviceAccountName: {{ .Release.Name }}-downscaler
           containers:
           - name: downscaler-cron
-            image: {{ .Values.image | quote }}
+            image: "{{ .Values.image }}:{{ .Values.tag }}"
             command: ["/bin/sh", "-c"]
             args:
               - node downscale

--- a/silta-downscaler/templates/downscaler-cron.yaml
+++ b/silta-downscaler/templates/downscaler-cron.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-downscale-cron
+spec:
+  schedule: "{{ .Values.schedule }}"
+  startingDeadlineSeconds: 3600
+  suspend: true
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ .Release.Name }}-downscaler
+          containers:
+          - name: downscaler-cron
+            image: {{ .Values.image | quote }}
+            command: ["/bin/sh", "-c"]
+            args:
+              - node downscale
+            resources:
+              {{ .Values.resources | toYaml | nindent 14 }}
+            env:
+              - name: PLACEHOLDER_SERVICE_NAME
+                value: {{ .Release.Name }}-placeholder-upscaler
+              - name: PLACEHOLDER_SERVICE_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace

--- a/silta-downscaler/templates/downscaler-cron.yaml
+++ b/silta-downscaler/templates/downscaler-cron.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   schedule: "{{ .Values.schedule }}"
   startingDeadlineSeconds: 3600
-  suspend: true
   jobTemplate:
     spec:
       template:

--- a/silta-downscaler/templates/placeholder-upscaler.yaml
+++ b/silta-downscaler/templates/placeholder-upscaler.yaml
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-downscaler
       containers:
       - name: placeholder-upscaler
-        image: {{ .Values.image | quote }}
+        image: "{{ .Values.image }}:{{ .Values.tag }}"
         imagePullPolicy: Always
         ports:
         - containerPort: 3000

--- a/silta-downscaler/templates/placeholder-upscaler.yaml
+++ b/silta-downscaler/templates/placeholder-upscaler.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-placeholder-upscaler
+  labels:
+    release: {{ .Release.Name }}
+    deployment: placeholder-upscaler
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 3000
+  selector:
+    release: {{ .Release.Name }}
+    deployment: placeholder-upscaler
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-placeholder-upscaler
+spec:
+  selector:
+    matchLabels:
+      release: {{ .Release.Name }}
+      deployment: placeholder-upscaler
+  template:
+    metadata:
+      labels:
+        release: {{ .Release.Name }}
+        deployment: placeholder-upscaler
+    spec:
+      enableServiceLinks: false
+      serviceAccountName: {{ .Release.Name }}-downscaler
+      containers:
+      - name: placeholder-upscaler
+        image: {{ .Values.image | quote }}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3000
+        livenessProbe:
+          tcpSocket:
+            port: 3000
+        readinessProbe:
+          tcpSocket:
+            port: 3000
+        resources:
+          {{ .Values.resources | toYaml | nindent 10 }}
+        env:
+          - name: PLACEHOLDER_DOMAIN
+            value: {{ .Values.domain }}
+          - name: PLACEHOLDER_SERVICE_NAME
+            value: {{ .Release.Name }}-placeholder-upscaler
+          - name: PLACEHOLDER_SERVICE_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-placeholder-upscaler
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
+    ingress.kubernetes.io/ssl-redirect: "true"
+  labels:
+    release: {{ .Release.Name }}
+    deployment: placeholder-upscaler
+spec:
+  {{- if .Values.ssl.enabled }}
+  tls:
+  - secretName: {{ .Release.Name }}-placeholder-upscaler
+  {{- end }}
+  rules:
+  - host: {{ .Values.domain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ .Release.Name }}-placeholder-upscaler
+          servicePort: 80
+---
+{{- if .Values.ssl.enabled }}
+{{- if has .Values.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-placeholder-upscaler
+  labels:
+    release: {{ .Release.Name }}
+    deployment: placeholder-upscaler
+spec:
+  secretName: {{ .Release.Name }}-placeholder-upscaler
+  dnsNames:
+  - {{ .Values.domain }}
+  issuerRef:
+    name: {{ .Values.ssl.issuer }}
+    kind: ClusterIssuer
+  acme:
+    config:
+      - http01:
+          ingress: {{ .Release.Name }}-placeholder-upscaler
+        domains:
+          - {{ .Values.domain }}
+{{- end -}}
+{{- end -}}

--- a/silta-downscaler/templates/rbac.yaml
+++ b/silta-downscaler/templates/rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-downscaler
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-downscaler
+rules:
+  - apiGroups: ["", "extensions", "networking.k8s.io", "batch", "apps"]
+    resources: ["services", "services/status", "ingresses", "deployments", "deployments/status", "cronjobs", "statefulsets"]
+    verbs: ["get", "list", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-downscaler
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-downscaler
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-downscaler
+  apiGroup: rbac.authorization.k8s.io

--- a/silta-downscaler/values.yaml
+++ b/silta-downscaler/values.yaml
@@ -10,6 +10,7 @@ ssl:
 schedule: "0 4,18 * * *"
 
 image: wunderio/silta-downscaler
+tag: "v0.1.0"
 
 resources: {}
 

--- a/silta-downscaler/values.yaml
+++ b/silta-downscaler/values.yaml
@@ -12,3 +12,12 @@ schedule: "0 6,18 * * *"
 image: wunderio/silta-downscaler
 
 resources: {}
+
+# How long should releases be kept by default.
+defaultMinAge: 1d
+
+# How long should releases with matching names be kept. The last matching rule takes effect.
+releaseMinAge:
+  "^production": 10y
+  "^(master|stage|staging)": 1w
+  "^dependabot": 1h

--- a/silta-downscaler/values.yaml
+++ b/silta-downscaler/values.yaml
@@ -1,0 +1,14 @@
+
+
+domain: downscaler.silta.wdr.io
+
+ssl:
+  enabled: true
+  issuer: letsencrypt
+
+# A cron schedule to determine when applications will be downscaled.
+schedule: "0 6,18 * * *"
+
+image: wunderio/silta-downscaler
+
+resources: {}

--- a/silta-downscaler/values.yaml
+++ b/silta-downscaler/values.yaml
@@ -7,7 +7,7 @@ ssl:
   issuer: letsencrypt
 
 # A cron schedule to determine when applications will be downscaled.
-schedule: "0 6,18 * * *"
+schedule: "0 4,18 * * *"
 
 image: wunderio/silta-downscaler
 


### PR DESCRIPTION
This chart consists of a cron job and a deployment, both of which use https://github.com/wunderio/silta-downscaler, with a serviceAccount which has access to list and patch resources across the cluster.