### PR TITLE
SLT-523: Execute custom command at the end of deployment

### DIFF
--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.2.37
+version: 0.2.38
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -132,7 +132,7 @@ spec:
                   values:
                   - frontend-{{ $index }}
       {{- end }}
-{{- if $service.postupgrade }}
+{{- if or $service.postupgrade $service.postinstall }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -162,6 +162,9 @@ spec:
         command: ["/bin/bash", "-c"]
         args:
         - |
+            {{- if $.Release.IsInstall }}
+            {{ $service.postinstall.command }}
+            {{- end }}
             {{ $service.postupgrade.command }}
         volumeMounts:
           {{ if $service.mounts }}

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -132,6 +132,74 @@ spec:
                   values:
                   - frontend-{{ $index }}
       {{- end }}
+{{- if $service.postupgrade }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ $.Release.Name }}-{{ $index }}-post-release"
+  labels:
+    {{ include "frontend.release_labels" $ | indent 4 }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  completions: 1
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{ include "frontend.release_labels" $ | indent 8 }}
+    spec:
+      restartPolicy: Never
+      enableServiceLinks: false
+      containers:
+      - name: {{ $index }}
+        image: {{ $service.image | quote }}
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+            {{ $service.postupgrade.command }}
+        volumeMounts:
+          {{ if $service.mounts }}
+          {{- range $index, $mountName := $service.mounts -}}
+          {{ $mount := (index $.Values.mounts $mountName) }}
+          {{- if eq $mount.enabled true }}
+          - name: frontend-{{ $mountName }}
+            mountPath: {{ $mount.mountPath }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{ if $.Values.shell.enabled -}}
+          - name: shell-keys
+            mountPath: /etc/ssh/keys
+          {{- end }}
+        env:
+        {{- include "services.env" (dict "Values" $.Values "Release" $.Release "service" $service) | nindent 8 }}
+        {{- range $key, $val := $service.env }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+        {{- end }}
+      volumes:
+        {{ if $service.mounts }}
+        {{- range $index, $mountName := $service.mounts -}}
+        {{ $mount := (index $.Values.mounts $mountName) }}
+        {{- if eq $mount.enabled true }}
+        - name: frontend-{{ $mountName }}
+          persistentVolumeClaim:
+            claimName: {{ $.Release.Name }}-{{ $mountName }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{ if $.Values.shell.enabled -}}
+        - name: shell-keys
+          persistentVolumeClaim:
+            claimName: {{ $.Release.Name }}-shell-keys
+        {{- end }}
+{{- end }}
 
 {{- if $service.autoscaling }}
 {{- if $service.autoscaling.enabled }}

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -182,6 +182,12 @@ services: {}
   #     limits:
   #       memory: 512Mi
 
+  #  # Post-release hook.
+  #  # This is run every time a new release is deployed
+  #  postupgrade:
+  #    command: |
+  #      'your command here'
+
   #  cron:
   #    example:
   #      command: echo "hello world"

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -182,11 +182,17 @@ services: {}
   #     limits:
   #       memory: 512Mi
 
-  #  # Post-release hook.
+  #  # Post-install hook.
+  #  # This is run every time a new environment (most commonly a first deployment for a new branch) is created
+  #  postinstall:
+  #    command: |
+  #      your command goes here
+
+  #  # Post-upgrade hook.
   #  # This is run every time a new release is deployed
   #  postupgrade:
   #    command: |
-  #      'your command here'
+  #      your command goes here
 
   #  cron:
   #    example:


### PR DESCRIPTION
Adds two custom jobs to be defined by the user:

    Postinstall - executes after a new environment is made (common case is first deployment for a new branch);
    Postupgrade - executes after each deployment.

Testing:

    Create postinstall,postupgrade tasks for a service
    Both of these tasks execute on the first deployment - check post-release pod logs.
    Subsequent deployments only execute postrelease.
