### PR TITLE
Pass maxMemoryLimit and maxItemSize as command arguments to memcached. 

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.77
+version: 0.3.78
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -494,20 +494,22 @@ elasticsearch:
           - static-ip
 
 # Memcache service overrides
-# see: https://github.com/helm/charts/blob/master/stable/memcached/values.yaml
+# see: https://github.com/bitnami/charts/blob/master/bitnami/memcached/values.yaml
 memcached:
   enabled: false
   replicaCount: 1
-  pdbMinAvailable: 0
-  memcached:
-    # This should be less than the memory limit, or memcached will crash.
-    maxItemMemory: 118
   resources:
     requests:
       cpu: 10m
       memory: 128Mi
     limits:
       memory: 128Mi
+  arguments:
+    - /run.sh
+    # MaxMemoryLimit, this should be less than the resources.limits.memory, or memcached will crash.
+    - -m 118
+    # MaxItemSize
+    - -I 4M
 
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml


### PR DESCRIPTION
Memcache chart has been changed from Kubernetes stable to Bitnami (https://github.com/wunderio/drupal-project-k8s/commit/735d7e242e93484712fd0a5aef1d87e2bc5652e7) but the configurations to comply with Bitnami chart wasn't updated.
This pull request updates the memcached `maxMemorySize` from `memcached.maxItemMemory` to be passed as command argument. 

See https://github.com/wunderio/drupal-project-k8s/pull/316