### PR TITLE
Silta-Cluster: silta-proxy nodeSelector and toleration changes

### DIFF
--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -22,6 +22,6 @@ dependencies:
   version: 0.1.0
 - name: instana-agent
   repository: https://agents.instana.io/helm
-  version: 1.1.9
-digest: sha256:74d5935ea10b3716678f202658aac4af86e332c3d1e4373908ecc85ea654747e
-generated: "2021-01-06T13:42:18.450641561+02:00"
+  version: 1.1.10
+digest: sha256:ed37d3b73da2b6e280e633b357a84703fa66b668cf1d64136c64918c56fe93ed
+generated: "2021-02-16T15:28:50.749394882+02:00"

--- a/silta-proxy/templates/proxy-deployment.yaml
+++ b/silta-proxy/templates/proxy-deployment.yaml
@@ -36,7 +36,11 @@ spec:
       - name: tinyproxy
         configMap:
           name: {{ .Release.Name }}-tinyproxy
+      {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
       tolerations:
         {{- .Values.tolerations | toYaml | nindent 8 }}
+      {{- end }}

--- a/silta-proxy/values.yaml
+++ b/silta-proxy/values.yaml
@@ -1,6 +1,6 @@
 # Default values for silta-proxy.
 
-image: wunderio/silta-proxy
+image: eu.gcr.io/silta-images/silta-proxy
 tag: "latest"
 
 service:
@@ -11,10 +11,10 @@ resources:
     cpu: 10m
     memory: 10Mi
 
-nodeSelector:
-  cloud.google.com/gke-nodepool: static-ip
+nodeSelector: {}
+  # cloud.google.com/gke-nodepool: static-ip
 
-tolerations:
-  - key: cloud.google.com/gke-nodepool
-    operator: Equal
-    value: static-ip
+tolerations: []
+  # - key: cloud.google.com/gke-nodepool
+  #   operator: Equal
+  #   value: static-ip


### PR DESCRIPTION
- Moving silta-proxy nodeSelectors and toleration conf to cluster specific yamls because cluster specific yaml configurations can't override nodeSelector (neither `{}` nor `null` worked)
- Use silta-images image repository for silta-proxy docker image