### PR TITLE
Unified probe for php-fpm readiness state

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.82
+version: 0.3.83
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -63,6 +63,7 @@ ports:
 - name: config
   configMap:
     name: {{ .Release.Name }}-drupal
+    defaultMode: 0777
 {{- end }}
 
 {{- define "drupal.imagePullSecrets" }}

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -619,3 +619,19 @@ data:
     Host *
     ProxyCommand=nc -X connect -x {{ $proxy.url }}:{{ $proxy.port }} %h %p
 {{- end }}
+
+  php-fpm-probe.sh: |
+    #!/bin/bash
+    
+    # Prevent requests during the site installation process.
+    if [ {{ include "drupal.installation-in-progress-test" $ }} ]; then 
+        exit 1; 
+    fi
+
+    # Ping php-fpm process
+    SCRIPT_NAME=/ping \
+    SCRIPT_FILENAME=/ping \
+    REQUEST_METHOD=GET \
+    cgi-fcgi -bind -connect localhost:9000 \
+    > /dev/null
+

--- a/drupal/templates/drupal-deployment.yaml
+++ b/drupal/templates/drupal-deployment.yaml
@@ -27,13 +27,15 @@ spec:
         {{- include "drupal.php-container" . | nindent 8}}
         volumeMounts:
           {{- include "drupal.volumeMounts" . | nindent 10 }}
+          - name: config
+            mountPath: /php-fpm-probe.sh
+            subPath: php-fpm-probe.sh
         livenessProbe:
           tcpSocket:
             port: 9000
         readinessProbe:
           exec:
-            # Prevent coming in during the installation process.
-            command: ['/bin/bash', '-c', 'if [ {{ include "drupal.installation-in-progress-test" . }} ]; then exit 1; fi']
+            command: ['/bin/bash', '-c', '/php-fpm-probe.sh']
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
 

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -116,6 +116,9 @@ ssl:
 nginx:
   image: 'you need to pass in a value for nginx.image to your helm chart'
 
+  # Possible Values: debug, info, notice, warn, error, crit, alert, or emerg.
+  loglevel: error
+
   # The Kubernetes resources for the nginx container.
   # These values are optimised for development environments.
   resources:
@@ -255,7 +258,6 @@ php:
 
   # PHP settings
   php_ini:
-    loglevel: notice  # Possible Values: alert, error, warning, notice, debug
     upload_max_filesize: 60M
     post_max_size: 60M
     memory_limit: 256M


### PR DESCRIPTION
Replaces liveness probe with a combined check that both tries to prevent requests during the site installation process and checks the php-fpm process readiness before marking container as Ready.
This should prevent `"no live upstreams while connecting to upstream"` errors when the php-fpm process has not fully started up yet.

Plus, this PR removes the unused `.Values.php_ini.loglevel` and replaces with `.Values.nginx.loglevel`

Related PR: https://github.com/wunderio/drupal-project-k8s/pull/325