### PR TITLE
Add annotations support to sshd-jumpserver.

### DIFF
--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.11
+version: 0.2.12
 dependencies:
 - name: traefik
   version: 1.87.x

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -4,6 +4,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-jumpserver
+  {{- if .Values.gitAuth.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.gitAuth.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   ports:
     - name: ssh


### PR DESCRIPTION
When running e.g. Microk8s with Metallb on single host setups getting both sshd-jumpserver and Traefik ingress to share the host ip requires adding sharing key annotation to those services: https://github.com/metallb/metallb/blob/main/website/content/usage/_index.md#ip-address-sharing