### PR TITLE
Increase worker_connections and worker_rlimit_nofile.

### DIFF
--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -74,11 +74,12 @@ data:
   nginx_conf: |
     user                            nginx;
     worker_processes                auto;
+    worker_rlimit_nofile            102400;
 
     error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};
 
     events {
-        worker_connections          1024;
+        worker_connections          102400;
         multi_accept                on;
     }
 

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.2.42
+version: 0.2.43
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/frontend/templates/configmap.yaml
+++ b/frontend/templates/configmap.yaml
@@ -8,11 +8,12 @@ data:
   nginx_conf: |
     user                            nginx;                                                 
     worker_processes                auto;
+    worker_rlimit_nofile            102400;
 
     error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};                                 
                                                                                           
     events {                                                                               
-        worker_connections          1024;                                                  
+        worker_connections          102400;                                                  
         multi_accept                on;                                                    
     }                                                                                      
                                                                                           

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.11
+version: 0.2.12
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/configmap.yaml
+++ b/simple/templates/configmap.yaml
@@ -8,11 +8,12 @@ data:
   nginx_conf: |
     user                            nginx;                                                 
     worker_processes                auto;
+    worker_rlimit_nofile            102400;
 
     error_log                       /proc/self/fd/2 {{ .Values.nginx.loglevel }};                                 
                                                                                           
     events {                                                                               
-        worker_connections          1024;                                                  
+        worker_connections          102400;                                                  
         multi_accept                on;                                                    
     }                                                                                      
                                                                                           


### PR DESCRIPTION
Added suggested mitigations # 1 and # 4 from https://hexadix.com/slowloris-dos-attack-mitigation-nginx-web-server/
Other limits were already appropriate.
Tested and approved in https://github.com/wunderio/drupal-project-k8s/pull/327