### PR TITLE
Feature/release 20220609

### DIFF
--- a/drupal/Chart.lock
+++ b/drupal/Chart.lock
@@ -1,16 +1,16 @@
 dependencies:
 - name: mariadb
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   version: 7.5.2
 - name: pxc-db
   repository: https://percona.github.io/percona-helm-charts/
   version: 1.9.1
 - name: memcached
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   version: 4.2.27
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.8.7
+  version: 16.8.10
 - name: mailhog
   repository: https://codecentric.github.io/helm-charts
   version: 3.1.3
@@ -20,5 +20,5 @@ dependencies:
 - name: silta-release
   repository: file://../silta-release
   version: 0.1.1
-digest: sha256:4998925a8a4dd89914789dfc4ee934c1ac5179f12f601c8baeb7aee83c6c9c97
-generated: "2022-04-25T08:47:01.004115611+03:00"
+digest: sha256:823cb88a03560c779bcee85b2ba9ec036fbe0cb769108f69339e91906c4f5d0b
+generated: "2022-06-02T16:46:22.620314421+03:00"

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: drupal
-version: 0.3.124
+version: 0.3.125
 dependencies:
 - name: mariadb
   version: 7.5.x
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   condition: mariadb.enabled,drupal.mariadb.enabled,global.mariadb.enabled
 - name: pxc-db
   version: 1.9.x
@@ -12,7 +12,7 @@ dependencies:
   condition: pxc-db.enabled
 - name: memcached
   version: 4.2.x
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   condition: memcached.enabled
 - name: redis
   version: 16.8.x

--- a/drupal/files/settings.silta.php
+++ b/drupal/files/settings.silta.php
@@ -30,15 +30,29 @@ if (getenv('PRIVATE_FILES_PATH')) {
  * Set Elasticsearch Helper module configuration if needed.
  */
 if ($elasticsearch_host = getenv('ELASTICSEARCH_HOST')) {
+
+  $elasticsearch_port = 9200;
+
   // Elasticsearch Helper 6.x compatible configuration override.
   $config['elasticsearch_helper.settings']['elasticsearch_helper']['host'] = $elasticsearch_host;
-  $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = 9200;
+  $config['elasticsearch_helper.settings']['elasticsearch_helper']['port'] = $elasticsearch_port;
 
   // Elasticsearch Helper 7.x compatible configuration override.
   $config['elasticsearch_helper.settings']['hosts'] = [
     [
       'host' => $elasticsearch_host,
-      'port' => 9200,
+      'port' => $elasticsearch_port,
+    ],
+  ];
+
+  // Enable Drupal Ping to survey the Elasticsearch connection
+  // https://github.com/wunderio/drupal-ping#elasticsearch
+  $settings['ping_elasticsearch_connections'] = [
+    [
+      'severity' => 'warning',
+      'proto' => 'http',
+      'host' => $elasticsearch_host,
+      'port' => $elasticsearch_port,
     ],
   ];
 }

--- a/frontend/Chart.lock
+++ b/frontend/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: mariadb
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   version: 7.10.4
 - name: elasticsearch
   repository: file://../elasticsearch
   version: 7.8.1
 - name: rabbitmq
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   version: 6.17.5
 - name: mongodb
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   version: 10.26.4
 - name: silta-release
   repository: file://../silta-release
   version: 0.1.1
-digest: sha256:b3aaf4ef2adc5df31d7cc08159860c2a0402fa4bf8c72fd9db53fa02e0b78ce8
-generated: "2021-12-13T16:23:09.212253546+02:00"
+digest: sha256:fa010b15537422cbbbcd0a06575e348e25e5b4096a8dd66307a5794a417a83d7
+generated: "2022-06-02T21:31:30.85885293+03:00"

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: frontend
-version: 0.2.69
+version: 0.2.70
 dependencies:
 - name: mariadb
   version: 7.10.x
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   condition: mariadb.enabled
 - name: elasticsearch
   version: 7.8.x
@@ -13,11 +13,11 @@ dependencies:
   condition: elasticsearch.enabled
 - name: rabbitmq
   version: 6.17.x
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   condition: rabbitmq.enabled
 - name: mongodb
   version: 10.26.x
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   condition: mongodb.enabled
 - name: silta-release
   version: 0.1.1


### PR DESCRIPTION
drupal chart (0.3.125): 
  - [Enable Elasticsearch pinging by Drupal Ping (Credit @ragnarkurmwunder)](https://github.com/wunderio/drupal-project-k8s/pull/490)
  - [Use forked version of charts due to bitnami phasing out older charts](https://github.com/wunderio/drupal-project-k8s/pull/494)

frontend chart (0.2.70):
  -  [Use forked version of charts due to bitnami phasing out older charts](https://github.com/wunderio/frontend-project-k8s/pull/73)
