### PR TITLE
Feature/release 20210806

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.92
+version: 0.3.93
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/drupal-certificate.yaml
+++ b/drupal/templates/drupal-certificate.yaml
@@ -6,6 +6,8 @@
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true" 
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
@@ -95,6 +97,8 @@ data:
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true" 
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -416,6 +416,13 @@ data:
                 try_files $uri @drupal;
             }
 
+            {{- if .Values.nginx.retry404s }}
+            # Retry file lookup in 5 seconds (fs sync workaround)
+            location ~* ^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$ {
+                try_files $uri $uri/ @files_delay;
+            }
+            {{- end }}
+            
             ## Serve static files & images directly, without all standard drupal rewrites, php-fpm etc.
             location ~* ^.+\.(?:css|js|jpe?g|gif|png|ico|svg|swf|docx?|xlsx?|tiff?|txt|cgi|bat|pl|dll|exe|class)$ {
                 tcp_nodelay     off;
@@ -491,10 +498,6 @@ data:
         }
 
         {{- if .Values.nginx.retry404s }}
-        # Retry file lookup in 5 seconds (fs sync workaround)
-        location /sites/default/files/ {
-            try_files $uri $uri/ @files_delay;
-        }
         location @files_delay {
             internal;
             echo_sleep {{ .Values.nginx.retry404s }}.0;
@@ -502,7 +505,8 @@ data:
         }
         location @files_retry {
             internal;
-            try_files $uri $uri/ =404;
+            # Pass file request to drupal as a final fallback. 
+            try_files $uri @drupal;
         }
         {{- end }}
 

--- a/drupal/templates/drupal-ingress.yaml
+++ b/drupal/templates/drupal-ingress.yaml
@@ -6,8 +6,11 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
     acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- else }}
+    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}
@@ -100,8 +103,11 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- if ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
     acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- else }}
+    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.2.47
+version: 0.2.48
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/frontend/templates/certificate.yaml
+++ b/frontend/templates/certificate.yaml
@@ -6,6 +6,8 @@
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true" 
   labels:
     {{- include "frontend.release_labels" . | nindent 4 }}
 spec:
@@ -94,6 +96,8 @@ data:
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true" 
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
 spec:

--- a/frontend/templates/ingress.yaml
+++ b/frontend/templates/ingress.yaml
@@ -6,8 +6,11 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
     acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- else }}
+    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}
@@ -95,8 +98,11 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- if ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
     acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- else }}
+    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.17
+version: 0.2.18
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/certificate.yaml
+++ b/simple/templates/certificate.yaml
@@ -6,6 +6,8 @@
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true"
   labels:
     {{- include "simple.release_labels" . | nindent 4 }}
 spec:
@@ -70,6 +72,8 @@ data:
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true"
   labels:
     {{- include "simple.release_labels" $ | nindent 4 }}
 spec:

--- a/simple/templates/configmap.yaml
+++ b/simple/templates/configmap.yaml
@@ -164,3 +164,8 @@ data:
             location ~ /\. { return 404; access_log off; log_not_found off; }
         }                                                                                                                                                                                                                                                                                                                                     
     }
+
+{{- if .Values.nginx.extraConfig }}
+  extraConfig: |
+  {{ .Values.nginx.extraConfig | nindent 4 }}
+{{- end }}

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           readOnly: true
           subPath: simple_conf
         {{- if .Values.nginx.extraConfig }}
-        - name: config
+        - name: nginx-conf
           # provide empty configuration file in /etc/nginx/conf.d for users to populate
           mountPath: /etc/nginx/conf.d/misc.conf
           readOnly: true
@@ -67,6 +67,10 @@ spec:
                 path: nginx_conf
               - key: simple_conf
                 path: simple_conf
+              {{- if .Values.nginx.extraConfig }}
+              - key: extraConfig
+                path: extraConfig
+              {{- end }}
         {{- if .Values.nginx.basicauth.enabled }}
         - name: nginx-basicauth
           secret:

--- a/simple/templates/ingress.yaml
+++ b/simple/templates/ingress.yaml
@@ -6,8 +6,11 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
     acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- else }}
+    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}
@@ -75,8 +78,11 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- if ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
     acme.cert-manager.io/http01-edit-in-place: "true"
+    {{- else }}
+    certmanager.k8s.io/acme-http01-edit-in-place: "true"
+    {{- end }}
     {{- if eq $ingress.type "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}


### PR DESCRIPTION
- [Cert-Manger] Api agnostic edit-in-place annotation for ingress; 
- [Cert-Manger] allow issuing temporary certificates;
- FS sync workaround fix (avoid delaying image derivative generation)
- nginx.extraConfig fix (defines missing kubernetes resource templates)

