### PR TITLE
Make jumphost port configurable.

### DIFF
--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ports:
     - name: ssh
-      port: 22
+      port: {{ .Values.gitAuth.port }}
   type: "LoadBalancer"
 {{- if .Values.gitAuth.loadBalancerIP }}
   loadBalancerIP: {{ .Values.gitAuth.loadBalancerIP }}

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -80,6 +80,7 @@ splash:
 # SSH Jumphost settings
 gitAuth:
   enabled: true
+  port: 22
   keyserver:
     url: ''
     username: ''


### PR DESCRIPTION
When running on single node / vm setup if we bind the jumphost port to default ssh port we lose connectivity to the host node over ssh.