### PR TITLE
Improve Nginx Retry404 RX

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -183,7 +183,7 @@ nginx:
   # retry404s:
   #   delay: 5
   #   paths:
-  #     - "^/sites/(.*)/files/(?:css|js)/(.*).(?:css|js)$"
+  #     - "^/sites/[^/]+/files/(?:css|js)/"
 
   # Allow load-balancer to pod session affinity for consecutive requests. Does not work with varnish enabled.
   sessionAffinity: false


### PR DESCRIPTION
- Don't use capture, it's slower, and not needed
- Match only one dir level between sites/ and files/
- No need to match particular filenames, css|js dir is sufficient
- Filename matching had problems too:
    - dot was not quoted
    - .gz was not considered
    - queries were not considered (?v=1.0.8)
    - subdirs of js/ and css/ were not considered (fex .../js/optimised/...)
- So the reference pattern is now more universal and accurate at the same time

**How to test?**
Try this in regex101.com
<img width="771" alt="Screenshot 2022-01-19 at 14 49 30" src="https://user-images.githubusercontent.com/28702260/150134026-3303ec0c-9ae2-4007-bcad-62379b4e87dc.png">