### PR TITLE
SLT-505: Re-enable and fix the error produced by the previous change

### DIFF
--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -49,15 +49,12 @@ if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
 if (getenv('MEMCACHED_HOST')) {
   $settings['memcache']['servers'] = [getenv('MEMCACHED_HOST') . ':11211' => 'default'];
 
-  $memcache_exists = class_exists('Memcache', FALSE);
-  $memcached_exists = class_exists('Memcached', FALSE);
-
   // Set the default cache backend to use memcache if memcache host is set
   // and if one of the memcache libraries was found.
   // The existence of the memcache drupal module should also be checked
   // but this is not possible until this issue has been fixed:
   // https://www.drupal.org/project/drupal/issues/2766509
-  if ($memcache_exists || $memcached_exists) {
+  if (class_exists('Memcache', FALSE) || class_exists('Memcached', FALSE)) {
     $settings['cache']['default'] = 'cache.backend.memcache';
   }
 }

--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -49,10 +49,17 @@ if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
 if (getenv('MEMCACHED_HOST')) {
   $settings['memcache']['servers'] = [getenv('MEMCACHED_HOST') . ':11211' => 'default'];
 
-  // Set the memcache backend if class is defined.
-  // if (class_exists('\Drupal\memcache\MemcacheBackend')) {
-  //   $settings['cache']['default'] = 'cache.backend.memcache';
-  // }
+  $memcache_exists = class_exists('Memcache', FALSE);
+  $memcached_exists = class_exists('Memcached', FALSE);
+
+  // Set the default cache backend to use memcache if memcache host is set
+  // and if one of the memcache libraries was found.
+  // The existence of the memcache drupal module should also be checked
+  // but this is not possible until this issue has been fixed:
+  // https://www.drupal.org/project/drupal/issues/2766509
+  if ($memcache_exists || $memcached_exists) {
+    $settings['cache']['default'] = 'cache.backend.memcache';
+  }
 }
 
 /**


### PR DESCRIPTION
This fixes the error that happens in projects using memcache in which it could not find the memcache backend class. For now we just check if the memcache libraries exists.