### PR TITLE
SLT-502 replace deprecated apis

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.41
+version: 0.3.42
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/drupal-ingress.yaml
+++ b/drupal/templates/drupal-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-drupal
@@ -45,7 +45,7 @@ spec:
 ---
 
 {{- range $index, $domain := .Values.exposeDomains }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $.Release.Name }}-drupal-{{ $index }}

--- a/drupal/templates/shell-deployment.yaml
+++ b/drupal/templates/shell-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.shell.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-shell

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.2.27
+version: 0.2.28
 apiVersion: v2
 dependencies:
 - name: elasticsearch

--- a/frontend/templates/ingress.yaml
+++ b/frontend/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-nginx
@@ -46,7 +46,7 @@ spec:
 {{- end }}
 ---
 {{- range $index, $domain := .Values.exposeDomains }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $.Release.Name }}-nginx-{{ $index }}

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.5
+version: 0.2.6
 dependencies:
 - name: traefik
   version: 1.86.x

--- a/silta-cluster/templates/deployment-remover-ingress.yaml
+++ b/silta-cluster/templates/deployment-remover-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deploymentRemover.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-deployment-remover

--- a/silta-cluster/templates/splash-ingress.yaml
+++ b/silta-cluster/templates/splash-ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-splash

--- a/silta-cluster/templates/ssh-key-server-ingress.yaml
+++ b/silta-cluster/templates/ssh-key-server-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.sshKeyServer.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ssh-key-server

--- a/silta-cluster/templates/ssh-key-server.yaml
+++ b/silta-cluster/templates/ssh-key-server.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     name: {{ .Release.Name }}-ssh-key-server
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-ssh-key-server

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -19,7 +19,7 @@ spec:
   selector:
     name: {{ .Release.Name }}-jumpserver
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-jumpserver

--- a/silta-downscaler/templates/placeholder-upscaler.yaml
+++ b/silta-downscaler/templates/placeholder-upscaler.yaml
@@ -55,7 +55,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-placeholder-upscaler

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: simple
-version: 0.2.3
+version: 0.2.4
 apiVersion: v2

--- a/simple/templates/ingress.yaml
+++ b/simple/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-drupal
@@ -28,7 +28,7 @@ spec:
           servicePort: 80
 ---
 {{- range $index, $domain := .Values.exposeDomains }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $.Release.Name }}-drupal-{{ $index }}


### PR DESCRIPTION
The extensions/v1beta1 API is deprecated, and unsupported for Deployment resources starting with kubernetes 1.16. These resources are stateless, replacing them doesn't cause any issues.