### PR TITLE
Updating default elasticsearch images to fix CVE-2021-45105

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.109
+version: 0.3.110
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -508,7 +508,7 @@ elasticsearch:
 
   # The elasticsearch version to use.
   # It's a good idea to tag this in your silta.yml
-  imageTag: 6.8.21
+  imageTag: 6.8.22
 
   replicas: 1
   minimumMasterNodes: 1

--- a/elasticsearch/values.yaml
+++ b/elasticsearch/values.yaml
@@ -51,7 +51,7 @@ secretMounts: []
 #    defaultMode: 0755
 
 image: "docker.elastic.co/elasticsearch/elasticsearch"
-imageTag: "7.16.1"
+imageTag: "7.16.2"
 imagePullPolicy: "IfNotPresent"
 
 podAnnotations: {}

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.57
+version: 0.2.58
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -354,7 +354,7 @@ elasticsearch:
 
   # The elasticsearch version to use.
   # It's a good idea to tag this in your silta.yml
-  imageTag: 7.16.1
+  imageTag: 7.16.2
 
   replicas: 1
   minimumMasterNodes: 1


### PR DESCRIPTION
- Drupal chart update default elasticsearch image to 6.8.22
- Frontend chart update default elasticsearch image to 7.16.2
- Forked elasticsearch chart update default elasticsearch image to 7.16.2