### PR TITLE
Quote host names to support wildcards

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.37
+version: 0.3.38
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/drupal-certificate.yaml
+++ b/drupal/templates/drupal-certificate.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   secretName: {{ .Release.Name }}-tls
   dnsNames:
-  - {{ template "drupal.domain" . }}
+  - {{ include "drupal.domain" . | quote }}
   issuerRef:
     name: {{ .Values.ssl.issuer }}
     kind: ClusterIssuer
@@ -30,7 +30,7 @@ metadata:
 spec:
   secretName: {{ $.Release.Name }}-tls-p{{ $index }}
   dnsNames:
-  - {{$prefix}}.{{ template "drupal.domain" $ }}
+  - '{{$prefix}}.{{ include "drupal.domain" $ }}'
   issuerRef:
     name: {{ $.Values.ssl.issuer }}
     kind: ClusterIssuer
@@ -39,7 +39,7 @@ spec:
       - http01:
           ingress: {{ $.Release.Name }}-drupal
         domains:
-          - {{$prefix}}.{{ template "drupal.domain" $ }}
+          - '{{$prefix}}.{{ include "drupal.domain" $ }}'
 ---
 {{- end }}
 

--- a/drupal/templates/drupal-ingress.yaml
+++ b/drupal/templates/drupal-ingress.yaml
@@ -26,7 +26,7 @@ spec:
   {{- end }}
   {{- end }}
   rules:
-  - host: {{ template "drupal.domain" . }}
+  - host: {{ include "drupal.domain" . | quote }}
     http:
       paths:
       - path: /
@@ -34,7 +34,7 @@ spec:
           serviceName: {{ include "drupal.servicename" . }}
           servicePort: 80
 {{- range $index, $prefix := .Values.domainPrefixes }}
-  - host: {{$prefix}}.{{ template "drupal.domain" $ }}
+  - host: '{{$prefix}}.{{ template "drupal.domain" $ }}'
     http:
       paths:
       - path: /

--- a/drupal/tests/drupal_ingress_test.yaml
+++ b/drupal/tests/drupal_ingress_test.yaml
@@ -73,7 +73,7 @@ tests:
 
   - it: takes a hostname prefix
     set:
-      domainPrefixes: ['qux', 'quux']
+      domainPrefixes: ['qux', 'quux', '*']
       environmentName: 'foo'
       projectName: 'bar'
       clusterDomain: 'baz'
@@ -87,3 +87,6 @@ tests:
       - equal:
          path: spec.rules[2].host
          value: 'quux.foo.bar.baz'
+      - equal:
+         path: spec.rules[3].host
+         value: '*.foo.bar.baz'


### PR DESCRIPTION
We have an interesting use case that requires using a wildcard as the domain prefix. This work, but the resource definition is only valid YAML if the hostnames are quoted.