### PR TITLE
Log4j jndi removal for ES; Frontend uses forked ES; ES image upgrades to patched versions

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.107
+version: 0.3.108
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/solr-statefulset.yaml
+++ b/drupal/templates/solr-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           mountPath: /var/solr/search
       containers:
       - name: solr
-        image: {{ printf "%s:%s" .Values.solr.image .Values.solr.imageTag | quote }}
+        image: "{{ .Values.solr.image }}:{{ .Values.solr.imageTag }}"
         ports:
         - containerPort: 8983
         command: {{ .Values.solr.command }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -508,7 +508,7 @@ elasticsearch:
 
   # The elasticsearch version to use.
   # It's a good idea to tag this in your silta.yml
-  imageTag: 6.8.3
+  imageTag: 6.8.21
 
   replicas: 1
   minimumMasterNodes: 1
@@ -587,8 +587,8 @@ smtp:
 solr:
   enabled: false
   # Available image tags: https://hub.docker.com/r/geerlingguy/solr/tags
-  image: geerlingguy/solr
-  imageTag: latest
+  image: eu.gcr.io/silta-images/solr
+  imageTag: 8
 
   # Solr 4.x and 5.x does not support "-force" argument (optional override)
   command: ["/opt/solr/bin/solr"]

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -51,7 +51,7 @@ secretMounts: []
 #    defaultMode: 0755
 
 image: "docker.elastic.co/elasticsearch/elasticsearch"
-imageTag: "7.8.1-SNAPSHOT"
+imageTag: "7.16.1"
 imagePullPolicy: "IfNotPresent"
 
 podAnnotations: {}

--- a/frontend/Chart.lock
+++ b/frontend/Chart.lock
@@ -3,8 +3,8 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 7.10.4
 - name: elasticsearch
-  repository: https://helm.elastic.co
-  version: 7.4.1
+  repository: file://../elasticsearch
+  version: 7.8.1
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 6.17.5
@@ -14,5 +14,5 @@ dependencies:
 - name: silta-release
   repository: file://../silta-release
   version: 0.1.1
-digest: sha256:f5e19e1c740500eaecd108fb891097242e96fe08a69577f212f79e7c54a8e513
-generated: "2021-10-06T11:40:52.43546269+03:00"
+digest: sha256:b3aaf4ef2adc5df31d7cc08159860c2a0402fa4bf8c72fd9db53fa02e0b78ce8
+generated: "2021-12-13T16:23:09.212253546+02:00"

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,14 +1,15 @@
 apiVersion: v2
 name: frontend
-version: 0.2.56
+version: 0.2.57
 dependencies:
 - name: mariadb
   version: 7.10.x
   repository: https://charts.bitnami.com/bitnami
   condition: mariadb.enabled
 - name: elasticsearch
-  version: 7.4.1
-  repository: https://helm.elastic.co
+  version: 7.8.x
+#  repository: https://helm.elastic.co
+  repository: file://../elasticsearch
   condition: elasticsearch.enabled
 - name: rabbitmq
   version: 6.17.x

--- a/frontend/templates/_overrides.tpl
+++ b/frontend/templates/_overrides.tpl
@@ -6,15 +6,15 @@ Override templates from subcharts.
 The elasticsearch chart uses an incompatible naming scheme,
 we make it compatible by overriding the following templates.
 */}}
-{{- define "uname" -}}
+{{- define "elasticsearch.uname" -}}
 {{ .Release.Name }}-es
 {{- end }}
 
-{{- define "masterService" -}}
+{{- define "elasticsearch.masterService" -}}
 {{ .Release.Name }}-es
 {{- end }}
 
-{{- define "endpoints" -}}
+{{- define "elasticsearch.endpoints" -}}
 {{ .Release.Name }}-es-0
 {{- end -}}
 

--- a/frontend/tests/elasticsearch_test.yaml
+++ b/frontend/tests/elasticsearch_test.yaml
@@ -1,0 +1,31 @@
+suite: drupal elasticsearch
+templates:
+  - services-deployment.yaml
+  - configmap.yaml
+capabilities:
+  apiVersions:
+    - pxc.percona.com/v1
+tests:
+  - it: sets elasticsearch hostname in drupal environment if elasticsearch is enabled
+    template: services-deployment.yaml
+    set:
+      services.node.enabled: true
+      elasticsearch.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_HOST
+            value: RELEASE-NAME-es
+
+  - it: sets no elasticsearch hostname in drupal environment if elasticsearch is disabled
+    template: services-deployment.yaml
+    set:
+      services.node.enabled: true
+      elasticsearch.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_HOST
+            value: RELEASE-NAME-es

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -354,7 +354,7 @@ elasticsearch:
 
   # The elasticsearch version to use.
   # It's a good idea to tag this in your silta.yml
-  imageTag: 7.4.1
+  imageTag: 7.16.1
 
   replicas: 1
   minimumMasterNodes: 1
@@ -362,8 +362,7 @@ elasticsearch:
   clusterHealthCheckParams: 'wait_for_status=yellow&timeout=1s'
 
   # This value should be slightly less than 50% of the requested memory.
-  # Dlog4j2.formatMsgNoLookups=true *is* important to keep. This variable mitigates Log4j exploit CVE-2021-44228
-  esJavaOpts: -Dlog4j2.formatMsgNoLookups=true -Xmx220m -Xms220m
+  esJavaOpts: -Xmx220m -Xms220m
   xpack:
     enabled: false
   volumeClaimTemplate:


### PR DESCRIPTION
- Reusing local elasticsearch chart fork for frontend chart & upgrading frontend es chart from 7.4 to 7.8;
- Upgrading default elasticsearch image from 7.4.1 to 7.16.1 (patched for log4j exploit) for frontend chart;
- Moving formatMsgNoLookups in frontend chart to library chart.
- Upgrading default elasticsearch image from 6.8.3 to 6.8.21 (patched for log4j exploit) for drupal chart;
- Temporary switching to forked solr 8 image with CVE-2021-44228 and CVE 2021-45046 [mitigation](https://github.com/wunderio/silta-images/commit/9060b7eb2e9431434a718311fe4e02a8b0f1c859).