### PR TITLE
exposeDomains, AGW

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.113
+version: 0.3.114
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/drupal-ingress.yaml
+++ b/drupal/templates/drupal-ingress.yaml
@@ -29,6 +29,9 @@ metadata:
     {{- end }}
     {{- if $redirect_https }}
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- if eq $ingress.type "azure/application-gateway" }}
+    appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
     {{- end }}
 
     {{- if eq $ingress.type "gce" }}
@@ -37,7 +40,11 @@ metadata:
     {{- if $ingress.staticIpAddressName }}
     kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
-
+    
+    {{- if eq $ingress.type "azure/application-gateway" }}
+    cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
+    
     {{- if $ingress.extraAnnotations }}
     {{- $ingress.extraAnnotations | toYaml | nindent 4 }}
     {{- end }}
@@ -154,6 +161,9 @@ metadata:
     {{- end }}
     {{- if $redirect_https }}
     ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- if eq $ingress.type "azure/application-gateway" }}
+    appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
     {{- end }}
 
     {{- if eq $ingress.type "gce" }}
@@ -161,6 +171,10 @@ metadata:
     {{- end }}
     {{- if $ingress.staticIpAddressName }}
     kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
+    {{- end }}
+    
+    {{- if eq $ingress.type "azure/application-gateway" }}
+    cert-manager.io/cluster-issuer: letsencrypt
     {{- end }}
     
     {{- if $ingress.extraAnnotations }}

--- a/drupal/test.values.yaml
+++ b/drupal/test.values.yaml
@@ -1,11 +1,13 @@
 # This file includes the configuration used to validate the chart with a dry-run installation.
 
 exposeDomains:
- - hostname: example.com
- - hostname: www.example.com
-   ssl:
-     enabled: true
-     issuer: letsencrypt-staging
+  example:
+    hostname: example.com
+  example2:
+    hostname: www.example.com
+    ssl:
+      enabled: true
+      issuer: letsencrypt-staging
 
 domainPrefixes: ['en', 'fi']
 

--- a/drupal/tests/drupal_ingress_test.yaml
+++ b/drupal/tests/drupal_ingress_test.yaml
@@ -243,22 +243,6 @@ tests:
           path: 'spec.rules[0].host'
           value: 'bar.baz'
 
-  - it: exposeDomains as list, multiple hostnames can use the same ingress [list definition to be deprecated]
-    template: drupal-ingress.yaml
-    set:
-      exposeDomains:
-        - hostname: foo.baz
-        - hostname: bar.baz
-    asserts:
-      - documentIndex: 1
-        equal:
-          path: 'spec.rules[0].host'
-          value: 'foo.baz'
-      - documentIndex: 1
-        equal:
-          path: 'spec.rules[1].host'
-          value: 'bar.baz'
-
   - it: exposeDomains - can supply staticIpAddressName for gce type ingress
     template: drupal-ingress.yaml
     set:

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -62,7 +62,7 @@
         "enabled": { "type": "boolean" }
       }
     },
-    "exposeDomains": { "type": ["array","object"], "items": { "type": "object"}},
+    "exposeDomains": { "type": "object", "items": { "type": "object"}},
     "exposeDomainsDefaults": { "type": "object"},
     "domainPrefixes": { "type": "array", "items": { "type": "string"}},
     "ssl": { "type": "object" },

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.60
+version: 0.2.61
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/test.values.yaml
+++ b/frontend/test.values.yaml
@@ -1,11 +1,13 @@
 # This file includes the configuration used to validate the chart with a dry-run installation.
 
 exposeDomains:
- - hostname: example.com
- - hostname: www.example.com
-   ssl:
-     enabled: true
-     issuer: letsencrypt-staging
+  example:
+    hostname: example.com
+  example2:
+    hostname: www.example.com
+    ssl:
+      enabled: true
+      issuer: letsencrypt-staging
 
 domainPrefixes: ['en', 'fi']
 

--- a/frontend/tests/ingress_test.yaml
+++ b/frontend/tests/ingress_test.yaml
@@ -209,22 +209,6 @@ tests:
           path: 'spec.rules[0].host'
           value: 'bar.baz'
 
-  - it: exposeDomains as list, multiple hostnames can use the same ingress [list definition to be deprecated]
-    template: ingress.yaml
-    set:
-      exposeDomains:
-        - hostname: foo.baz
-        - hostname: bar.baz
-    asserts:
-      - documentIndex: 1
-        equal:
-          path: 'spec.rules[0].host'
-          value: 'foo.baz'
-      - documentIndex: 1
-        equal:
-          path: 'spec.rules[1].host'
-          value: 'bar.baz'
-
   - it: exposeDomains - can supply staticIpAddressName for gce type ingress
     template: ingress.yaml
     set:

--- a/frontend/values.schema.json
+++ b/frontend/values.schema.json
@@ -8,7 +8,7 @@
     "branchName": { "type": "string" },
     "imagePullSecrets": { "type": "array" },
     "app": { "type": "string" },
-    "exposeDomains": { "type": ["array","object"], "items": { "type": "object"}},
+    "exposeDomains": { "type": "object", "items": { "type": "object"}},
     "exposeDomainsDefaults": { "type": "object"},
     "domainPrefixes": { "type": "array", "items": { "type": "string"}},
     "ssl": { "type": "object" },

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.23
+version: 0.2.24
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/tests/ingress_test.yaml
+++ b/simple/tests/ingress_test.yaml
@@ -184,22 +184,6 @@ tests:
           path: 'spec.rules[0].host'
           value: 'bar.baz'
 
-  - it: exposeDomains as list, multiple hostnames can use the same ingress [list definition to be deprecated]
-    template: ingress.yaml
-    set:
-      exposeDomains:
-        - hostname: foo.baz
-        - hostname: bar.baz
-    asserts:
-      - documentIndex: 1
-        equal:
-          path: 'spec.rules[0].host'
-          value: 'foo.baz'
-      - documentIndex: 1
-        equal:
-          path: 'spec.rules[1].host'
-          value: 'bar.baz'
-
   - it: exposeDomains - can supply staticIpAddressName for gce type ingress
     template: ingress.yaml
     set:

--- a/simple/values.schema.json
+++ b/simple/values.schema.json
@@ -10,7 +10,7 @@
     "branchName": { "type": "string" },
     "imagePullSecrets": { "type": "array" },
     "app": { "type": "string" },
-    "exposeDomains": { "type": ["array","object"], "items": { "type": "object"}},
+    "exposeDomains": { "type": "object", "items": { "type": "object"}},
     "exposeDomainsDefaults": { "type": "object"},
     "ssl": { "type": "object" },
     "backendConfig": { "type": ["array","object"], "items": { "type": "object"}},


### PR DESCRIPTION
- Disallows old exposeDomains structure;
- Adds support for Azure's Application Gateway.