### PR TITLE
Update projectName description.

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -8,7 +8,7 @@ silta-release:
 # Subdomains of this domain will be created automatically for each environment.
 clusterDomain: "silta.wdr.io"
 
-# An optional human-readable label for the project, defaults to the repository name.
+# An optional machine-readable label for the project, defaults to the repository name.
 # This name is mainly used to create nice subdomains for each environment.
 projectName: ""
 


### PR DESCRIPTION
I propose to change `projectName` description to avoid broken URL's.

Currently, description advises to use human-readable syntax which might break the environment's URL's as happened in https://github.com/wunderio/client-fi-sanoma-b2b, where `projectName: 'Sanoma B2B'` is used and all non-prod env URL's are broken as a consequence (f. ex: https://master.client-fi-sanoma-b2b.dev.wdr.io).