### PR TITLE
Document varnish key override

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -439,6 +439,7 @@ varnish:
   # See https://github.com/wunderio/silta/blob/master/docs/silta-examples.md#using-varnish
   # to configure varnish for Your site correctly.
   enabled: false
+  secret: "not-a-secret-123"
   resources:
     requests:
       cpu: 25m


### PR DESCRIPTION
This setting was implied in the varnish control key secrets template, but not visible to end users.
https://github.com/wunderio/charts/blob/master/drupal/templates/varnish-secret.yaml#L10-L14

This fixes it for people that are used to set a custom varnish key.