### PR TITLE
Feature/jumphost keyserver

### DIFF
--- a/silta-cluster/templates/deployment-remover.yaml
+++ b/silta-cluster/templates/deployment-remover.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         name: {{ .Release.Name }}-deployment-remover
     spec:
+      enableServiceLinks: false
       initContainers:
       - name: wait-redis
         image: busybox

--- a/silta-cluster/templates/splash-deployment.yaml
+++ b/silta-cluster/templates/splash-deployment.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         name: {{ .Release.Name }}-splash
     spec:
+      enableServiceLinks: false
       containers:
       - image: "wunderio/silta-splash"
         name: nginx

--- a/silta-cluster/templates/ssh-key-server-ingress.yaml
+++ b/silta-cluster/templates/ssh-key-server-ingress.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.sshKeyServer.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-ssh-key-server
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    {{- if .Values.sshKeyServer.ssl.enabled }}
+    traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
+    ingress.kubernetes.io/ssl-redirect: "true"
+    {{- else }}
+    traefik.ingress.kubernetes.io/frontend-entry-points: "http"
+    ingress.kubernetes.io/ssl-redirect: "false"
+    {{- end }}
+spec:
+  {{- if .Values.sshKeyServer.ssl.enabled }}
+  tls:
+  - secretName: {{ .Release.Name }}-tls-ssh-key-server
+  {{- end }}
+  rules:
+  - host: keys.{{ .Values.clusterDomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ .Release.Name }}-ssh-key-server
+          servicePort: 80
+---
+{{- if .Values.sshKeyServer.ssl.enabled }}
+{{- if has .Values.sshKeyServer.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-crt-ssh-key-server
+spec:
+  secretName: {{ .Release.Name }}-tls-ssh-key-server
+  dnsNames:
+  - keys.{{ .Values.clusterDomain }}
+  issuerRef:
+    name: {{ .Values.sshKeyServer.ssl.issuer }}
+    kind: ClusterIssuer
+  acme:
+    config:
+      - http01:
+          ingress: {{ .Release.Name }}-ssh-key-server
+        domains:
+          - keys.{{ .Values.clusterDomain }}
+---
+{{- else if eq .Values.sshKeyServer.ssl.issuer "selfsigned" }}
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-crt-ssh-key-server
+spec:
+  secretName: {{ .Release.Name }}-tls-ssh-key-server
+  duration: 2160h
+  renewBefore: 150h 
+  commonName: keys.{{ .Values.clusterDomain }}
+  dnsNames:
+  - keys.{{ .Values.clusterDomain }}
+  issuerRef:
+    name: {{ .Values.sshKeyServer.ssl.issuer }}
+    kind: ClusterIssuer
+---
+{{- else if eq .Values.sshKeyServer.ssl.issuer "custom" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-tls-ssh-key-server
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.sshKeyServer.ssl.crt | b64enc }}
+  tls.key: {{ .Values.sshKeyServer.ssl.key | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/silta-cluster/templates/ssh-key-server.yaml
+++ b/silta-cluster/templates/ssh-key-server.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.sshKeyServer.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-ssh-key-server
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+    - port: 80
+  selector:
+    name: {{ .Release.Name }}-ssh-key-server
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-ssh-key-server
+spec:
+  replicas: {{ .Values.sshKeyServer.replicas }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}-ssh-key-server
+    spec:
+      enableServiceLinks: false
+      containers:
+      - name: {{ .Release.Name }}-ssh-key-server
+        image: wunderio/silta-ssh-keys:v0.1
+        ports:
+          - containerPort: 80
+        imagePullPolicy: Always
+        env:
+          - name: GITAUTH_API_TOKEN
+            value: {{ required "A valid .Values.sshKeyServer.gitauthApiToken entry required!" .Values.sshKeyServer.gitauthApiToken | quote }}
+          - name: KEYS_SERVER_API_USERNAME
+            value: {{ required "A valid .Values.sshKeyServer.computeZone entry required!" .Values.sshKeyServer.apiUsername | quote }}
+          - name: KEYS_SERVER_API_PASSWORD
+            value: {{ required "A valid .Values.sshKeyServer.clusterName entry required!" .Values.sshKeyServer.apiPassword | quote }}
+        resources:
+          {{- .Values.sshKeyServer.resources | toYaml | nindent 10 }}
+{{- end }}

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -29,6 +29,7 @@ spec:
       labels:
         name: {{ .Release.Name }}-jumpserver
     spec:
+      enableServiceLinks: false
       containers:
       - name: {{ .Release.Name }}-jumpserver
         image: wunderio/sshd-gitauth:v0.1

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gitAuth.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -32,17 +33,21 @@ spec:
       enableServiceLinks: false
       containers:
       - name: {{ .Release.Name }}-jumpserver
-        image: wunderio/sshd-gitauth:v0.1
+        image: wunderio/sshd-gitauth:v0.2
         imagePullPolicy: Always
         ports:
           - containerPort: 22
         env:
-          - name: GITAUTH_API_TOKEN
-            value: {{ required "A valid .Values.gitAuth.apiToken entry required!" .Values.gitAuth.apiToken | quote }}
-          - name: GITAUTH_HOST
-            value: {{ required "A valid .Values.gitAuth.host entry required!" .Values.gitAuth.host | quote }}
-          - name: GITAUTH_ORGANISATION
-            value: {{ required "A valid .Values.gitAuth.organisation entry required!" .Values.gitAuth.organisation | quote }}
+          - name: GITAUTH_URL
+            value: {{ .Values.gitAuth.keyserver.url | default (printf "https://keys.%s/api/1/git-ssh-keys" .Values.clusterDomain) | quote }}
+          - name: GITAUTH_USERNAME
+            value: {{ .Values.gitAuth.keyserver.username | default .Values.sshKeyServer.apiUsername | quote }}
+          - name: GITAUTH_PASSWORD
+            value: {{ .Values.gitAuth.keyserver.password | default .Values.sshKeyServer.apiPassword | quote }}
+          - name: GITAUTH_SCOPE
+            value: {{ required "A valid .Values.gitAuth.scope entry required!" .Values.gitAuth.scope | quote }}
+          - name: OUTSIDE_COLLABORATORS
+            value: {{ .Values.gitAuth.outsideCollaborators | default true | quote }}
         volumeMounts:
         - name: shell-keys
           mountPath: /etc/ssh/keys
@@ -67,3 +72,5 @@ spec:
   resources:
     requests:
       storage: 50M
+
+{{- end }}

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -89,6 +89,24 @@ gitAuth:
   # The static IP to be used for the exposed endpoint.
   loadBalancerIP: null
 
+# SSH keyserver (keys.[clusterDomain])
+sshKeyServer:
+  enabled: true
+  gitauthApiToken: ''
+  apiUsername: ''
+  apiPassword: ''
+  replicas: 1
+  resources: {}
+  ssl:
+    enabled: true
+    email: admin@example.com
+    # Available issuers: letsencrypt-staging, letsencrypt, selfsigned, custom
+    issuer: letsencrypt
+    # Used when certificate type is custom
+    # ca: ""
+    # key: ""
+    # crt: ""
+
 # Deployment remover
 deploymentRemover:
   enabled: true

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -79,13 +79,16 @@ splash:
 
 # SSH Jumphost settings
 gitAuth:
-  host: 'github.com'
-  organisation: ''
-  apiToken: ''
+  enabled: true
+  keyserver:
+    url: ''
+    username: ''
+    password: ''
+  scope: ''
+  outsideCollaborators: true
   allowedIps: []
   # Kubernetes resource allocation.
   resources: {}
-
   # The static IP to be used for the exposed endpoint.
   loadBalancerIP: null
 


### PR DESCRIPTION
`silta-cluster` chart now bundles an optional ssh keyserver which holds the github key list. This allows caching user keys and repos more effectively. 

Key server code at https://github.com/wunderio/silta-ssh-keys

New image for jumphost is already built and tagged: https://github.com/wunderio/sshd-gitauth/commit/28799f68afa8ee271e371ec8bb9e5d68fac33d46