### PR TITLE
SLT-508: Backup validation

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.64
+version: 0.3.65
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -413,7 +413,12 @@ fi
 {{- end }}
 
 {{- define "drupal.backup-command" -}}
-set -e
+  {{ include "drupal.backup-command.dump-database" . }}
+  {{ include "drupal.backup-command.archive-store-backup" . }}
+{{- end }}
+
+{{- define "drupal.backup-command.dump-database" -}}
+  set -e
 
   # Generate the id of the backup.
   BACKUP_ID=`date +%Y-%m-%d-%H-%M-%S`
@@ -433,11 +438,14 @@ set -e
   /usr/bin/mysqldump -u $DB_USER --password=$DB_PASS -h $DB_HOST --skip-lock-tables --single-transaction --quick $IGNORE_TABLES $DB_NAME > /tmp/db.sql
   /usr/bin/mysqldump -u $DB_USER --password=$DB_PASS -h $DB_HOST --skip-lock-tables --single-transaction --quick --force --no-data $DB_NAME $IGNORED_TABLES >> /tmp/db.sql
   echo "Database backup complete."
+{{- end }}
 
+{{- define "drupal.backup-command.archive-store-backup" -}}
+  
   # Compress the database dump and copy it into the backup folder.
   # We don't do this directly on the volume mount to avoid sending the uncompressed dump across the network.
   echo "Compressing database backup."
-  gzip -9 /tmp/db.sql
+  gzip -k9 /tmp/db.sql
 
   # Create a folder for the backup
   mkdir -p $BACKUP_LOCATION
@@ -456,4 +464,40 @@ set -e
 
   # List content of backup folder
   ls -lh /backups/*
+{{- end }}
+
+
+{{- define "mariadb.db-validation" -}}
+  set -e
+
+  # Stop DB container when exiting this shell (backup container has done its job)
+  function stop_db {
+    mysqld_pid=$(pgrep mysqld)
+    kill -TERM $mysqld_pid && echo "Killed MariaDB, PID ${mysqld_pid}"
+  }
+  trap stop_db EXIT ERR
+
+
+  export DB_USER=root 
+  export DB_PASS={{ .db_password }}
+  export DB_HOST=127.0.0.1
+  export DB_NAME=drupal
+
+  TIME_WAITING=0
+  echo "Waiting for database.";
+  until mysqladmin status --connect_timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST --protocol=tcp --silent; do
+    echo -n "."
+    sleep 1s
+    TIME_WAITING=$((TIME_WAITING+1))
+
+    if [ $TIME_WAITING -gt 20 ]; then
+      echo "Database connection timeout"
+      exit 1
+    fi
+  done
+
+  
+  mysql -u $DB_USER -p$DB_PASS $DB_NAME -h $DB_HOST --protocol=tcp < /tmp/db.sql
+  drush status --fields=bootstrap
+
 {{- end }}

--- a/drupal/templates/backup-cron.yaml
+++ b/drupal/templates/backup-cron.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.backup.enabled }}
+{{- $db_password := randAlphaNum 20 }}
+{{- $params := dict "db_password" $db_password  -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -15,9 +17,13 @@ spec:
   suspend: false
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
+      backoffLimit: 2
       template:
         spec:
           enableServiceLinks: false
+          # Lets us kill DB process (in mariadb container) from backup container
+          shareProcessNamespace: true
           containers:
           - name: backup
             {{- include "drupal.php-container" . | nindent 12 }}
@@ -28,17 +34,38 @@ spec:
             command: ["/bin/bash", "-c"]
             args:
               - |
-                {{ include "drupal.backup-command" . | nindent 16 }}
+                {{ include "drupal.backup-command" (merge $params . ) | nindent 16 }}
+                {{ include "mariadb.db-validation" (merge $params . ) | nindent 16 }}
+            securityContext:
+              capabilities:
+                #For shareProcessNamespace
+                add:
+                  - SYS_PTRACE
+          - name: mariadb
+            image: docker.io/bitnami/mariadb:10.2
+            imagePullPolicy: IfNotPresent
+            env:
+            - name: MARIADB_ROOT_PASSWORD
+              value: {{ $db_password }}
+            - name: MARIADB_DATABASE
+              value: drupal
+            ports:
+            - containerPort: 3306
+              name: mariadb
             resources:
               {{- .Values.backup.resources | toYaml | nindent 14 }}
+            securityContext:
+              capabilities:
+                #For shareProcessNamespace
+                add:
+                  - SYS_PTRACE
           restartPolicy: Never
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}
             - name: {{ .Release.Name }}-backup
               persistentVolumeClaim:
                 claimName: {{ .Release.Name }}-backup
-
-
           {{- include "drupal.imagePullSecrets" . | nindent 10 }}
 {{- end }}
+
 ---


### PR DESCRIPTION
Updates backup cronjob:
 Test the DB .sql file by importing data into ephemeral mariadb container and bootstrapping drush against it.