### PR TITLE
Fix the non-working table ignoring in db backup job

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.54
+version: 0.3.55
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -78,7 +78,7 @@ imagePullSecrets:
     secretKeyRef:
       name: {{ .Release.Name }}-secrets-smtp
       key: password
-# Duplicate SMTP env variables for ssmtp bundled with amazee php image 
+# Duplicate SMTP env variables for ssmtp bundled with amazee php image
 - name: SSMTP_MAILHUB
   {{- if .Values.mailhog.enabled }}
   value: "{{ .Release.Name }}-mailhog:1025"
@@ -279,7 +279,7 @@ done
 
   # Make backup of current deployment
   {{ include "drupal.backup-command" . }}
-  
+
   # Restore files from targeted backup
   {{ include "drupal.import-backup-files" . }}
 
@@ -412,7 +412,7 @@ set -e
   IGNORED_TABLES=""
   for TABLE in `drush sql-query "show tables;" | grep -E '{{ .Values.backup.ignoreTableContent }}'` ;
   do
-    IGNORE_TABLES="$IGNORE_TABLES --ignore-table='$DB_NAME.$TABLE'";
+    IGNORE_TABLES="$IGNORE_TABLES --ignore-table=$DB_NAME.$TABLE";
     IGNORED_TABLES="$IGNORED_TABLES $TABLE";
   done
 


### PR DESCRIPTION
This PR stems from the discussion in this [Slack thread](https://wunder.slack.com/archives/C8UN6AG9W/p1589794939125800).

So basically I noticed that the `--ignore-table` options work in the `drupal.extract-reference-data` job but not in the `drupal.backup-command` job. After comparing the two, I found that it was the surrounding single quotes that broke it in the latter.