### PR TITLE
Nginx limits. API versions

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.114
+version: 0.3.115
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -548,3 +548,20 @@ set -e
 if [ -f /lagoon/entrypoints.sh ] ; then /lagoon/entrypoints.sh ; fi
 
 {{- end }}
+
+
+{{- define "drupal.cron.api-version" }}
+{{- if semverCompare ">=1.21" .Capabilities.KubeVersion.Version }}
+batch/v1
+{{- else }}
+batch/v1beta1
+{{- end }}
+{{- end }}
+
+{{- define "drupal.autoscaling.api-version" }}
+{{- if semverCompare ">=1.23" .Capabilities.KubeVersion.Version }}
+autoscaling/v2
+{{- else }}
+autoscaling/v2beta1
+{{- end }}
+{{- end }}

--- a/drupal/templates/backup-cron.yaml
+++ b/drupal/templates/backup-cron.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.backup.enabled }}
 {{- $db_password := randAlphaNum 20 }}
 {{- $params := dict "db_password" $db_password  -}}
-apiVersion: batch/v1beta1
+apiVersion: {{ include "drupal.cron.api-version" $ | trim }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-backup

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -463,7 +463,11 @@ data:
                 expires         365d;
                 add_header Cache-Control "public";
                 ## Set the OS file cache.
-                open_file_cache max=10000 inactive=120s;
+                {{- if .Values.nginx.open_file_cache.enabled }}
+                open_file_cache max={{ .Values.nginx.open_file_cache.max }} inactive={{ .Values.nginx.open_file_cache.inactive }};
+                {{- else }}
+                open_file_cache off;
+                {{- end }}
                 open_file_cache_valid 45s;
                 open_file_cache_min_uses 2;
                 open_file_cache_errors off;
@@ -485,7 +489,11 @@ data:
                 expires 365d;
                 add_header Cache-Control "public";
                 ## Set the OS file cache.
-                open_file_cache max=10000 inactive=120s;
+                {{- if .Values.nginx.open_file_cache.enabled }}
+                open_file_cache max={{ .Values.nginx.open_file_cache.max }} inactive={{ .Values.nginx.open_file_cache.inactive }};
+                {{- else }}
+                open_file_cache off;
+                {{- end }}
                 open_file_cache_valid 45s;
                 open_file_cache_min_uses 2;
                 open_file_cache_errors off;

--- a/drupal/templates/drupal-deployment.yaml
+++ b/drupal/templates/drupal-deployment.yaml
@@ -148,7 +148,7 @@ spec:
                   - drupal
 ---
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "drupal.autoscaling.api-version" . | trim }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-drupal

--- a/drupal/templates/reference-data-cron.yaml
+++ b/drupal/templates/reference-data-cron.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.referenceData.enabled }}
 {{- if eq .Values.referenceData.referenceEnvironment .Values.environmentName }}
-apiVersion: batch/v1beta1
+apiVersion: {{ include "drupal.cron.api-version" . | trim }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-refdata

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -137,6 +137,9 @@ nginx:
     requests:
       cpu: 1m
       memory: 10M
+    limits:
+      cpu: 500m
+      memory: 250M
 
   # Set of values to enable and use http basic authentication
   # It is implemented only for very basic protection (like web crawlers)
@@ -196,6 +199,13 @@ nginx:
 
   # Extra configuration to pass to nginx as a file
   extraConfig: |
+
+  # Toggle open_files_cache.
+  # Naming follows https://nginx.org/en/docs/http/ngx_http_core_module.html#open_file_cache directive
+  open_file_cache:
+    enabled: true
+    max: 6000
+    inactive: 120s
 
 # Configuration for everything that runs in php containers.
 php:

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.61
+version: 0.2.62
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/_helpers.tpl
+++ b/frontend/templates/_helpers.tpl
@@ -154,3 +154,19 @@ networking.k8s.io/v1
 networking.k8s.io/v1beta1
 {{- end }}
 {{- end }}
+
+{{- define "frontend.cron.api-version" }}
+{{- if semverCompare ">=1.21" .Capabilities.KubeVersion.Version }}
+batch/v1
+{{- else }}
+batch/v1beta1
+{{- end }}
+{{- end }}
+
+{{- define "frontend.autoscaling.api-version" }}
+{{- if semverCompare ">=1.23" .Capabilities.KubeVersion.Version }}
+autoscaling/v2
+{{- else }}
+autoscaling/v2beta1
+{{- end }}
+{{- end }}

--- a/frontend/templates/backup-cron.yaml
+++ b/frontend/templates/backup-cron.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.backup.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: {{ include "frontend.cron.api-version" . | trim }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-backup

--- a/frontend/templates/nginx.yaml
+++ b/frontend/templates/nginx.yaml
@@ -78,7 +78,7 @@ spec:
         {{- end }}
 ---
 {{- if .Values.nginx.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "frontend.autoscaling.api-version" . | trim }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-nginx

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -2,7 +2,7 @@
 {{ if $service.cron }}
 {{- range $jobName, $job := $service.cron }}
 
-apiVersion: batch/v1beta1
+apiVersion: {{ include "frontend.cron.api-version" $ | trim }}
 kind: CronJob
 metadata:
   name: {{ $.Release.Name }}-{{ $jobName }}

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -215,7 +215,7 @@ spec:
 {{- if $service.autoscaling }}
 {{- if $service.autoscaling.enabled }}
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "frontend.autoscaling.api-version" $ | trim }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $.Release.Name }}-{{ $index }}

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.24
+version: 0.2.25
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/_helpers.tpl
+++ b/simple/templates/_helpers.tpl
@@ -56,3 +56,11 @@ networking.k8s.io/v1
 networking.k8s.io/v1beta1
 {{- end }}
 {{- end }}
+
+{{- define "simple.autoscaling.api-version" }}
+{{- if semverCompare ">=1.23" .Capabilities.KubeVersion.Version }}
+autoscaling/v2
+{{- else }}
+autoscaling/v2beta1
+{{- end }}
+{{- end }}

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
         {{- end }}
 ---
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "simple.autoscaling.api-version" . | trim }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-simple


### PR DESCRIPTION
Drupal, frontend, simple: 
- batch, autoscaling resources are version dependant

Drupal:
- Customizable nginx static cache