### PR TITLE
Add serverExtraLocations

### DIFF
--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -314,6 +314,10 @@ data:
         {{- end}}
 
         location / {
+            {{- if .Values.nginx.extraLocations }}
+            # Custom configuration gets included here
+              {{- .Values.nginx.serverExtraLocations | nindent 12 -}}
+            {{- end }}
 
             location ~* /system/files/ {
                 include fastcgi.conf;

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -127,6 +127,9 @@ nginx:
   # Extra configuration to pass to nginx as a file
   extraConfig: |
 
+  # Extra locations & location overrides.
+  serverExtraLocations: |
+
 # Configuration for everything that runs in php containers.
 php:
   # The docker image to be used. This is typically passed by your CI system using the --set parameter.


### PR DESCRIPTION
Our nginx configs have some default handling defined for static file handling that can't be easily overridden without including most parts of the nginx configs into project specific silta configs.
This pr adds serverExtraLocations block that can be used to define both new location definitions as well as used to override the existing ones by including it before the default ones within the `location /` block.