### PR TITLE
[Drupal; Frontend; Simple; Elasticsearch] nginx 8080, api version updates, bugfixes

### DIFF
--- a/drupal/Chart.lock
+++ b/drupal/Chart.lock
@@ -18,4 +18,4 @@ dependencies:
   repository: file://../silta-release
   version: 0.1.1
 digest: sha256:17055f326935954f815a6a337b556b0c487391d6ac4ea6533151af403a787e88
-generated: "2021-10-19T09:02:03.014121382+03:00"
+generated: "2022-04-21T16:56:04.883373952+03:00"

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.119
+version: 0.3.120
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -43,7 +43,7 @@ ports:
   readOnly: true
   subPath: silta_services_yml
 - name: config
-  mountPath: /usr/local/etc/php-fpm.d/zz-custom.conf
+  mountPath: /tmp/zz-custom.conf
   readOnly: false
   subPath: php_fpm_d_custom
 - name: config

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -75,7 +75,7 @@ data:
 
     include modules/*.conf;
 
-    user                            nginx;
+    # user                            nginx;
     worker_processes                auto;
     worker_rlimit_nofile            10240;
 
@@ -286,7 +286,7 @@ data:
 
     server {
         server_name drupal;
-        listen 80;
+        listen 8080;
 
         # Loadbalancer health checks need to be fed with http 200
         if ($hc_ua) { return 200; }
@@ -522,6 +522,7 @@ data:
 
             location = /robots.txt {
                 add_header  Content-Type  text/plain;
+                access_log  off;
                 try_files $uri @drupal;
             }
 

--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -1,5 +1,5 @@
 {{- range $index, $job := .Values.php.cron }}
-apiVersion: batch/v1beta1
+apiVersion: {{ include "drupal.cron.api-version" $ | trim }}
 kind: CronJob
 metadata:
   {{- $indexHash := sha256sum $index | trunc 3 }}

--- a/drupal/templates/drupal-deployment.yaml
+++ b/drupal/templates/drupal-deployment.yaml
@@ -36,6 +36,13 @@ spec:
         readinessProbe:
           exec:
             command: ['/bin/bash', '-c', '/php-fpm-probe.sh']
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash
+              - -c
+              - cp /tmp/zz-custom.conf /usr/local/etc/php-fpm.d/zz-custom.conf
         resources:
           {{- .Values.php.resources | toYaml | nindent 10 }}
 
@@ -44,7 +51,7 @@ spec:
         image: {{ .Values.nginx.image | quote }}
         env:
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           name: drupal
         volumeMounts:
         {{- range $index, $mount := $.Values.mounts }}
@@ -81,7 +88,7 @@ spec:
         {{- end }}
         livenessProbe:
           tcpSocket:
-            port: 80
+            port: 8080
         resources:
           {{- .Values.nginx.resources | toYaml | nindent 10 }}
 

--- a/drupal/templates/drupal-service.yaml
+++ b/drupal/templates/drupal-service.yaml
@@ -24,6 +24,7 @@ spec:
   externalName: null
   ports:
     - port: 80
+      targetPort: 8080
   selector:
     {{- include "drupal.release_selector_labels" . | nindent 4 }}
     deployment: drupal

--- a/elasticsearch/Chart.yaml
+++ b/elasticsearch/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-description: Official Elastic helm chart for Elasticsearch
+description: Official Elastic helm chart for Elasticsearch.
 home: https://github.com/elastic/helm-charts
 maintainers:
 - email: helm-charts@elastic.co

--- a/elasticsearch/templates/poddisruptionbudget.yaml
+++ b/elasticsearch/templates/poddisruptionbudget.yaml
@@ -1,6 +1,9 @@
----
 {{- if .Values.maxUnavailable }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+apiVersion: policy/v1
+{{- else}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "elasticsearch.uname" . }}-pdb"

--- a/elasticsearch/templates/podsecuritypolicy.yaml
+++ b/elasticsearch/templates/podsecuritypolicy.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.podSecurityPolicy.create -}}
 {{- $fullName := include "elasticsearch.uname" . -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
+apiVersion: policy/v1
+{{- else}}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ default $fullName .Values.podSecurityPolicy.name | quote }}

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.64
+version: 0.2.65
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/configmap.yaml
+++ b/frontend/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ include "frontend.release_labels" . | indent 4 }}
 data:
   nginx_conf: |
-    user                            nginx;                                                 
+    # user                            nginx;                                                 
     worker_processes                auto;
     worker_rlimit_nofile            10240;
 
@@ -120,7 +120,7 @@ data:
 
     server {                               
         server_name frontend;
-        listen 80;
+        listen 8080;
 
         # Loadbalancer health checks need to be fed with http 200 
         if ($hc_ua) { return 200; }

--- a/frontend/templates/nginx.yaml
+++ b/frontend/templates/nginx.yaml
@@ -27,7 +27,7 @@ spec:
         image: {{ .Values.nginx.image | quote }}
         imagePullPolicy: Always
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           name: web
         volumeMounts:
         - name: nginx-conf
@@ -53,10 +53,10 @@ spec:
         {{- end }}
         livenessProbe:
           tcpSocket:
-            port: 80
+            port: 8080
         readinessProbe:
           tcpSocket:
-            port: 80
+            port: 8080
         resources:
           {{ .Values.nginx.resources | toYaml | nindent 10 }}
       volumes:

--- a/frontend/templates/service.yaml
+++ b/frontend/templates/service.yaml
@@ -21,6 +21,7 @@ spec:
   externalName: null
   ports:
     - port: 80
+      targetPort: 8080
   selector:
     {{ include "frontend.release_labels" . | indent 4 }}
     deployment: frontend

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.26
+version: 0.2.27
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/configmap.yaml
+++ b/simple/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{ include "simple.release_labels" . | indent 4 }}
 data:
   nginx_conf: |
-    user                            nginx;                                                 
+    # user                            nginx;                                                 
     worker_processes                auto;
     worker_rlimit_nofile            10240;
 
@@ -130,7 +130,7 @@ data:
                                  
     server {                               
         server_name simple;                          
-        listen 80;          
+        listen 8080;          
 
         # Loadbalancer health checks need to be fed with http 200 
         if ($hc_ua) { return 200; }

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         image: {{ .Values.nginx.image | quote }}
         env:
         ports:
-        - containerPort: 80
+        - containerPort: 8080
           name: simple
         volumeMounts:
         - name: nginx-conf
@@ -50,11 +50,11 @@ spec:
         {{- end }}
         livenessProbe:
           tcpSocket:
-            port: 80
+            port: 8080
         readinessProbe:
           httpGet:
             path: /
-            port: 80
+            port: 8080
         resources:
 {{ .Values.nginx.resources | toYaml | indent 10 }}
 

--- a/simple/templates/service.yaml
+++ b/simple/templates/service.yaml
@@ -19,5 +19,6 @@ spec:
   externalTrafficPolicy: Local
   ports:
     - port: 80
+      targetPort: 8080
   selector:
     {{ include "simple.release_labels" . | indent 4 }}


### PR DESCRIPTION
- [Drupal, Frontend, Simple] Changing nginx default port to 8080 due to nginx user being unable to open privileged ports
- Do not set user in nginx conf
- [Drupal] Cloud agnostic cronjob api version
- [Drupal] Workaround for php-fpm read only zz-custom.conf error message
- [Elasticsearch] Resource api version update