### PR TITLE
Downscaler: ingress api, cert api, cert to ingress link

### DIFF
--- a/silta-downscaler/templates/_helpers.tpl
+++ b/silta-downscaler/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{- define "cert-manager.api-version" }}
+{{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
+cert-manager.io/v1
+{{- else }}
+certmanager.k8s.io/v1alpha1
+{{- end }}
+{{- end }}
+
+{{- define "ingress.api-version" }}
+{{- if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
+networking.k8s.io/v1
+{{- else }}
+networking.k8s.io/v1beta1
+{{- end }}
+{{- end }}
+

--- a/silta-downscaler/templates/placeholder-upscaler.yaml
+++ b/silta-downscaler/templates/placeholder-upscaler.yaml
@@ -55,7 +55,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "ingress.api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-placeholder-upscaler
@@ -77,15 +77,25 @@ spec:
       paths:
       - path: /
         backend:
+          {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Release.Name }}-placeholder-upscaler
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ .Release.Name }}-placeholder-upscaler
           servicePort: 80
+          {{- end }}
 ---
 {{- if .Values.ssl.enabled }}
 {{- if has .Values.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: {{ include "cert-manager.api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-placeholder-upscaler
+  annotations:
+    cert-manager.io/issue-temporary-certificate: "true" 
+    acme.cert-manager.io/http01-override-ingress-name: "{{ .Release.Name }}-placeholder-upscaler"
   labels:
     release: {{ .Release.Name }}
     deployment: placeholder-upscaler


### PR DESCRIPTION
- Uses Ingress API v1 when kubernetes version is above 1.18
- Ingress pointer in certificate resource
- certificate apiVersion conditional