### PR TITLE
Drupal: Varnish 6.6 and slight configuration changes

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.103
+version: 0.3.104
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/varnish-configmap-vcl.yaml
+++ b/drupal/templates/varnish-configmap-vcl.yaml
@@ -126,7 +126,7 @@ data:
                 return (deliver);
             } else {
                 # No candidate for grace. Fetch a fresh object.
-                return(miss);
+                return (restart);
             }
         } else {
             # backend is sick - use full grace
@@ -135,7 +135,7 @@ data:
                 return (deliver);
             } else {
                 # no graced object.
-                return (miss);
+                return (restart);
             }
         }
     }
@@ -288,6 +288,11 @@ data:
       # Its purpose is to decide whether or not to serve the request, how to do it, and, if applicable,
       # which backend to use.
       # also used to modify the request
+
+      # Fixes "Too many restarts" error
+      if (req.restarts > 0) { 
+        set req.hash_always_miss = true; 
+      }
 
       # Pipe connections with x-pipe-request (used for larger file downloads)
       if (req.http.x-pipe-request && req.restarts > 0) {
@@ -518,6 +523,7 @@ data:
       {{- if not .Values.nginx.expose_cache_headers }} 
       # Removing cache headers from final response
       unset resp.http.cache-tags;
+      unset resp.http.purge-cache-tags;
       unset resp.http.X-Drupal-Cache-Tags;
       unset resp.http.X-Drupal-Cache-Contexts;
       {{- end }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -469,10 +469,10 @@ varnish:
       cpu: 25m
       memory: 32Mi
   image: eu.gcr.io/silta-images/varnish
-  imageTag: 6-v0.1
-  # https://varnish-cache.org/docs/6.0/users-guide/storage-backends.html
+  imageTag: 6-v0.2
+  # https://varnish-cache.org/docs/6.6/users-guide/storage-backends.html
   storageBackend: 'file,/var/lib/varnish/varnish_storage.bin,512M'
-  # https://varnish-cache.org/docs/6.0/reference/varnishd.html#list-of-parameters
+  # https://varnish-cache.org/docs/6.6/reference/varnishd.html#list-of-parameters
   extraParams: ""
   # Inject custom code into vcl_recv subroutine.
   vcl_recv_extra: ""
@@ -482,7 +482,7 @@ varnish:
   vcl_extra_cookies: ""
   # Do not cache files larger than 3 megabytes (use integers).
   cache_skip_size: 3
-  # https://varnish-cache.org/docs/6.0/reference/vcl.html#backend-definition
+  # https://varnish-cache.org/docs/6.6/reference/vcl.html#backends-and-health-probes
   backend_config: |
     .max_connections = 300;
     .probe = {


### PR DESCRIPTION
- Varnish 6.0 upgraded to varnish 6.6.
- Since varnish 6.2 removed miss from vcl_hit, vcl needs slight adjustment
- Strips purge-cache-tags header in varnish just like nginx does (unless exposed via configuration)