### PR TITLE
Add TLS_RSA_WITH_AES_***_GCM_SHA*** cipher suites

### DIFF
--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -21,6 +21,8 @@ traefik:
       - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
       - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
       - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+      - TLS_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_RSA_WITH_AES_128_GCM_SHA256
   dashboard:
     enabled: false
     serviceType: "NodePort"


### PR DESCRIPTION
Windows 2012 R2 having TLS 1.2 enabled doesn't support any of current cihper suites.

Adding two additional cihper suites that are suppored by Win server will allow some Windows servers to talk securely to our server.

According to cihpersuite.info, both are secure:

- https://ciphersuite.info/cs/TLS_RSA_WITH_AES_256_GCM_SHA384/
- https://ciphersuite.info/cs/TLS_RSA_WITH_AES_128_GCM_SHA256/

Both cipher suites are also recommended by Mozilla Server Side TLS:

- https://wiki.mozilla.org/Security/Server_Side_TLS