### PR TITLE
Feature/release 20210923

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: drupal
-version: 0.3.99
+version: 0.3.100
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -478,9 +478,17 @@ fi
 
 {{- define "cert-manager.api-version" }}
 {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
-apiVersion: cert-manager.io/v1
+cert-manager.io/v1
 {{- else }}
-apiVersion: certmanager.k8s.io/v1alpha1
+certmanager.k8s.io/v1alpha1
+{{- end }}
+{{- end }}
+
+{{- define "ingress.api-version" }}
+{{- if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
+networking.k8s.io/v1
+{{- else }}
+networking.k8s.io/v1beta1
 {{- end }}
 {{- end }}
 

--- a/drupal/templates/drupal-backendconfig.yaml
+++ b/drupal/templates/drupal-backendconfig.yaml
@@ -1,12 +1,10 @@
-{{- if eq .Values.cluster.type "gke" }}
+{{- if and (eq .Values.cluster.type "gke") (.Values.backendConfig) }}
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Release.Name }}-drupal
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
-{{ if .Values.backendConfig }} 
 spec:
   {{- toYaml .Values.backendConfig | nindent 2 }}
-{{- end }}
 {{- end }}

--- a/drupal/templates/drupal-certificate.yaml
+++ b/drupal/templates/drupal-certificate.yaml
@@ -2,12 +2,13 @@
 {{- $context_ssl := .Values.ssl }}
 {{- if $context_ingress.tls }}
 {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
   annotations:
     cert-manager.io/issue-temporary-certificate: "true" 
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal"
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:
@@ -17,7 +18,7 @@ spec:
   issuerRef:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -27,10 +28,13 @@ spec:
 {{- end }}
 ---
 {{- range $index, $prefix := .Values.domainPrefixes }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-p{{ $index }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true" 
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal"
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
@@ -40,7 +44,7 @@ spec:
   issuerRef:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -52,7 +56,7 @@ spec:
 {{- end }}
 
 {{- else if eq $context_ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" . }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
@@ -93,12 +97,13 @@ data:
 {{- if $domain.ssl }}
 {{- if $domain.ssl.enabled }}
 {{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
   annotations:
-    cert-manager.io/issue-temporary-certificate: "true" 
+    cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-drupal-{{ $domain.ingress }}"
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 spec:
@@ -108,7 +113,7 @@ spec:
   issuerRef:
     name: {{ $domain.ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -119,7 +124,7 @@ spec:
 ---
 
 {{- else if eq $domain.ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}

--- a/drupal/templates/drupal-ingress.yaml
+++ b/drupal/templates/drupal-ingress.yaml
@@ -1,12 +1,12 @@
 {{- $ingress := .Values.ingress.default }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-drupal
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
@@ -67,16 +67,30 @@ spec:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ include "drupal.servicename" . }}
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ include "drupal.servicename" . }}
           servicePort: 80
+          {{- end }}
 {{- range $index, $prefix := .Values.domainPrefixes }}
   - host: '{{ $prefix }}.{{ template "drupal.domain" $ }}'
     http:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ include "drupal.servicename" $ }}
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ include "drupal.servicename" $ }}
           servicePort: 80
+          {{- end }}
 {{- end }}
 ---
 
@@ -96,14 +110,14 @@ spec:
 {{- end }}
 
 {{- if $ingress_in_use }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" $ | trim }}
 kind: Ingress
 metadata:
   name: {{ $.Release.Name }}-drupal-{{ $ingress_index }}
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
@@ -165,8 +179,15 @@ spec:
       paths:
       - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
         backend:
+          {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ include "drupal.servicename" $ }}
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ include "drupal.servicename" $ }}
           servicePort: 80
+          {{- end }}
   {{- end }}
   {{- end }}
 ---

--- a/drupal/tests/drupal_ingress_test.yaml
+++ b/drupal/tests/drupal_ingress_test.yaml
@@ -36,21 +36,83 @@ tests:
           path: spec.rules[0].host
           value: 'foo.namespace.baz'
 
-  - it: directs traefik requests to drupal service by default
+  - it: directs traefik requests to drupal service by default (cm 0.8)
     template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+      apiVersions:
+        - certmanager.k8s.io/v1alpha1
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.serviceName
           value: 'RELEASE-NAME-drupal'
 
-  - it: directs traefik requests to varnish service when varnish is enabled
+  - it: directs traefik requests to drupal service by default (cm 1.4+)
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+      apiVersions:
+        - cert-manager.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: 'RELEASE-NAME-drupal'
+  
+  - it: directs traefik requests to varnish service when varnish is enabled (cm 0.8)
     template: drupal-ingress.yaml
     set:
       varnish.enabled: true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+      apiVersions:
+        - certmanager.k8s.io/v1alpha1
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.serviceName
           value: 'RELEASE-NAME-varnish'
+
+  - it: directs traefik requests to varnish service when varnish is enabled (cm 1.4+)
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+      apiVersions:
+        - cert-manager.io/v1
+    set:
+      varnish.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: 'RELEASE-NAME-varnish'
+
+  - it: uses correct ingress api version (1.17)
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1beta1'
+
+  - it: uses correct ingress api version (1.18+)
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1'
+
+
+
+
+
+
 
   - it: shortens long project names
     template: drupal-ingress.yaml

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: frontend
-version: 0.2.50
+version: 0.2.51
 apiVersion: v2
 dependencies:
 - name: mariadb

--- a/frontend/templates/_helpers.tpl
+++ b/frontend/templates/_helpers.tpl
@@ -136,9 +136,16 @@ rsync -az /values_mounts/ /backups/current/
 
 {{- define "cert-manager.api-version" }}
 {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
-apiVersion: cert-manager.io/v1
+cert-manager.io/v1
 {{- else }}
-apiVersion: certmanager.k8s.io/v1alpha1
+certmanager.k8s.io/v1alpha1
 {{- end }}
 {{- end }}
 
+{{- define "ingress.api-version" }}
+{{- if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
+networking.k8s.io/v1
+{{- else }}
+networking.k8s.io/v1beta1
+{{- end }}
+{{- end }}

--- a/frontend/templates/backendconfig.yaml
+++ b/frontend/templates/backendconfig.yaml
@@ -1,12 +1,10 @@
-{{- if eq .Values.cluster.type "gke" }}
+{{- if and (eq .Values.cluster.type "gke") (.Values.backendConfig) }}
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
   name: {{ .Release.Name }}-nginx
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
-{{ if .Values.backendConfig }} 
 spec:
   {{- toYaml .Values.backendConfig | nindent 2 }}
-{{- end }}
 {{- end }}

--- a/frontend/templates/certificate.yaml
+++ b/frontend/templates/certificate.yaml
@@ -2,12 +2,13 @@
 {{- $context_ssl := .Values.ssl }}
 {{- if $context_ingress.tls }}
 {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" . }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
   annotations:
-    cert-manager.io/issue-temporary-certificate: "true" 
+    cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-nginx"
   labels:
     {{- include "frontend.release_labels" . | nindent 4 }}
 spec:
@@ -17,7 +18,7 @@ spec:
   issuerRef:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -27,10 +28,13 @@ spec:
 {{- end }}
 ---
 {{- range $index, $prefix := .Values.domainPrefixes }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-p{{ $index }}
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true" 
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-nginx"
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
 spec:
@@ -40,7 +44,7 @@ spec:
   issuerRef:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -52,7 +56,7 @@ spec:
 {{- end }}
 
 {{- else if eq $context_ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" . }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
@@ -92,12 +96,13 @@ data:
 {{- if $domain.ssl }}
 {{- if $domain.ssl.enabled }}
 {{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
   annotations:
-    cert-manager.io/issue-temporary-certificate: "true" 
+    cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-nginx-{{ $domain.ingress }}"
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
 spec:
@@ -107,7 +112,7 @@ spec:
   issuerRef:
     name: {{ $domain.ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -118,7 +123,7 @@ spec:
 ---
 
 {{- else if eq $domain.ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}

--- a/frontend/templates/configmap.yaml
+++ b/frontend/templates/configmap.yaml
@@ -18,8 +18,17 @@ data:
     }                                                                                      
                                                                                           
     http {
-
+        
+        # List of upstream proxies we trust to set X-Forwarded-For correctly.
+        {{- if kindIs "string" .Values.nginx.realipfrom }}
         set_real_ip_from            {{ .Values.nginx.realipfrom }};
+        {{- end }}
+        {{- if kindIs "map" .Values.nginx.realipfrom }}
+        {{- range .Values.nginx.realipfrom }}
+        set_real_ip_from            {{ . }};
+        {{- end }}
+        {{- end }}
+
         real_ip_header              {{ .Values.nginx.real_ip_header }};
 
         include                     /etc/nginx/mime.types;                                 
@@ -63,6 +72,15 @@ data:
 
         map_hash_bucket_size 128;
 
+        map $http_host $x_robots_tag_header {
+            "~{{ template "frontend.domain" $ }}$" "noindex, nofollow, nosnippet, noarchive";
+            {{- range $index, $prefix := .Values.domainPrefixes }}
+            "~{{$prefix}}.{{ template "frontend.domain" $ }}$" "noindex, nofollow, nosnippet, noarchive";
+            {{- end }}
+            default  '';
+        }
+        add_header                  X-Robots-Tag $x_robots_tag_header;
+
         map $uri $no_slash_uri {                                                                                                                           
             ~^/(?<no_slash>.*)$ $no_slash;                                                                                                                 
         }
@@ -97,8 +115,8 @@ data:
         {{- end }}
         {{- end }}
     }
-    {{- end }}                                      
-                                          
+    {{- end }}
+
     server {                               
         server_name frontend;
         listen 80;
@@ -141,11 +159,7 @@ data:
           
           location = {{ $service.exposedRoute }}/robots.txt {
             access_log off;
-            {{- if not $.Values.nginx.robotsTxt.allow }}
-              add_header Content-Type text/plain;
-              return 200 'User-agent: *\nDisallow: /';
-            {{- end}}
-          } 
+          }
 
           ## Most sites won't have configured favicon
           ## and since its always grabbed, turn it off in access log

--- a/frontend/templates/ingress.yaml
+++ b/frontend/templates/ingress.yaml
@@ -1,12 +1,12 @@
 {{- $ingress := .Values.ingress.default }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-nginx
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" . | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
@@ -63,16 +63,30 @@ spec:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Release.Name }}-nginx
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ .Release.Name }}-nginx
           servicePort: 80
+          {{- end }}
 {{- range $index, $prefix := .Values.domainPrefixes }}
   - host: {{ $prefix }}.{{ template "frontend.domain" $ }}
     http:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ $.Release.Name }}-nginx
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ $.Release.Name }}-nginx
           servicePort: 80
+          {{- end }}
 {{- end }}
 ---
 # Ingresses for exposeDomains 
@@ -91,14 +105,14 @@ spec:
 {{- end }}
 
 {{- if $ingress_in_use }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" $ | trim }}
 kind: Ingress
 metadata:
   name: {{ $.Release.Name }}-nginx-{{ $ingress_index }}
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
@@ -158,8 +172,15 @@ spec:
       paths:
       - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
         backend:
+          {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ $.Release.Name }}-nginx
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ $.Release.Name }}-nginx
           servicePort: 80
+          {{- end }}
   {{- end }}
   {{- end }}
 ---

--- a/frontend/tests/configmap_test.yaml
+++ b/frontend/tests/configmap_test.yaml
@@ -33,3 +33,28 @@ tests:
       matchRegex:
         path: data.frontend_conf
         pattern: 'auth_basic "Restricted";'
+
+  - it: tests realipfrom nginx configuration (legacy string value)
+    template: configmap.yaml
+    set:
+      nginx:
+        realipfrom: '1.2.3.4'
+    asserts:
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'set_real_ip_from *1.2.3.4'
+ 
+  - it: tests realipfrom nginx configuration (multivalue object)
+    template: configmap.yaml
+    set:
+      nginx:
+        realipfrom: 
+          foo: '1.1.1.1'
+          bar: '2.2.2.2'
+    asserts:
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'set_real_ip_from *1.1.1.1'
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'set_real_ip_from *2.2.2.2'

--- a/frontend/tests/ingress_test.yaml
+++ b/frontend/tests/ingress_test.yaml
@@ -36,12 +36,49 @@ tests:
           path: spec.rules[0].host
           value: 'foo.namespace.baz'
 
-  - it: directs traefik requests to nginx service by default
+  - it: directs traefik requests to nginx service by default (cm 0.8)
     template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+      apiVersions:
+        - certmanager.k8s.io/v1alpha1
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.serviceName
           value: 'RELEASE-NAME-nginx'
+
+  - it: directs traefik requests to nginx service by default (cm 1.4+)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+      apiVersions:
+        - cert-manager.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: 'RELEASE-NAME-nginx'
+  
+  - it: uses correct ingress api version (1.17)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1beta1'
+
+  - it: uses correct ingress api version (1.18+)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1'
 
   - it: shortens long project names
     template: ingress.yaml

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -122,8 +122,11 @@ nginx:
   # Header containing real IP address
   real_ip_header: X-Forwarded-For
 
-  # Trust X-Forwarded-For from these hosts for getting external IP 
-  realipfrom: 10.0.0.0/8
+  # Trust X-Forwarded-For from these hosts for getting external IP
+  realipfrom: 
+    gke-internal: 10.0.0.0/8
+    gce-health-check-1: 130.211.0.0/22
+    gce-health-check-2: 35.191.0.0/16
 
   # Add IP addresses that should be excluded from basicauth.
   # Note that the key is only used for documentation purposes.
@@ -140,10 +143,6 @@ nginx:
       username: silta
       password: demo
 
-  # Robots txt file blocked by default
-  robotsTxt:
-    allow: false
- 
   # Security headers
   # includeSubdomains should be used whenever possible, but before enabling it needs to be made sure there are no subdomains not using https:
   hsts_include_subdomains: ""

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.19
+version: 0.2.20
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/_helpers.tpl
+++ b/simple/templates/_helpers.tpl
@@ -24,8 +24,15 @@ release: {{ .Release.Name }}
   {{- if .Values.nginx.basicauth.enabled }}
   satisfy any;
   allow 127.0.0.1;
+  {{- if .Values.nginx.basicauth.noauthips }}
   {{- range .Values.nginx.basicauth.noauthips }}
   allow {{ . }};
+  {{- end }}
+  {{- end }}
+  {{- if .Values.nginx.noauthips }}
+  {{- range .Values.nginx.noauthips }}
+  allow {{ . }};
+  {{- end }}
   {{- end }}
   deny all;
 
@@ -36,8 +43,16 @@ release: {{ .Release.Name }}
 
 {{- define "cert-manager.api-version" }}
 {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
-apiVersion: cert-manager.io/v1
+cert-manager.io/v1
 {{- else }}
-apiVersion: certmanager.k8s.io/v1alpha1
+certmanager.k8s.io/v1alpha1
+{{- end }}
+{{- end }}
+
+{{- define "ingress.api-version" }}
+{{- if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
+networking.k8s.io/v1
+{{- else }}
+networking.k8s.io/v1beta1
 {{- end }}
 {{- end }}

--- a/simple/templates/backendconfig.yaml
+++ b/simple/templates/backendconfig.yaml
@@ -1,12 +1,10 @@
-{{- if eq .Values.cluster.type "gke" }}
-apiVersion: cloud.google.com/v1
+{{- if and (eq .Values.cluster.type "gke") (.Values.backendConfig) }}
+apiVersion: cloud.google.com/v1beta1
 kind: BackendConfig
 metadata:
   name: {{ .Release.Name }}-simple
   labels:
     {{- include "simple.release_labels" $ | nindent 4 }}
-{{ if .Values.backendConfig }} 
 spec:
   {{- toYaml .Values.backendConfig | nindent 2 }}
-{{- end }}
 {{- end }}

--- a/simple/templates/certificate.yaml
+++ b/simple/templates/certificate.yaml
@@ -2,12 +2,13 @@
 {{- $context_ssl := .Values.ssl }}
 {{- if $context_ingress.tls }}
 {{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" . }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
   annotations:
     cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ .Release.Name }}-simple"
   labels:
     {{- include "simple.release_labels" . | nindent 4 }}
 spec:
@@ -17,7 +18,7 @@ spec:
   issuerRef:
     name: {{ $context_ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -28,7 +29,7 @@ spec:
 ---
 
 {{- else if eq $context_ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" . }}
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-crt
@@ -68,12 +69,13 @@ data:
 {{- if $domain.ssl }}
 {{- if $domain.ssl.enabled }}
 {{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}
   annotations:
     cert-manager.io/issue-temporary-certificate: "true"
+    acme.cert-manager.io/http01-override-ingress-name: "{{ $.Release.Name }}-simple-{{ $domain.ingress }}"
   labels:
     {{- include "simple.release_labels" $ | nindent 4 }}
 spec:
@@ -83,7 +85,7 @@ spec:
   issuerRef:
     name: {{ $domain.ssl.issuer }}
     kind: ClusterIssuer
-{{- if not ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+{{- if eq ( include "cert-manager.api-version" $ | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:
@@ -94,7 +96,7 @@ spec:
 ---
 
 {{- else if eq $domain.ssl.issuer "selfsigned" }}
-{{- include "cert-manager.api-version" $ }}
+apiVersion: {{ include "cert-manager.api-version" $ | trim }}
 kind: Certificate
 metadata:
   name: {{ $.Release.Name }}-crt-{{ $index }}

--- a/simple/templates/configmap.yaml
+++ b/simple/templates/configmap.yaml
@@ -19,8 +19,22 @@ data:
                                                                                           
     http {
 
-        set_real_ip_from                {{ .Values.nginx.basicauth.realipfrom }};
-        real_ip_header                  {{ .Values.nginx.real_ip_header }};
+        # List of upstream proxies we trust to set X-Forwarded-For correctly.
+        {{- if kindIs "string" .Values.nginx.realipfrom }}
+        set_real_ip_from            {{ .Values.nginx.realipfrom }};
+        {{- end }}
+        {{- if kindIs "map" .Values.nginx.realipfrom }}
+        {{- range .Values.nginx.realipfrom }}
+        set_real_ip_from            {{ . }};
+        {{- end }}
+        {{- end }}
+
+        {{ if .Values.nginx.basicauth.realipfrom }}
+        # This will be depreciated, migrate this setting to nginx.realipfrom
+        set_real_ip_from            {{ .Values.nginx.basicauth.realipfrom }};
+        {{- end }}
+
+        real_ip_header              {{ .Values.nginx.real_ip_header }};
 
         include                     /etc/nginx/mime.types;                                 
         default_type                application/octet-stream;                              
@@ -70,6 +84,12 @@ data:
         add_header                  Referrer-Policy "no-referrer, strict-origin-when-cross-origin" always;
 
         map_hash_bucket_size        128;
+
+        map $http_host $x_robots_tag_header {
+            "~{{ template "simple.domain" $ }}$" "noindex, nofollow, nosnippet, noarchive";
+            default  '';
+        }
+        add_header                  X-Robots-Tag $x_robots_tag_header;
 
         map $uri $no_slash_uri {                                                                                                                           
             ~^/(?<no_slash>.*)$ $no_slash;                                                                                                                 
@@ -136,12 +156,8 @@ data:
         {{ include "simple.basicauth" . | indent 6}}
 
         location = /robots.txt {
-          access_log off;
-          {{- if not .Values.nginx.robotsTxt.allow }}
-            add_header Content-Type text/plain;
-            return 200 'User-agent: *\nDisallow: /';
-          {{- end}}
-        } 
+            access_log off;
+        }
 
         location / {
 

--- a/simple/templates/ingress.yaml
+++ b/simple/templates/ingress.yaml
@@ -1,12 +1,12 @@
 {{- $ingress := .Values.ingress.default }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-simple
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" . | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
@@ -53,8 +53,15 @@ spec:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Release.Name }}-simple
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ .Release.Name }}-simple
           servicePort: 80
+          {{- end }}
 ---
 # Ingresses for exposeDomains 
 {{- range $ingress_index, $ingress := $.Values.ingress }}
@@ -71,14 +78,14 @@ spec:
 {{- end }}
 
 {{- if $ingress_in_use }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" $ | trim }}
 kind: Ingress
 metadata:
   name: {{ $.Release.Name }}-simple-{{ $ingress_index }}
   annotations:
     kubernetes.io/ingress.class: {{ $ingress.type | quote }}
     {{- if $ingress.tls }}
-    {{- if ( $.Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+    {{- if eq ( include "cert-manager.api-version" $ | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
@@ -137,8 +144,15 @@ spec:
       paths:
       - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
         backend:
+          {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ $.Release.Name }}-simple
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ $.Release.Name }}-simple
           servicePort: 80
+          {{- end }}
   {{- end }}
   {{- end }}
 ---

--- a/simple/tests/ingress_test.yaml
+++ b/simple/tests/ingress_test.yaml
@@ -32,11 +32,49 @@ tests:
           path: spec.rules[0].host
           value: 'foo.namespace.baz'
 
-  - it: directs traefik requests to simple service by default
+  - it: directs traefik requests to simple service by default (cm 0.8)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+      apiVersions:
+        - certmanager.k8s.io/v1alpha1
     asserts:
       - equal:
           path: spec.rules[0].http.paths[0].backend.serviceName
           value: 'RELEASE-NAME-simple'
+
+  - it: directs traefik requests to simple service by default (cm 1.4+)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+      apiVersions:
+        - cert-manager.io/v1
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: 'RELEASE-NAME-simple'
+  
+  - it: uses correct ingress api version (1.17)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1beta1'
+
+  - it: uses correct ingress api version (1.18+)
+    template: ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    asserts:
+      - equal:
+          path: apiVersion
+          value: 'networking.k8s.io/v1'
 
   - it: shortens long project names
     set:
@@ -177,3 +215,29 @@ tests:
         equal:
           path: 'metadata.annotations.kubernetes\.io\/ingress\.global-static-ip-name'
           value: 'baz'
+
+
+  - it: tests realipfrom nginx configuration (legacy string value)
+    template: configmap.yaml
+    set:
+      nginx:
+        realipfrom: '1.2.3.4'
+    asserts:
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'set_real_ip_from *1.2.3.4'
+ 
+  - it: tests realipfrom nginx configuration (multivalue object)
+    template: configmap.yaml
+    set:
+      nginx:
+        realipfrom: 
+          foo: '1.1.1.1'
+          bar: '2.2.2.2'
+    asserts:
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'set_real_ip_from *1.1.1.1'
+    - matchRegex:
+        path: data.nginx_conf
+        pattern: 'set_real_ip_from *2.2.2.2'

--- a/simple/values.schema.json
+++ b/simple/values.schema.json
@@ -21,7 +21,42 @@
         "vpcNative": { "type": "boolean"}
       }
     },
-    "nginx": { "type": "object" },
+    "nginx": { 
+      "type": "object",
+      "properties": {
+        "image": { "type": "string"},
+        "basicauth": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean"},
+            "credentials": {
+              "type": "object",
+              "properties": {
+                "username": { "type": "string"},
+                "password": { "type": "string"}
+              }
+            },
+            "realipfrom": {
+              "type": ["string"],
+              "deprecated": true
+            },
+            "noauthips": {
+              "type": ["object"],
+              "deprecated": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "realipfrom": {
+          "type": ["string", "object"],
+          "additionalProperties": { "type": "string"}
+        },
+        "noauthips": {
+          "type": "object",
+          "additionalProperties": { "type": "string"}
+        }
+      }
+    },
     "silta-release": {
       "type": "object"
     }

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -127,18 +127,26 @@ nginx:
       password: demo
 
     # Trust X-Forwarded-For from these hosts for getting external IP 
-    realipfrom: 10.0.0.0/8
+    # This will be deprecated soon in favor of nginx.realipfrom 
+    # realipfrom: 10.0.0.0/8
 
     # Add IP addresses that should be excluded from basicauth
-    noauthips:
-      gke-internal: 10.0.0.0/8
+    # This will be deprecated soon in favor of nginx.noauthips 
+    # noauthips:
+    #   gke-internal: 10.0.0.0/8
+  
+  # Trust X-Forwarded-For from these hosts for getting external IP
+  realipfrom: 
+    gke-internal: 10.0.0.0/8
+    gce-health-check-1: 130.211.0.0/22
+    gce-health-check-2: 35.191.0.0/16
+
+  # Add IP addresses that should be excluded from basicauth
+  noauthips:
+    gke-internal: 10.0.0.0/8
 
   # Header containing real IP address
   real_ip_header: X-Forwarded-For
-
-  # Robots txt file blocked by default
-  robotsTxt:
-    allow: false
 
   # Security headers
   # includeSubdomains should be used whenever possible, but before enabling it needs to be made sure there are no subdomains not using https:


### PR DESCRIPTION
Drupal chart:
- Uses Ingress API v1 when kubernetes version is above 1.18
- Optional backendconfig (resource does not get created when undefined)
- Ingress pointer in certificate resource
- Unifies certificate apiVersion conditionals

Frontend chart:
- Uses Ingress API v1 when kubernetes version is above 1.18
- Optional backendconfig (resource does not get created when undefined)
- Ingress pointer in certificate resource
- Unifies certificate apiVersion conditionals
- Multivalue nginx.realipfrom support
- X-Robots-Tag nofollow for builtin (non-exposeDomains) domains.

Simple chart:
- Uses Ingress API v1 when kubernetes version is above 1.18
- Optional backendconfig (resource does not get created when undefined)
- Ingress pointer in certificate resource
- Unifies certificate apiVersion conditionals
- Multivalue nginx.realipfrom support
- X-Robots-Tag nofollow for builtin (non-exposeDomains) domains.