### PR TITLE
Temporarily use our fork of the elasticsearch chart.

### DIFF
--- a/drupal/Chart.lock
+++ b/drupal/Chart.lock
@@ -9,10 +9,10 @@ dependencies:
   repository: https://codecentric.github.io/helm-charts
   version: 3.1.3
 - name: elasticsearch
-  repository: https://helm.elastic.co
-  version: 7.5.2
+  repository: file://../elasticsearch
+  version: 7.6.2
 - name: silta-release
   repository: file://../silta-release
   version: 0.1.1
-digest: sha256:496f3c9c7564d5f89d5bbfe20c1c170274939a7c6c323add5fe609e4162b945c
-generated: "2020-04-07T13:49:52.038661+02:00"
+digest: sha256:e5785ddc4d1e6bce769b59dec9a6b3ffee5f0a2e34548cae728a215bc483c1b8
+generated: "2020-05-06T10:26:02.407069+02:00"

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.30
+version: 0.3.31
 apiVersion: v2
 dependencies:
 - name: mariadb
@@ -16,8 +16,9 @@ dependencies:
   repository: https://codecentric.github.io/helm-charts
   condition: mailhog.enabled
 - name: elasticsearch
-  version: 7.5.x
-  repository: https://helm.elastic.co
+  version: 7.6.x
+  # repository: https://helm.elastic.co
+  repository: file://../elasticsearch
   condition: elasticsearch.enabled
 - name: silta-release
   version: 0.1.1


### PR DESCRIPTION
It looks like it will take some more time until https://github.com/elastic/helm-charts/pull/542 is merged, so we need to fork that chart to have a fix available for us in the meantime.