### PR TITLE
SLT-505: Set the cache backend to use memcache when memcache server is available

### DIFF
--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -45,10 +45,17 @@ if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
 
 /**
  * Set the memcache server hostname when a memcached server is available.
- * Set the cache backend to use memcache when a memcache server is available.
  */
 if (getenv('MEMCACHED_HOST')) {
   $settings['memcache']['servers'] = [getenv('MEMCACHED_HOST') . ':11211' => 'default'];
+}
+
+/**
+ * Set the cache backend to use memcache.
+ *
+ * Make sure that memcache host is set and memcache backend class is defined.
+ */
+if (getenv('MEMCACHED_HOST') && class_exists('\Drupal\memcache\MemcacheBackend')) {
   $settings['cache']['default'] = 'cache.backend.memcache';
 }
 

--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -45,9 +45,11 @@ if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
 
 /**
  * Set the memcache server hostname when a memcached server is available.
+ * Set the cache backend to use memcache when a memcache server is available.
  */
 if (getenv('MEMCACHED_HOST')) {
   $settings['memcache']['servers'] = [getenv('MEMCACHED_HOST') . ':11211' => 'default'];
+  $settings['cache']['default'] = 'cache.backend.memcache';
 }
 
 /**

--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -48,15 +48,11 @@ if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
  */
 if (getenv('MEMCACHED_HOST')) {
   $settings['memcache']['servers'] = [getenv('MEMCACHED_HOST') . ':11211' => 'default'];
-}
 
-/**
- * Set the cache backend to use memcache.
- *
- * Make sure that memcache host is set and memcache backend class is defined.
- */
-if (getenv('MEMCACHED_HOST') && class_exists('\Drupal\memcache\MemcacheBackend')) {
-  $settings['cache']['default'] = 'cache.backend.memcache';
+  // Set the memcache backend if class is defined.
+  if (class_exists('\Drupal\memcache\MemcacheBackend')) {
+    $settings['cache']['default'] = 'cache.backend.memcache';
+  }
 }
 
 /**


### PR DESCRIPTION
### Description

User story: https://wunder.atlassian.net/browse/SLT-505

Set the default cache backend to use memcache when a memcache server is available and when memcache cache backend is defined.

At the moment we only set the memcache host server settings, but it remains unused because it is not set as the backend cache for Drupal.