### PR TITLE
Drupal: backup retention; expose cache tag headers; cronjob entrypoints

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.93
+version: 0.3.94
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/backup-cron.yaml
+++ b/drupal/templates/backup-cron.yaml
@@ -32,7 +32,7 @@ spec:
             {{- include "drupal.php-container" . | nindent 12 }}
             volumeMounts:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
-              - name: {{ .Release.Name }}-backup
+              - name: {{ .Release.Name }}-backups
                 mountPath: /backups
             command: ["/bin/bash", "-c"]
             args:
@@ -40,7 +40,7 @@ spec:
                 {{ include "drupal.backup-command" (merge $params . ) | nindent 16 }}
                 {{ include "mariadb.db-validation" (merge $params . ) | nindent 16 }}
           - name: mariadb
-            image: docker.io/bitnami/mariadb:10.2
+            image: docker.io/bitnami/mariadb:10.3.24-debian-10-r49
             imagePullPolicy: IfNotPresent
             env:
             - name: MARIADB_ROOT_PASSWORD
@@ -51,13 +51,14 @@ spec:
             - containerPort: 3306
               name: mariadb
             resources:
-              {{- .Values.backup.resources | toYaml | nindent 14 }}
+              requests:
+                {{- .Values.backup.resources | toYaml | nindent 14 }}
           restartPolicy: Never
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}
-            - name: {{ .Release.Name }}-backup
+            - name: {{ .Release.Name }}-backups
               persistentVolumeClaim:
-                claimName: {{ .Release.Name }}-backup
+                claimName: {{ .Release.Name }}-backups
           {{- include "drupal.imagePullSecrets" . | nindent 10 }}
 {{- end }}
 

--- a/drupal/templates/backup-volume.yaml
+++ b/drupal/templates/backup-volume.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+  name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
   labels:
-    name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+    name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
   accessModes:
@@ -15,15 +15,15 @@ spec:
   {{- if .Values.backup.csiDriverName }}
   csi:
     driver: {{ .Values.backup.csiDriverName }}
-    volumeHandle: {{ .Release.Namespace }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+    volumeHandle: {{ .Release.Namespace }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
     volumeAttributes:
-      remotePathSuffix: /{{ .Release.Namespace }}/backup
+      remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/backups
   {{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Release.Name }}-backup
+  name: {{ .Release.Name }}-backups
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
@@ -36,6 +36,6 @@ spec:
 {{- if eq .Values.backup.storageClassName "silta-shared" }}
   selector:
     matchLabels:
-      name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+      name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backups
 {{- end }}
 {{- end }}

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -220,6 +220,13 @@ data:
     ## Hide the PHP X-Powered-By header.
     fastcgi_hide_header 'X-Powered-By';
 
+    {{- if and ( not .Values.nginx.expose_cache_headers ) ( not .Values.varnish.enabled ) }}
+    # Removing cache headers from backend response
+    fastcgi_hide_header 'Purge-Cache-Tags';
+    fastcgi_hide_header 'X-Drupal-Cache-Contexts';
+    fastcgi_hide_header 'X-Drupal-Cache-Tags';
+    {{- end }}
+    
     # Mitigate HTTPoxy
     # https://httpoxy.org/
     fastcgi_param HTTP_PROXY "";
@@ -280,8 +287,10 @@ data:
 
         {{ include "drupal.basicauth" . | indent 6}}
 
+        {{- if .Values.nginx.serverExtraConfig }}
         # Custom configuration gets included here
-        {{- .Values.nginx.serverExtraConfig | nindent 8 -}}
+        {{- .Values.nginx.serverExtraConfig | nindent 8 }}
+        {{- end }}
 
         {{- if .Values.mailhog.enabled }}
         location /mailhog {

--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -30,13 +30,14 @@ spec:
             command: ["/bin/bash", "-c"]
             args:
               - |
-                 set -ex
-                 if [ ! {{ include "drupal.installation-in-progress-test" $ }} ]
-                 then
-                  {{ $job.command | nindent 18 }}
-                 else
-                   exit 1
-                 fi
+                {{- include "cron.entrypoints" $ | nindent 16 }}
+                set -ex
+                if [ ! {{ include "drupal.installation-in-progress-test" $ }} ]
+                then
+                {{ $job.command | nindent 18 }}
+                else
+                  exit 1
+                fi
             resources:
               {{ if $job.resources }}
               {{- $job.resources | toYaml | nindent 14 }}

--- a/drupal/templates/shell-deployment.yaml
+++ b/drupal/templates/shell-deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: ssh-keys
           mountPath: /etc/ssh/keys
         {{- if .Values.backup.enabled }}
-        - name: {{ .Release.Name }}-backup
+        - name: {{ .Release.Name }}-backups
           mountPath: /backups
           readOnly: true
         {{- end }}
@@ -77,9 +77,9 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-ssh-keys
       {{- if .Values.backup.enabled }}
-      - name: {{ .Release.Name }}-backup
+      - name: {{ .Release.Name }}-backups
         persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-backup
+          claimName: {{ .Release.Name }}-backups
       {{- end }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 {{- end }}

--- a/drupal/templates/varnish-configmap-vcl.yaml
+++ b/drupal/templates/varnish-configmap-vcl.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 data:
-  default.vcl: |
+  default_vcl: |
     vcl 4.1;
 
     import std;
@@ -275,7 +275,7 @@ data:
       return (ok);
     }
 
-  vcl_recv.vcl: |
+  vcl_recv_vcl: |
     sub vcl_recv {
       # Called at the beginning of a request, after the complete request has been received and parsed.
       # Its purpose is to decide whether or not to serve the request, how to do it, and, if applicable,
@@ -456,7 +456,7 @@ data:
       return (hash);
     }
     
-  vcl_deliver.vcl: |
+  vcl_deliver_vcl: |
 
     # The routine when we deliver the HTTP request to the user
     # Last chance to modify headers that are sent to the client
@@ -505,15 +505,17 @@ data:
       unset resp.http.x-url;
       unset resp.http.x-host;
 
-      # Comment these for easier Drupal cache tag debugging in development.
+      {{- if not .Values.nginx.expose_cache_headers }} 
+      # Removing cache headers from final response
       unset resp.http.cache-tags;
       unset resp.http.X-Drupal-Cache-Tags;
       unset resp.http.X-Drupal-Cache-Contexts;
+      {{- end }}
 
       return (deliver);
     }
 
-  vcl_synth_500.vcl: |
+  vcl_synth_500_vcl: |
     set resp.http.Cache-Control = "no-cache, max-age: 0, must-revalidate";
     synthetic( {"
       {{- if .Values.varnish.status_500_html }}

--- a/drupal/templates/varnish-deployment.yaml
+++ b/drupal/templates/varnish-deployment.yaml
@@ -54,7 +54,7 @@ spec:
           readOnly: true
         - name: varnish-vcl
           mountPath: /etc/varnish/includes/vcl_deliver.vcl
-          subPath: vcl_deliver.vcl
+          subPath: vcl_deliver_vcl
           readOnly: true
         - name: varnish-vcl
           mountPath: /etc/varnish/includes/vcl_synth_500.vcl

--- a/drupal/tests/drupal_cache_tags_test.yaml
+++ b/drupal/tests/drupal_cache_tags_test.yaml
@@ -1,0 +1,50 @@
+suite: drupal cache tag exposure
+templates:
+  - varnish-configmap-vcl.yaml
+  - drupal-configmap.yaml
+tests:
+  - it: cache tag headers are removed when varnish is off and header exposing is off (nginx conf)
+    template: drupal-configmap.yaml
+    set:
+      nginx.expose_cache_headers: false
+      varnish.enabled: false
+    asserts:
+    - matchRegex:
+        path: data.drupal_conf
+        pattern: "fastcgi_hide_header 'Purge-Cache-Tags';"
+  - it: cache tag headers persist when varnish is off and header exposing is on (nginx conf)
+    template: drupal-configmap.yaml
+    set:
+      nginx.expose_cache_headers: true
+      varnish.enabled: false
+    asserts:
+    - notMatchRegex:
+        path: data.drupal_conf
+        pattern: "fastcgi_hide_header 'Purge-Cache-Tags';"
+  - it: cache tag headers persist when varnish is on and header exposing is off (nginx conf)
+    template: drupal-configmap.yaml
+    set:
+      nginx.expose_cache_headers: false
+      varnish.enabled: true
+    asserts:
+    - notMatchRegex:
+        path: data.drupal_conf
+        pattern: "fastcgi_hide_header 'Purge-Cache-Tags';"
+  - it: cache tag headers are removed when varnish is on and header exposing is off (varnish vcl)
+    template: varnish-configmap-vcl.yaml
+    set:
+      nginx.expose_cache_headers: false
+      varnish.enabled: true
+    asserts:
+    - matchRegex:
+        path: data.vcl_deliver_vcl
+        pattern: "unset resp.http.X-Drupal-Cache-Tags;"
+  - it: cache tag headers persist when varnish is on and header exposing is on (varnish vcl)
+    template: varnish-configmap-vcl.yaml
+    set:
+      nginx.expose_cache_headers: true
+      varnish.enabled: true
+    asserts:
+    - notMatchRegex:
+        path: data.vcl_deliver_vcl
+        pattern: "unset resp.http.X-Drupal-Cache-Tags;"

--- a/drupal/tests/shell_deployment_test.yaml
+++ b/drupal/tests/shell_deployment_test.yaml
@@ -57,7 +57,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /backups
-            name: RELEASE-NAME-backup
+            name: RELEASE-NAME-backups
             readOnly: true
 
   - it: does not mount backups volume when backups are disabled
@@ -70,6 +70,6 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /backups
-            name: RELEASE-NAME-backup
+            name: RELEASE-NAME-backups
             readOnly: true
 

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -151,6 +151,9 @@ nginx:
   # Header containing real IP address
   real_ip_header: X-Forwarded-For
 
+  # Expose drupal cache tag headers
+  expose_cache_headers: false
+
   # Trust X-Forwarded-For from these hosts for getting external IP
   realipfrom: 10.0.0.0/8
 
@@ -420,8 +423,6 @@ backup:
   resources:
     requests:
       cpu: 1000m
-      memory: 512M
-    limits:
       memory: 512M
 
 # Override the default values of the MariaDB subchart.


### PR DESCRIPTION
Drupal chart changes:
- Backup retention refactor
- Backups location (in storage backend) changed.
- Trigger entrypoints for cronjobs (fixes lacking crojob smtp credential issue)
- Nginx remove / expose Drupal cache tag headers. Requires `nginx.expose_cache_headers: true` to keep exposing cache tags.

