### PR TITLE
Don't use monolog in cli

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.33
+version: 0.3.34
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -74,4 +74,6 @@ if (getenv('VARNISH_ADMIN_HOST')) {
 /**
  * Use our own services override.
  */
-$settings['container_yamls'][] = 'sites/default/silta.services.yml';
+if (PHP_SAPI !== 'cli') {
+  $settings['container_yamls'][] = 'sites/default/silta.services.yml';
+}


### PR DESCRIPTION
This pr disables the usage of monolog in cli since it doesn't work well together with drush batch processing, but causes the process to fail when new threads are started and stdout is printed. Drush expects stdout to be valid json, but monolog interferes with that and causes json syntax errors.