### PR TITLE
Support for Elasticsearch Helper 7.x is added

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.51
+version: 0.3.53
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -39,14 +39,6 @@ if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
 }
 
 /**
- * If Elasticsearch is enabled, add configuration for the Elasticsearch Helper module.
- */
-if (getenv('ELASTICSEARCH_HOST')) {
-  $config['elasticsearch_helper.settings']['elasticsearch_helper']['host'] = getenv('ELASTICSEARCH_HOST');;
-  $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = "9200";
-}
-
-/**
  * Set the memcache server hostname when a memcached server is available
  */
 if (getenv('MEMCACHED_HOST')) {

--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -24,6 +24,23 @@ if (getenv('PRIVATE_FILES_PATH')) {
 /**
  * If Elasticsearch is enabled, add configuration for the Elasticsearch Helper module.
  */
+if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
+  // Elasticsearch Helper 6.x compatible configuration override.
+  $config['elasticsearch_helper.settings']['elasticsearch_helper']['host'] = $elasticsearch_host;
+  $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = 9200;
+
+  // Elasticsearch Helper 7.x compatible configuration override.
+  $config['elasticsearch_helper.settings']['hosts'] = [
+    [
+      'host' => $elasticsearch_host,
+      'port' => 9200,
+    ],
+  ];
+}
+
+/**
+ * If Elasticsearch is enabled, add configuration for the Elasticsearch Helper module.
+ */
 if (getenv('ELASTICSEARCH_HOST')) {
   $config['elasticsearch_helper.settings']['elasticsearch_helper']['host'] = getenv('ELASTICSEARCH_HOST');;
   $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = "9200";


### PR DESCRIPTION
This change makes Elasticsearch Helper configuration override in `settings.silta.php` compatible with both version Elasticsearch Helper 6.x and 7.x.

More information about Elasticsearch Helper configuration structure change in 7.x can be found here - https://github.com/wunderio/elasticsearch_helper/blob/8.x-7.x/UPGRADE.md#changes-in-configuration

Credits: Solution to combine config override for both version was suggested by @Jancis. 🎉