### PR TITLE
Use release name to identify shell services

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.53
+version: 0.3.54
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/_domains.tpl
+++ b/drupal/templates/_domains.tpl
@@ -18,7 +18,7 @@
 {{- end -}}
 
 {{- define "drupal.environment.hostname" -}}
-{{ regexReplaceAll "[^[:alnum:]]" (.Values.environmentName | default .Release.Name) "-" | lower | trunc 50 | trimSuffix "-" }}
+{{ regexReplaceAll "[^[:alnum:]]" .Release.Name "-" | lower | trunc 50 | trimSuffix "-" }}
 {{- end -}}
 
 # SSH-related hosts


### PR DESCRIPTION
Removed environmentName from being used as name for shell services, as it would be used to create multiple shell services with the same name in the case of deploying a drupal multisite.

