### PR TITLE
Allow skipping files backup.

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.83
+version: 0.3.84
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -464,12 +464,14 @@ fi
   mkdir -p $BACKUP_LOCATION
   cp /tmp/db.sql.gz $BACKUP_LOCATION/db.sql.gz
 
+  {{- if not .Values.backup.skipFiles }}
   {{ range $index, $mount := .Values.mounts -}}
   {{- if eq $mount.enabled true }}
   # File backup for {{ $index }} volume.
   echo "Starting {{ $index }} volume backup."
   tar -czP --exclude=css --exclude=js --exclude=styles -f $BACKUP_LOCATION/{{ $index }}.tar.gz {{ $mount.mountPath }}
   {{- end -}}
+  {{- end }}
   {{- end }}
 
   # Delete old backups

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -403,6 +403,9 @@ backup:
   # These tables will have their content ignored from the backups.
   ignoreTableContent: '(cache|cache_.*)'
 
+  #  Do not backup files
+  #skipFiles: true
+
   # Resources for the backup cron job.
   resources:
     requests:


### PR DESCRIPTION
In case the storage backend filesystem is already backed up there is no need to take extra backups of files.
https://github.com/wunderio/drupal-project-k8s/pull/323