### PR TITLE
SLT-474: Stable repo deprecation for silta-cluster chart

### DIFF
--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -3,11 +3,11 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.86.2
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.bitnami.com/bitnami
   version: 10.4.4
 - name: minio
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 2.5.14
+  repository: https://charts.bitnami.com/bitnami
+  version: 3.3.10
 - name: csi-rclone
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 0.1.10
@@ -20,5 +20,5 @@ dependencies:
 - name: instana-agent
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 1.0.28
-digest: sha256:eb212c6dcccdb4d54d49d5ec7b9ff41aeeeebcd3fdab30b10425f2839c1925a1
-generated: "2020-05-06T10:33:31.848873+02:00"
+digest: sha256:0cfff60ba3b2d25c743338f7be87b94a77c166fd6de2295300c010afd59edc7c
+generated: "2020-05-11T11:24:13.372165794Z"

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,18 +2,18 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.4
+version: 0.2.5
 dependencies:
 - name: traefik
   version: 1.86.x
   repository: https://kubernetes-charts.storage.googleapis.com/
 - name: redis
   version: 10.4.x
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.bitnami.com/bitnami
   condition: deploymentRemover.enabled
 - name: minio
-  version: 2.5.14
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 3.3.x
+  repository: https://charts.bitnami.com/bitnami
   condition: minio.enabled
 - name: csi-rclone
   version: 0.1.x


### PR DESCRIPTION
Issues:
 - minio 2.5.14 does not exist in bitnami. replaced with 3.3 with no further testing.
 - stable/traefik is not available anywhere else. traefik website links another chart instead, but it's based on traefik 2.0 (https://github.com/helm/charts/issues/17203; https://github.com/containous/traefik-helm-chart)
 - stable/instana agent is not available anywhere else. Official website links to stable charts.

Separate stories create to tackle them in the future.