### PR TITLE
rwx enabled mount for jumpserver

### DIFF
--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.13
+version: 0.2.14
 dependencies:
 - name: traefik
   version: 1.87.x

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -30,7 +30,7 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-jumpserver
 spec:
-  replicas: 1
+  replicas: {{ .Values.gitAuth.replicas }}
   selector:
     matchLabels:
       name: {{ .Release.Name }}-jumpserver
@@ -66,7 +66,6 @@ spec:
       - name: shell-keys
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-shell-keys
-
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -75,11 +74,37 @@ metadata:
   labels:
     name: {{ .Release.Name }}-jumpserver
 spec:
-  storageClassName: standard
+  storageClassName: {{ .Values.gitAuth.store.storageClassName }}
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.gitAuth.store.accessMode }}
   resources:
     requests:
-      storage: 50M
-
+      storage: {{ .Values.gitAuth.store.size }}
+  selector:
+    matchLabels:
+      name: {{ $.Release.Name }}-shell-keys-pv
+{{- end }}
+# silta-shared volume definition if its storage is selected
+{{- if eq .Values.gitAuth.store.storageClassName "silta-shared" }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ $.Release.Name }}-shell-keys-pv
+  labels:
+    name: {{ $.Release.Name }}-shell-keys-pv
+spec:
+  accessModes:
+    - {{ .Values.gitAuth.store.accessMode }}
+  capacity:
+    storage: {{ .Values.gitAuth.store.size }}
+  storageClassName: {{ .Values.gitAuth.store.storageClassName }}
+  {{- if .Values.gitAuth.store.csiDriverName }}
+  csi:
+    driver: {{ .Values.gitAuth.store.csiDriverName }}
+    volumeHandle: {{ $.Release.Name }}-shell-keys-pv
+    volumeAttributes:
+      remotePathSuffix: /{{ $.Release.Namespace }}/jumpserver
+      umask: "077"
+  {{- end }}
 {{- end }}

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -74,18 +74,21 @@ metadata:
   labels:
     name: {{ .Release.Name }}-jumpserver
 spec:
-  storageClassName: {{ .Values.gitAuth.store.storageClassName }}
+  {{- if .Values.gitAuth.persistence.storageClassName }}
+  storageClassName: {{ .Values.gitAuth.persistence.storageClassName }}
+  {{- end }}
   accessModes:
-    - {{ .Values.gitAuth.store.accessMode }}
+    - {{ .Values.gitAuth.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.gitAuth.store.size }}
+      storage: {{ .Values.gitAuth.persistence.size }}
   selector:
     matchLabels:
       name: {{ $.Release.Name }}-shell-keys-pv
 {{- end }}
 # silta-shared volume definition if its storage is selected
-{{- if eq .Values.gitAuth.store.storageClassName "silta-shared" }}
+{{- if .Values.gitAuth.persistence.storageClassName }}
+{{- if eq .Values.gitAuth.persistence.storageClassName "silta-shared" }}
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -95,16 +98,17 @@ metadata:
     name: {{ $.Release.Name }}-shell-keys-pv
 spec:
   accessModes:
-    - {{ .Values.gitAuth.store.accessMode }}
+    - {{ .Values.gitAuth.persistence.accessMode }}
   capacity:
-    storage: {{ .Values.gitAuth.store.size }}
-  storageClassName: {{ .Values.gitAuth.store.storageClassName }}
-  {{- if .Values.gitAuth.store.csiDriverName }}
+    storage: {{ .Values.gitAuth.persistence.size }}
+  storageClassName: {{ .Values.gitAuth.persistence.storageClassName }}
+  {{- if .Values.gitAuth.persistence.csiDriverName }}
   csi:
-    driver: {{ .Values.gitAuth.store.csiDriverName }}
+    driver: {{ .Values.gitAuth.persistence.csiDriverName }}
     volumeHandle: {{ $.Release.Name }}-shell-keys-pv
     volumeAttributes:
       remotePathSuffix: /{{ $.Release.Namespace }}/jumpserver
       umask: "077"
   {{- end }}
+{{- end }}
 {{- end }}

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -88,6 +88,11 @@ gitAuth:
   scope: ''
   outsideCollaborators: true
   allowedIps: []
+  replicas: 1
+  store:
+    storageClassName: standard
+    accessMode: ReadWriteOnce
+    size: 50M
   # Kubernetes resource allocation.
   resources: {}
   # The static IP to be used for the exposed endpoint.

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -90,7 +90,7 @@ gitAuth:
   allowedIps: []
   replicas: 1
   persistence:
-    storageClassName: null
+    # storageClassName: silta-shared
     accessMode: ReadWriteOnce
     size: 50M
   # Kubernetes resource allocation.

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -89,8 +89,8 @@ gitAuth:
   outsideCollaborators: true
   allowedIps: []
   replicas: 1
-  store:
-    storageClassName: standard
+  persistence:
+    storageClassName: null
     accessMode: ReadWriteOnce
     size: 50M
   # Kubernetes resource allocation.


### PR DESCRIPTION
Allows to change replica count for jumpserver,ssh-keyserver.
Exposes storage options to allow for custom storage mounts.