### PR TITLE
Add Helm dry run chart install to validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,8 @@ jobs:
               helm dependency build $CHART
               helm lint $CHART
               helm unittest $CHART --helm3
-              if [ -f $CHART test.values.yaml ]; then
-                helm install --dry-run --generate-name --values $CHART/test.values.yaml $CHART
+              if [ -f "$CHART/test.values.yaml" ]; then
+                helm install --dry-run --generate-name --values "$CHART/test.values.yaml" $CHART
               fi
               helm package $CHART --destination /tmp/charts
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,9 @@ jobs:
               helm dependency build $CHART
               helm lint $CHART
               helm unittest $CHART --helm3
+              if [ -f $CHART test.values.yaml ]; then
+                helm install --dry-run --generate-name --values $CHART/test.values.yaml $CHART
+              fi
               helm package $CHART --destination /tmp/charts
             done
 

--- a/drupal/test.values.yaml
+++ b/drupal/test.values.yaml
@@ -1,0 +1,32 @@
+# This file includes the configuration used to validate the chart with a dry-run installation.
+
+exposeDomains:
+ - hostname: example.com
+ - hostname: www.example.com
+   ssl:
+     enabled: true
+     issuer: letsencrypt-staging
+
+domainPrefixes: ['en', 'fi']
+
+autoscaling:
+  enabled: true
+
+varnish:
+  enabled: true
+
+memcached:
+  enabled: true
+
+elasticsearch:
+  enabled: true
+
+mailhog:
+  enabled: true
+
+backup:
+  enabled: true
+
+mounts:
+  private-files:
+    enabled: true

--- a/frontend/test.values.yaml
+++ b/frontend/test.values.yaml
@@ -1,0 +1,38 @@
+# This file includes the configuration used to validate the chart with a dry-run installation.
+
+exposeDomains:
+ - hostname: example.com
+ - hostname: www.example.com
+   ssl:
+     enabled: true
+     issuer: letsencrypt-staging
+
+domainPrefixes: ['en', 'fi']
+
+nginx:
+  autoscaling:
+    enabled: true
+
+services:
+  node:
+    # This value needs to be present, but is not validated to be a correct docker image
+    image: test/test:version
+  autoscaling:
+    enabled: true
+
+shell:
+  enabled: true
+
+elasticsearch:
+  enabled: true
+
+rabbitmq:
+  enabled: true
+
+mounts:
+  files:
+    enabled: true
+    storage: 1G
+    mountPath: /app/files
+    storageClassName: silta-shared
+    csiDriverName: csi-rclone

--- a/simple/test.values.yaml
+++ b/simple/test.values.yaml
@@ -1,0 +1,13 @@
+# This file includes the configuration used to validate the chart with a dry-run installation.
+
+exposeDomains:
+ - hostname: example.com
+ - hostname: www.example.com
+   ssl:
+     enabled: true
+     issuer: letsencrypt-staging
+
+domainPrefixes: ['en', 'fi']
+
+autoscaling:
+  enabled: true


### PR DESCRIPTION
A Helm dry run can catch quite a few errors, as the generated output is validated against the kubernetes API (even though nothing gets created). This provides us with another safety net when pushing out new releases.

The CircleCI script now looks for a file called `test.values.yaml` in each chart, this has many purposes:
- The existence of the file determines if a dry run should take place. For example we don't want to test charts that will only be used as subcharts.
- We can pass required attributes, such as the docker image required by services in the frontend chart.
- We can enable optional resources so that they are tested as well.

So far the drupal, frontend and simple charts are covered. It would be nice to include the silta-cluster chart as well, but since it creates some resources that are unique in the cluster, we get errors due to conflicts with existing resources when testing against an existing silta cluster.