### PR TITLE
SLT-505: Do not set memcache backend during installation

### DIFF
--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -51,10 +51,11 @@ if (getenv('MEMCACHED_HOST')) {
 
   // Set the default cache backend to use memcache if memcache host is set
   // and if one of the memcache libraries was found.
+  // Cache backends should not be set to memcache during installation.
   // The existence of the memcache drupal module should also be checked
   // but this is not possible until this issue has been fixed:
   // https://www.drupal.org/project/drupal/issues/2766509
-  if (class_exists('Memcache', FALSE) || class_exists('Memcached', FALSE)) {
+  if (!\Drupal\Core\Installer\InstallerKernel::installationAttempted() && (class_exists('Memcache', FALSE) || class_exists('Memcached', FALSE))) {
     $settings['cache']['default'] = 'cache.backend.memcache';
   }
 }

--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -5,6 +5,8 @@
  * Automatically injected settings for the Silta environment.
  */
 
+use Drupal\Core\Installer\InstallerKernel;
+
 // Database settings.
 $databases['default']['default'] = [
   'database' => getenv('DB_NAME'),
@@ -55,7 +57,7 @@ if (getenv('MEMCACHED_HOST')) {
   // The existence of the memcache drupal module should also be checked
   // but this is not possible until this issue has been fixed:
   // https://www.drupal.org/project/drupal/issues/2766509
-  if (!\Drupal\Core\Installer\InstallerKernel::installationAttempted() && (class_exists('Memcache', FALSE) || class_exists('Memcached', FALSE))) {
+  if (!InstallerKernel::installationAttempted() && (class_exists('Memcache', FALSE) || class_exists('Memcached', FALSE))) {
     $settings['cache']['default'] = 'cache.backend.memcache';
   }
 }


### PR DESCRIPTION
### Description

This fixes cache backend errors that occurs when installing Drupal in cases where memcache is defined as cache backend. 