### PR TITLE
silta-cluster and silta-downscaler: Conditional apiVersion updates

### DIFF
--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.18
+version: 0.2.19
 dependencies:
 - name: traefik
   version: 1.87.x

--- a/silta-cluster/templates/_helpers.tpl
+++ b/silta-cluster/templates/_helpers.tpl
@@ -15,3 +15,11 @@ solvers:
 http01: {}
 {{- end -}}
 {{- end }}
+
+{{- define "silta-cluster.ingress-api-version" }}
+{{- if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
+networking.k8s.io/v1
+{{- else }}
+networking.k8s.io/v1beta1
+{{- end }}
+{{- end }}

--- a/silta-cluster/templates/deployment-remover-ingress.yaml
+++ b/silta-cluster/templates/deployment-remover-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deploymentRemover.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "silta-cluster.ingress-api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-deployment-remover
@@ -22,9 +22,19 @@ spec:
     http:
       paths:
       - path: /
+        {{- if eq ( include "silta-cluster.ingress-api-version" . | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
+          {{- if eq ( include "silta-cluster.ingress-api-version" . | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Release.Name }}-deployment-remover
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ .Release.Name }}-deployment-remover
           servicePort: 80
+          {{- end }}
 ---
 {{- if .Values.deploymentRemover.ssl.enabled }}
 {{- if has .Values.deploymentRemover.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}

--- a/silta-cluster/templates/splash-ingress.yaml
+++ b/silta-cluster/templates/splash-ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "silta-cluster.ingress-api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-splash
@@ -22,9 +22,19 @@ spec:
     http:
       paths:
       - path: /
+        {{- if eq ( include "silta-cluster.ingress-api-version" . | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
+          {{- if eq ( include "silta-cluster.ingress-api-version" . | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Release.Name }}-splash
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ .Release.Name }}-splash
           servicePort: 80
+          {{- end }}
 ---
 {{- if .Values.ssl.enabled }}
 {{- if has .Values.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}

--- a/silta-cluster/templates/ssh-key-server-ingress.yaml
+++ b/silta-cluster/templates/ssh-key-server-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.sshKeyServer.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: {{ include "silta-cluster.ingress-api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ssh-key-server
@@ -22,9 +22,19 @@ spec:
     http:
       paths:
       - path: /
+        {{- if eq ( include "silta-cluster.ingress-api-version" . | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
+          {{- if eq ( include "silta-cluster.ingress-api-version" . | trim ) "networking.k8s.io/v1" }}
+          service:
+            name: {{ .Release.Name }}-ssh-key-server
+            port: 
+              number: 80
+          {{- else }}
           serviceName: {{ .Release.Name }}-ssh-key-server
           servicePort: 80
+          {{- end }}
 ---
 {{- if .Values.sshKeyServer.ssl.enabled }}
 {{- if has .Values.sshKeyServer.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -82,9 +82,13 @@ spec:
   resources:
     requests:
       storage: {{ .Values.gitAuth.persistence.size }}
+  {{- if .Values.gitAuth.persistence.storageClassName }}
+  {{- if eq .Values.gitAuth.persistence.storageClassName "silta-shared" }}
   selector:
     matchLabels:
       name: {{ $.Release.Name }}-shell-keys-pv
+  {{- end }}
+  {{- end }}
 {{- end }}
 # silta-shared volume definition if its storage is selected
 {{- if .Values.gitAuth.persistence.storageClassName }}

--- a/silta-downscaler/templates/_helpers.tpl
+++ b/silta-downscaler/templates/_helpers.tpl
@@ -1,4 +1,4 @@
-{{- define "cert-manager-api-version" }}
+{{- define "silta-cluster.cert-manager-api-version" }}
 {{- if ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) }}
 cert-manager.io/v1
 {{- else }}
@@ -6,7 +6,7 @@ certmanager.k8s.io/v1alpha1
 {{- end }}
 {{- end }}
 
-{{- define "ingress-api-version" }}
+{{- define "silta-downscaler.ingress-api-version" }}
 {{- if semverCompare ">=1.18" .Capabilities.KubeVersion.Version }}
 networking.k8s.io/v1
 {{- else }}

--- a/silta-downscaler/templates/placeholder-upscaler.yaml
+++ b/silta-downscaler/templates/placeholder-upscaler.yaml
@@ -55,7 +55,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
 ---
-apiVersion: {{ include "ingress-api-version" . | trim }}
+apiVersion: {{ include "silta-downscaler.ingress-api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-placeholder-upscaler
@@ -76,8 +76,11 @@ spec:
     http:
       paths:
       - path: /
+        {{- if eq ( include "silta-downscaler.ingress-api-version" . | trim ) "networking.k8s.io/v1" }}
+        pathType: Prefix
+        {{- end }}
         backend:
-          {{- if eq ( include "ingress-api-version" . | trim ) "networking.k8s.io/v1" }}
+          {{- if eq ( include "silta-downscaler.ingress-api-version" . | trim ) "networking.k8s.io/v1" }}
           service:
             name: {{ .Release.Name }}-placeholder-upscaler
             port: 
@@ -89,7 +92,7 @@ spec:
 ---
 {{- if .Values.ssl.enabled }}
 {{- if has .Values.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
-apiVersion: {{ include "cert-manager-api-version" . | trim }}
+apiVersion: {{ include "silta-cluster.cert-manager-api-version" . | trim }}
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-placeholder-upscaler
@@ -106,7 +109,7 @@ spec:
   issuerRef:
     name: {{ .Values.ssl.issuer }}
     kind: ClusterIssuer
-  {{- if eq ( include "cert-manager-api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
+  {{- if eq ( include "silta-cluster.cert-manager-api-version" . | trim ) "certmanager.k8s.io/v1alpha1" }}
   acme:
     config:
       - http01:


### PR DESCRIPTION
- silta-cluster: Uses Ingress API v1 when kubernetes version is above 1.18. Includes required ingress changes. 
- silta-downscaler: `apiVersion` define variable name change