### PR TITLE
Add a 10 second timeout before shutting down the drupal pod container…

### DIFF
--- a/drupal/templates/drupal-deployment.yaml
+++ b/drupal/templates/drupal-deployment.yaml
@@ -39,6 +39,9 @@ spec:
           exec:
             command: ['/bin/bash', '-c', '/php-fpm-probe.sh']
         lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep","10"]
           postStart:
             exec:
               command:
@@ -91,6 +94,10 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 8080
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sleep","10"]
         resources:
           {{- .Values.nginx.resources | toYaml | nindent 10 }}
 


### PR DESCRIPTION
…s. This way any traffic that got sent to it before termination command was given, gets served.