### PR TITLE
drupal-chart: cloud type setting; backendConfig only deployed to gke;

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.74
+version: 0.3.75
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/drupal-backendconfig.yaml
+++ b/drupal/templates/drupal-backendconfig.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.cluster.type "gke" }}
 apiVersion: cloud.google.com/v1beta1
 kind: BackendConfig
 metadata:
@@ -7,4 +8,5 @@ metadata:
 {{ if .Values.backendConfig }} 
 spec:
   {{- toYaml .Values.backendConfig | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/drupal/templates/drupal-service.yaml
+++ b/drupal/templates/drupal-service.yaml
@@ -4,7 +4,9 @@ metadata:
   name: {{ .Release.Name }}-drupal
   annotations:
     auto-downscale/down: "false"
+    {{- if eq .Values.cluster.type "gke" }}
     beta.cloud.google.com/backend-config: '{"ports": {"80":"{{ .Release.Name }}-drupal"}}'
+    {{- end }}
     {{- if .Values.cluster }}
     {{- if .Values.cluster.vpcNative }}
     cloud.google.com/neg: '{"ingress": true}'

--- a/drupal/test.values.yaml
+++ b/drupal/test.values.yaml
@@ -30,3 +30,6 @@ backup:
 mounts:
   private-files:
     enabled: true
+
+cluster:
+  type: ""

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -80,6 +80,7 @@ ingress:
 
 # Infrastructure related settings.
 cluster: 
+  type: gke
   vpcNative: false
 
 # backendConfig customisations for Drupal service


### PR DESCRIPTION
- Adds `cluster.type` setting (should be overriden by ci tool). Defaults to gke so existing deployments won't start to die.
- `backendConfig` only included on gke cluster
