### PR TITLE
Ingress pathType fix; Solr 5 path fix; drush cr on empty db

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.110
+version: 0.3.111
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/drupal-ingress.yaml
+++ b/drupal/templates/drupal-ingress.yaml
@@ -73,6 +73,9 @@ spec:
     http:
       paths:
       - path: /
+        {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
           {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
           service:
@@ -89,6 +92,9 @@ spec:
     http:
       paths:
       - path: /
+        {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
           {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
           service:
@@ -190,6 +196,9 @@ spec:
     http:
       paths:
       - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
+        {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
           {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
           service:

--- a/drupal/templates/solr-statefulset.yaml
+++ b/drupal/templates/solr-statefulset.yaml
@@ -68,6 +68,11 @@ spec:
           mountPath: /opt/solr/example/solr/search
         - name: {{ .Release.Name }}-solr-data
           mountPath: /opt/solr/example/solr/search/data
+          # Compatability mount: SOLR 5.x
+        - name: {{ .Release.Name }}-core-dir
+          mountPath: /opt/solr/server/solr/search
+        - name: {{ .Release.Name }}-solr-data
+          mountPath: /opt/solr/server/solr/search/data
 
         resources:
           {{- .Values.solr.resources | toYaml | nindent 10 }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -259,9 +259,9 @@ php:
       # example service files have changed, Drupal might not be able to
       # bootstrap, not even for the `drush status` command below.
       if [[ $DRUPAL_CORE_VERSION -eq 7 ]] ; then
-        drush cache-clear all
+        drush cache-clear all || true
       else
-        drush cache-rebuild
+        drush cache-rebuild || true
       fi
       if [[ "$(drush status --fields=bootstrap)" = *'Successful'* ]] ; then
         drush updatedb -y

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.58
+version: 0.2.59
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/ingress.yaml
+++ b/frontend/templates/ingress.yaml
@@ -62,6 +62,9 @@ spec:
     http:
       paths:
       - path: /
+        {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
           {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
           service:
@@ -78,6 +81,9 @@ spec:
     http:
       paths:
       - path: /
+        {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
           {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
           service:
@@ -172,6 +178,9 @@ spec:
     http:
       paths:
       - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
+        {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
           {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
           service:

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.21
+version: 0.2.22
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/ingress.yaml
+++ b/simple/templates/ingress.yaml
@@ -52,6 +52,9 @@ spec:
     http:
       paths:
       - path: /
+        {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
           {{- if eq ( include "ingress.api-version" . | trim ) "networking.k8s.io/v1" }}
           service:
@@ -143,6 +146,9 @@ spec:
     http:
       paths:
       - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
+        {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
           {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
           service:


### PR DESCRIPTION
- Ingress pathType fix (drupal chart);
- Drupal: Solr 5 core path fix
- Drupal: Allow drush cr on an empty db in postinstall job.