### PR TITLE
PHP logging changes

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.67
+version: 0.3.68
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -187,6 +187,11 @@ data:
 
   php_fpm_d_custom: |
 
+    [global]
+    error_log = /proc/self/fd/2
+    ; https://github.com/docker-library/php/pull/725#issuecomment-443540114
+    log_limit = 8192
+
     [www]
     pm = dynamic
     ; This should adjust to amount of memory given to the container
@@ -197,8 +202,12 @@ data:
     pm.process_idle_timeout = 60s
     pm.max_requests = 500
     
+    ; if we send this to /proc/self/fd/1, it never appears
     access.log = /proc/self/fd/2
+    
+    ; Ensure worker stdout and stderr are sent to the main error log.
     catch_workers_output = yes
+    decorate_workers_output = no
     
     clear_env = no
 


### PR DESCRIPTION
PHP error log to `/proc/self/fd/2`
Removing php fpm child decorator from stdio error log (stdout)