### PR TITLE
Drupal: retry404s paths, tls hosts, nginx sticky sessions, pxc fixes

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.104
+version: 0.3.105
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -314,10 +314,10 @@ done
   {{- end }}
 
   {{ include "drupal.wait-for-db-command" . }}
+  {{ include "drupal.create-db" . }}
 
   {{ if .Release.IsInstall }}
     touch {{ .Values.webRoot }}/sites/default/files/_installing
-    {{ include "drupal.create-db" . }}
     {{- if .Values.referenceData.enabled }}
       {{ include "drupal.import-reference-db" . }}
     {{- end }}

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
 data:
   gdpr-dump: |
-    [mysqldump]
-    gdpr-replacements='{{ .Values.gdprDump | toJson }}'
+    # [mysqldump]
+    # gdpr-replacements='{{ .Values.gdprDump | toJson }}'
 
   {{- if eq .Values.php.drupalCoreVersion "7" }}
   settings_silta_php: |{{ .Files.Get "files/settings.silta.d7.php" | nindent 4 }}
@@ -445,10 +445,15 @@ data:
             }
 
             {{- if .Values.nginx.retry404s }}
-            # Retry file lookup in 5 seconds (fs sync workaround)
-            location ~* ^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$ {
+            {{- if kindIs "float64" .Values.nginx.retry404s }}
+            {{- fail ".Values.nginx.retry404s configuration schema has been changed. Please check chart values file for updates." }}
+            {{- end }}
+            # Retry file lookup in {{ .Values.nginx.retry404s.delay }} seconds (fs sync workaround)
+            {{- range .Values.nginx.retry404s.paths }}
+            location ~* {{ . }} {
                 try_files $uri $uri/ @files_delay;
             }
+            {{- end }}
             {{- end }}
             
             ## Serve static files & images directly, without all standard drupal rewrites, php-fpm etc.
@@ -528,7 +533,7 @@ data:
         {{- if .Values.nginx.retry404s }}
         location @files_delay {
             internal;
-            echo_sleep {{ .Values.nginx.retry404s }}.0;
+            echo_sleep {{ .Values.nginx.retry404s.delay }}.0;
             echo_exec @files_retry;
         }
         location @files_retry {

--- a/drupal/templates/drupal-ingress.yaml
+++ b/drupal/templates/drupal-ingress.yaml
@@ -54,10 +54,16 @@ spec:
   tls:
   {{- if .Values.ssl.existingTLSSecret }}
   - secretName: {{ .Values.ssl.existingTLSSecret }}
+    hosts: 
+      - {{ include "drupal.domain" . | quote }}
   {{- else }}
   - secretName: {{ .Release.Name }}-tls
+    hosts: 
+      - {{ include "drupal.domain" . | quote }}
   {{- range $index, $prefix := .Values.domainPrefixes }}
   - secretName: {{ $.Release.Name }}-tls-p{{ $index }}
+    hosts: 
+      - '{{ $prefix }}.{{ template "drupal.domain" $ }}'
   {{- end }}
   {{- end }}
   {{- end }}
@@ -162,8 +168,12 @@ spec:
   {{- if $domain.ssl.enabled }}
   {{- if $domain.ssl.existingTLSSecret }}
   - secretName: {{ $domain.ssl.existingTLSSecret }}
+    hosts: 
+      - {{ $domain.hostname }}
   {{- else }}
   - secretName: {{ $.Release.Name }}-tls-{{ $domain_index }}
+    hosts: 
+      - {{ $domain.hostname }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/drupal/templates/drupal-service.yaml
+++ b/drupal/templates/drupal-service.yaml
@@ -12,6 +12,10 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
     {{- end }}
     {{- end }}
+    {{- if .Values.nginx.sessionAffinity }}
+    traefik.ingress.kubernetes.io/affinity: "true"
+    traefik.ingress.kubernetes.io/session-cookie-name: "sticky-drupal"
+    {{- end }}
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
 spec:

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -180,7 +180,13 @@ nginx:
   comp_level: 6
 
   # Retry file lookup in 5 seconds (filesystem sync workaround)
-  # retry404s: 5
+  # retry404s:
+  #   delay: 5
+  #   paths:
+  #     - "^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$"
+
+  # Allow load-balancer to pod session affinity for consecutive requests. Does not work with varnish enabled.
+  sessionAffinity: false
 
   # Extra configuration block in server context.
   serverExtraConfig: |
@@ -390,6 +396,7 @@ referenceData:
 
 # Parameters for sanitizing reference data with gdpr-dump.
 # Uses formatters from https://packagist.org/packages/fzaninotto/faker.
+# ! This functionality has been temporary disabled
 gdprDump:
   users_field_data:
     name:
@@ -626,6 +633,7 @@ pxc-db:
     size: 3
     expose:
       enabled: false
+    disableTLS: true
     resources:
       requests:
         cpu: 250m


### PR DESCRIPTION
- Exposes nginx session affinity option as .Values.nginx.sessionAffinity setting. False by default.
- tls hosts definition for ingress resources
- Disable tls for pxc cluster;
- Always create db if not exists
- Allows custom locations for retry404s.
- Disables gdprdump due to unavailable gdpr-dump extended mysqldump binary
- Deprecates old retry404s configuration schema (with failure message)

Old configuration syntax:
```
nginx:
  retry404s: 5
```
New configuration syntax:
```
nginx:
  retry404s:
    delay: 5
    paths:
      - "^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$"
      - "^/sites/(.*)/files/(.*).(?:png|jpg)$"
```