### PR TITLE
Give memcached some buffer or it will crash when the cache is full.

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -430,10 +430,13 @@ memcached:
   replicaCount: 1
   pdbMinAvailable: 0
   memcached:
-    maxItemMemory: 128
+    # This should be less than the memory limit, or memcached will crash.
+    maxItemMemory: 118
   resources:
     requests:
       cpu: 10m
+      memory: 128Mi
+    limits:
       memory: 128Mi
 
 # Mailhog service overrides


### PR DESCRIPTION
We noticed this on a big project, but it should be fixed by default even if it's usually not a problem.