### PR TITLE
Feature/release 20220630

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.125
+version: 0.3.126
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -432,8 +432,12 @@ fi
   {{- if eq $mount.enabled true -}}
   if [ -d "/app/reference-data/{{ $index }}" ] && [ -n "$(ls /app/reference-data/{{ $index }})" ]; then
     echo "Importing {{ $index }} files"
-    for f in /app/reference-data/{{ $index }}/*; do
-      rsync -r --temp-dir=/tmp/ $f "{{ $mount.mountPath }}" &
+    # skip subfolders
+    rsync -r --delete --temp-dir=/tmp/ --filter "- */" "/app/reference-data/{{ $index }}/" "{{ $mount.mountPath }}" &
+    # run rsync for each subfolder
+    for f in /app/reference-data/{{ $index }}/*/; do
+      subfolder="$(realpath -s $f)"
+      rsync -r --delete --temp-dir=/tmp/ "${subfolder}" "{{ $mount.mountPath }}" &
     done
   fi
   {{ end -}}

--- a/drupal/templates/drupal-ingress.yaml
+++ b/drupal/templates/drupal-ingress.yaml
@@ -192,11 +192,11 @@ spec:
   {{- if $domain.ssl.enabled }}
   {{- if $domain.ssl.existingTLSSecret }}
   - secretName: {{ $domain.ssl.existingTLSSecret }}
-    hosts: 
+    hosts:
       - {{ $domain.hostname | quote }}
   {{- else }}
   - secretName: {{ $.Release.Name }}-tls-{{ $domain_index }}{{- if eq $domain.ssl.issuer "custom" }}-custom{{- end }}
-    hosts: 
+    hosts:
       - {{ $domain.hostname | quote }}
   {{- end }}
   {{- end }}
@@ -211,7 +211,7 @@ spec:
   - host: {{ $domain.hostname | quote }}
     http:
       paths:
-      - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
+      - path: /{{ if and ( eq $ingress.type "gce" ) ( and ( le $.Capabilities.KubeVersion.Major "1") ( le $.Capabilities.KubeVersion.Minor "18" ) ) }}*{{ end }}
         {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
         pathType: Prefix
         {{- end }}

--- a/drupal/tests/drupal_ingress_test.yaml
+++ b/drupal/tests/drupal_ingress_test.yaml
@@ -270,3 +270,83 @@ tests:
         equal:
           path: 'metadata.annotations.kubernetes\.io\/ingress\.global-static-ip-name'
           value: 'baz'
+
+  - it: exposeDomains - non-gce ingress path wildcard for kubernetes <1.19
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+      apiVersions:
+        - cert-manager.io/v1
+        - networking.k8s.io/v1
+    set:
+      exposeDomains:
+        bar:
+          hostname: foo.bar
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].http.paths[0].path
+          value: '/'
+
+  - it: exposeDomains - non-gce ingress path without wildcard for kubernetes 1.19+
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+      apiVersions:
+        - cert-manager.io/v1
+        - networking.k8s.io/v1
+    set:
+      exposeDomains:
+        bar:
+          hostname: foo.bar
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].http.paths[0].path
+          value: '/'
+
+  - it: exposeDomains - gce ingress path wildcard for kubernetes <1.19
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 17
+      apiVersions:
+        - cert-manager.io/v1
+        - networking.k8s.io/v1
+    set:
+      exposeDomains:
+        bar:
+          hostname: foo.bar
+          ingress: gce
+      ingress:
+        gce:
+          staticIpAddressName: baz
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].http.paths[0].path
+          value: '/*'
+
+  - it: exposeDomains - gce ingress path without wildcard for kubernetes 1.19+
+    template: drupal-ingress.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+      apiVersions:
+        - cert-manager.io/v1
+        - networking.k8s.io/v1
+    set:
+      exposeDomains:
+        bar:
+          hostname: foo.bar
+          ingress: gce
+      ingress:
+        gce:
+          staticIpAddressName: baz
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.rules[0].http.paths[0].path
+          value: '/'

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.70
+version: 0.2.71
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/ingress.yaml
+++ b/frontend/templates/ingress.yaml
@@ -60,8 +60,13 @@ spec:
   {{- if $ingress.tls }}
   tls:
   - secretName: {{ .Release.Name }}-tls{{- if eq $.Values.ssl.issuer "custom" }}-custom{{- end }}
+    hosts: 
+      - {{ include "frontend.domain" . | quote }}
   {{- range $index, $prefix := .Values.domainPrefixes }}
+  {{ $params := dict "prefix" $prefix -}}
   - secretName: {{ $.Release.Name }}-tls-p{{ $index }}{{- if eq $.Values.ssl.issuer "custom" }}-custom{{- end }}
+    hosts: 
+      - '{{ template "frontend.domain" (merge $params $ ) }}'
   {{- end }}
   {{- end }}
   rules:
@@ -179,6 +184,8 @@ spec:
   {{- if $domain.ssl }}
   {{- if $domain.ssl.enabled }}
   - secretName: {{ $.Release.Name }}-tls-{{ $domain_index }}{{- if eq $domain.ssl.issuer "custom" }}-custom{{- end }}
+    hosts: 
+      - {{ $domain.hostname | quote }}
   {{- end }}
   {{- end }}
   {{- end }}
@@ -191,7 +198,7 @@ spec:
   - host: {{ $domain.hostname }}
     http:
       paths:
-      - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
+      - path: /{{ if and ( eq $ingress.type "gce" ) ( and ( le $.Capabilities.KubeVersion.Major "1") ( le $.Capabilities.KubeVersion.Minor "18" ) ) }}*{{ end }}
         {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
         pathType: Prefix
         {{- end }}

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.31
+version: 0.2.32
 dependencies:
 - name: traefik
   version: 1.87.x

--- a/silta-cluster/README.md
+++ b/silta-cluster/README.md
@@ -26,7 +26,7 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.6.1 \
+  --version v1.8.0 \
   --set installCRDs=true \
   --set global.logLevel=1
 ```
@@ -101,6 +101,13 @@ helm upgrade --install --wait silta-cluster silta-cluster \
 
 - `local-values.yaml` contains overrides of [chart defaults](values.yaml) 
 
+## Compatibility
+
+- Kubernetes 1.24 requires at least 0.2.32
+- Kubernetes 1.23 requires at least 0.2.32
+- Kubernetes 1.22 requires at least 0.2.30
+- Kubernetes 1.20 requires at least 0.2.18
+- Should work with kubernetes 1.13+
 ## Upgrading
 
 Chart upgrades are managed like a normal helm release, though it's suggested to do helm diff first:
@@ -117,6 +124,8 @@ helm upgrade --install --wait silta-cluster silta-cluster \
 
 ## Upgrade path for older versions:
 
+ - Upgrading silta-cluster chart to 0.2.32 ([docs/Upgrading-to-0.2.32.md](docs/Upgrading-to-0.2.32.md))
+ 
  - Upgrading silta-cluster chart to 0.2.18 ([docs/Upgrading-to-0.2.18.md](docs/Upgrading-to-0.2.18.md))
 
  - Upgrading silta-cluster chart to 0.2.14 ([docs/Upgrading-to-0.2.14.md](docs/Upgrading-to-0.2.14.md))

--- a/silta-cluster/docs/Upgrading-to-0.2.32.md
+++ b/silta-cluster/docs/Upgrading-to-0.2.32.md
@@ -1,0 +1,14 @@
+# Upgrading silta-cluster chart to 0.2.32
+
+## Cert-manager 1.8.0 upgrade
+
+4. Upgrade cert-manager
+```bash
+helm upgrade --install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version v1.8.0 \
+  --set installCRDs=true \
+  --set global.logLevel=1
+```

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -21,6 +21,8 @@ traefik:
   ssl:
     enabled: true
     enforced: false
+    generateTLS: true
+    defaultCN: "*.silta.wdr.io"
     # Values from Mozilla SSL Configuration Generator
     # https://ssl-config.mozilla.org/#server=traefik&server-version=1.7.20&config=intermediate
     tlsMinVersion: "VersionTLS12"

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.29
+version: 0.2.30
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/ingress.yaml
+++ b/simple/templates/ingress.yaml
@@ -54,7 +54,9 @@ metadata:
 spec:
   {{- if $ingress.tls }}
   tls:
-  - secretName: {{ .Release.Name }}-tls{{- if eq $.Values.ssl.issuer "custom" }}-custom{{- end }}
+  - secretName: {{ .Release.Name }}-tls
+    hosts: 
+      - {{ template "simple.domain" . }}
   {{- end }}
   rules:
   - host: {{ template "simple.domain" . }}
@@ -150,7 +152,9 @@ spec:
   {{- if eq $domain.ingress $ingress_index }}
   {{- if $domain.ssl }}
   {{- if $domain.ssl.enabled }}
-  - secretName: {{ $.Release.Name }}-tls-{{ $domain_index }}{{- if eq $domain.ssl.issuer "custom" }}-custom{{- end }}
+  - secretName: {{ $.Release.Name }}-tls-{{ $domain_index }}
+    hosts:
+      - {{ $domain.hostname }}
   {{- end }}
   {{- end }}
   {{- end }}
@@ -163,7 +167,7 @@ spec:
   - host: {{ $domain.hostname }}
     http:
       paths:
-      - path: {{ if eq $ingress.type "gce" }}/*{{ else }}/{{ end }}
+      - path: /{{ if and ( eq $ingress.type "gce" ) ( and ( le $.Capabilities.KubeVersion.Major "1") ( le $.Capabilities.KubeVersion.Minor "18" ) ) }}*{{ end }}
         {{- if eq ( include "ingress.api-version" $ | trim ) "networking.k8s.io/v1" }}
         pathType: Prefix
         {{- end }}


### PR DESCRIPTION
drupal chart (0.3.126):
- Support for GKE Ingress on 1.19+ ([PR](https://github.com/wunderio/drupal-project-k8s/pull/504))
- referenceData subfolder rsync separation ([PR](https://github.com/wunderio/drupal-project-k8s/pull/503))

frontend chart (0.2.71):
- Support for GKE Ingress on 1.19+ ([PR](https://github.com/wunderio/frontend-project-k8s/pull/74))
- Include domains for TLS secrets -> [PR](https://github.com/wunderio/frontend-project-k8s/pull/74))

simple chart (0.2.30)
- Support for GKE Ingress on 1.19+ ([PR](https://github.com/wunderio/simple-project-k8s/pull/27))
- Include domains for TLS secrets ([PR](https://github.com/wunderio/simple-project-k8s/pull/27))

silta-cluster (0.2.32)
- Kubernetes 1.23 / 1.24 compatibility ([PR](https://github.com/wunderio/charts/pull/307))