### PR TITLE
Allow defining static ssh keys;  Local externalTrafficPolicy

### DIFF
--- a/silta-cluster/templates/sshd-jumpserver-cm.yaml
+++ b/silta-cluster/templates/sshd-jumpserver-cm.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.gitAuth.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-sshd-jumphost
+  namespace: {{ .Release.Namespace }}
+data:
+  authorizedKeys: |
+  {{- if .Values.gitAuth.authorizedKeys }}
+    {{- range .Values.gitAuth.authorizedKeys }}
+    {{ . }}
+    {{- end }}
+  {{- end }}
+
+{{- end }}

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -15,6 +15,7 @@ spec:
     - name: ssh
       port: {{ .Values.gitAuth.port }}
   type: "LoadBalancer"
+  externalTrafficPolicy: Local
 {{- if .Values.gitAuth.loadBalancerIP }}
   loadBalancerIP: {{ .Values.gitAuth.loadBalancerIP }}
 {{- end }}
@@ -38,6 +39,8 @@ spec:
     metadata:
       labels:
         name: {{ .Release.Name }}-jumpserver
+      annotations:
+        configMap-checksum: {{ include (print $.Template.BasePath "/sshd-jumpserver-cm.yaml") . | sha256sum }}
     spec:
       enableServiceLinks: false
       containers:
@@ -47,6 +50,7 @@ spec:
         ports:
           - containerPort: 22
         env:
+          {{- if .Values.gitAuth.keyserver.enabled }}
           - name: GITAUTH_URL
             value: {{ .Values.gitAuth.keyserver.url | default (printf "https://keys.%s/api/1/git-ssh-keys" .Values.clusterDomain) | quote }}
           - name: GITAUTH_USERNAME
@@ -57,15 +61,23 @@ spec:
             value: {{ required "A valid .Values.gitAuth.scope entry required!" .Values.gitAuth.scope | quote }}
           - name: OUTSIDE_COLLABORATORS
             value: {{ .Values.gitAuth.outsideCollaborators | default true | quote }}
+          {{- end }}
         volumeMounts:
         - name: shell-keys
           mountPath: /etc/ssh/keys
+        - name: sshd-jumphost-configmap
+          mountPath: /etc/ssh/authorized_keys
+          subPath: authorizedKeys
+          readOnly: true
         resources:
           {{- .Values.gitAuth.resources | toYaml | nindent 10 }}
       volumes:
       - name: shell-keys
         persistentVolumeClaim:
           claimName: {{ .Release.Name }}-shell-keys
+      - name: sshd-jumphost-configmap
+        configMap:
+          name: {{ .Release.Name }}-sshd-jumphost
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -82,9 +82,11 @@ gitAuth:
   enabled: true
   port: 22
   keyserver:
+    enabled: true
     url: ''
     username: ''
     password: ''
+  authorizedKeys: []
   scope: ''
   outsideCollaborators: true
   allowedIps: []


### PR DESCRIPTION
- Sets externalTrafficPolicy to Local so remote IP's pass trough correctly
- Allows disabling key server (enabled by default for compatibility reasons)
```
gitAuth:
  keyserver: 
    enabled: false
```
- Allows defining static ssh keys (Related jumphost image commit https://github.com/wunderio/sshd-gitauth/commit/0c26869bcf8b239d12c242ccf1f788d47f65312c)
```
gitAuth:
  authorizedKeys:
    # Key for user 1
    - "ssh-rsa ... user1@example.com"
    # Key for user 2
    - "ssh-rsa ... user2@example.com"
```