### PR TITLE
Drupal: Use external ssh key server for shell container

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.38
+version: 0.3.39
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/shell-deployment.yaml
+++ b/drupal/templates/shell-deployment.yaml
@@ -27,13 +27,22 @@ spec:
         image: {{ .Values.shell.image | quote }}
         env:
         {{- include "drupal.env" . | indent 8 }}
-        - name: GITAUTH_API_TOKEN
+        - name: GITAUTH_URL
+          value: {{ .Values.shell.gitAuth.keyserver.url | default (printf "https://keys.%s/api/1/git-ssh-keys" .Values.clusterDomain) | quote }}
+        - name: GITAUTH_USERNAME
           valueFrom:
             secretKeyRef:
               name: {{ .Release.Name }}-secrets-shell
-              key: gitAuth.apiToken
-        - name: GITAUTH_REPOSITORY_URL
-          value: "{{ .Values.shell.gitAuth.repositoryUrl }}"
+              key: keyserver.username
+        - name: GITAUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-secrets-shell
+              key: keyserver.password
+        - name: GITAUTH_SCOPE
+          value: {{ .Values.shell.gitAuth.repositoryUrl }}
+        - name: OUTSIDE_COLLABORATORS
+          value: {{ .Values.shell.gitAuth.outsideCollaborators | default true | quote }}
         - name: DRUSH_OPTIONS_URI
           value: "http://{{- template "drupal.domain" . }}"
         ports:

--- a/drupal/templates/shell-secret.yaml
+++ b/drupal/templates/shell-secret.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.shell.gitAuth.apiToken }}
-  gitAuth.apiToken: "{{ .Values.shell.gitAuth.apiToken | b64enc }}"
+  {{- if .Values.shell.gitAuth.keyserver.username }}
+  keyserver.username: "{{ .Values.shell.gitAuth.keyserver.username | b64enc }}"
+  {{- end }}
+  {{- if .Values.shell.gitAuth.keyserver.password }}
+  keyserver.password: "{{ .Values.shell.gitAuth.keyserver.password | b64enc }}"
   {{- end }}

--- a/drupal/tests/shell_deployment_test.yaml
+++ b/drupal/tests/shell_deployment_test.yaml
@@ -39,6 +39,6 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: GITAUTH_REPOSITORY_URL
+            name: GITAUTH_SCOPE
             value: foo
 

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -221,8 +221,13 @@ shell:
   # Values for the SSH gitAuth.
   gitAuth:
     # Project's git repository URL
-    repositoryUrl: 'you need to pass in a value for repositoryUrl to your helm chart'
-    apiToken: 'you need to pass in a value for shell.gitAuth.apiToken to your helm chart'
+    repositoryUrl: 'you need to pass in a value for shell.gitAuth.repositoryUrl to your helm chart'
+    outsideCollaborators: true
+    keyserver:
+      # Defaults to https://keys.[clusterDomain]/api/1/git-ssh-keys
+      url: ''
+      username: ''
+      password: ''
 
   # Specifications for the volume where host keys are mounted.
   mount:


### PR DESCRIPTION
Following things need to be released at the same time:
1. Chart update needs to be merged. Wait for chart to be tagged.
2. Tag a v0.1.x release for `drupal-shell` from master branch. Wait for image to be built.
3. Orb needs prefix change for shell image, so the shell image is rebuilt on the next deployment.
