### PR TITLE
Cluster tests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,331 @@
+# Create minikube test deployments on different kubernetes versions
+name: Silta chart tests 
+
+on:
+  # Run for pull requests, but there's an additional draft filter later on
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  schedule:
+    # Run compatability tests each Monday at 9
+    - cron: '0 9 * * 1'
+
+jobs:
+  minikube-test:
+    name: Minikube
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Available minikube kubernetes version list: 
+        # "minikube config defaults kubernetes-version"
+        # and https://kubernetes.io/releases/patch-releases/
+        kubernetes-version: ["v1.21.14", "v1.22.12", "v1.23.9", "v1.24.3", "latest"]
+    env:
+      CLUSTER_DOMAIN: minikube.local.wdr.io
+      K8S_PROJECT_REPO_DIR: k8s-project-repositories
+    if: github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Silta CLI setup
+        run: |
+          mkdir -p ~/.local/bin
+
+          # Latest tagged release
+          latest_release_url=$(curl -s https://api.github.com/repos/wunderio/silta-cli/releases/latest | jq -r '.assets[] | .browser_download_url | select(endswith("linux-amd64.tar.gz"))')
+          curl -sL $latest_release_url | tar xz -C ~/.local/bin
+
+          silta version
+      - name: Helm and repository setup
+        run: |
+          # Install Helm 3
+          HELM_VERSION=v3.6.3
+          curl -o /tmp/helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz \
+            && tar -zxvf /tmp/helm.tar.gz -C /tmp \
+            && mv /tmp/linux-amd64/helm ~/.local/bin/helm \
+            && helm repo add jetstack https://charts.jetstack.io \
+            && helm repo add instana https://agents.instana.io/helm \
+            && helm repo add nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner \
+            && helm repo add twun https://helm.twun.io \
+            && helm repo add bitnami https://charts.bitnami.com/bitnami \
+            && helm repo add minio https://helm.min.io/ \
+            && helm repo add wunderio https://storage.googleapis.com/charts.wdr.io \
+            && helm repo add percona https://percona.github.io/percona-helm-charts/ \
+            && helm repo add elastic https://helm.elastic.co \
+            && helm repo add codecentric https://codecentric.github.io/helm-charts \
+            && helm repo update
+
+      - name: Download and start minikube
+        run: |
+          CLUSTER_DOCKER_REGISTRY=registry.${CLUSTER_DOMAIN}:80
+
+          curl -Lo ~/.local/bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x ~/.local/bin/minikube
+          minikube start \
+            --kubernetes-version "${{ matrix.kubernetes-version }}" \
+            --insecure-registry "${CLUSTER_DOCKER_REGISTRY}" \
+            --cni auto \
+            --wait all 
+      # Could use "medyagh/setup-minikube" but it does not have a way to pass "--insecure-registry" flag
+      # https://github.com/medyagh/setup-minikube/pull/33  
+      # - name: Start minikube 1.21.14
+      #   with:
+      #     # "stable" for the latest stable build, or "latest" for the latest development build
+      #     kubernetes-version: v1.21.14
+      #     insecure-registry: "registry.minikube.local.wdr.io:80"
+      #   uses: medyagh/setup-minikube@master
+      - name: MetalLB setup
+        run: |
+          MINIKUBE_IP=$(minikube ip)
+
+          ##############
+          # MetalLB setup
+          # https://github.com/kubernetes/minikube/issues/10307#issuecomment-1024575716
+
+          METALLB_IP_START=${MINIKUBE_IP}
+          METALLB_IP_END=${MINIKUBE_IP}
+
+          minikube addons enable metallb
+          sleep 10
+
+          # Patch MetalLB config with updated IP address range
+          kubectl apply -f - -n metallb-system << EOF
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: config
+            namespace: metallb-system
+          data:
+            config: |
+              address-pools:
+              - name: default
+                protocol: layer2
+                addresses:
+                - ${METALLB_IP_START}-${METALLB_IP_END}
+          EOF
+
+          sleep 5
+
+          NAMESPACE=metallb-system
+          APP=metallb
+          TIMEOUT=20s
+
+          for COMPONENT in controller speaker
+          do
+            kubectl wait \
+              --for condition=ready pod \
+              -l app=${APP} -l component=${COMPONENT} \
+              -n ${NAMESPACE} \
+              --timeout=${TIMEOUT}
+          done
+
+      - name: silta-cluster chart setup and test
+        run: |
+          
+          helm upgrade --install \
+            cert-manager jetstack/cert-manager \
+            --namespace cert-manager \
+            --create-namespace \
+            --version v1.8.0 \
+            --set installCRDs=true \
+            --set global.logLevel=1 \
+            --wait
+
+          helm dependency build "./silta-cluster"
+
+          helm upgrade --install silta-cluster ./silta-cluster \
+            --create-namespace \
+            --namespace silta-cluster \
+            --set clusterDomain=${CLUSTER_DOMAIN} \
+            --values silta-cluster/test/values/minikube.yaml \
+            --wait
+
+          # Cluster landing page test
+          curl --resolve ${CLUSTER_DOMAIN}:443:${MINIKUBE_IP} https://${CLUSTER_DOMAIN} -ILk --fail
+          curl --resolve ${CLUSTER_DOMAIN}:80:${MINIKUBE_IP} --resolve ${CLUSTER_DOMAIN}:443:${MINIKUBE_IP} http://${CLUSTER_DOMAIN} -IL --fail
+
+      - name: Build Drupal chart images, deploy and test 
+        run: |
+
+          CLUSTER_DOCKER_REGISTRY=registry.${CLUSTER_DOMAIN}:80
+
+          # Check out drupal-project-k8s repo or use prebuilt images
+          if [ -d "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s" ]; then 
+              rm -Rf "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s"; 
+          fi
+          mkdir -p "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s"
+          git clone http://github.com/wunderio/drupal-project-k8s.git "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s"
+
+          # Composer install
+          # PHP_COMPOSER_VERSION=2.1.12
+          # php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
+          #   php composer-setup.php --version=${PHP_COMPOSER_VERSION} --install-dir=$HOME/.local/bin --filename=composer && \
+          #   php -r "unlink('composer-setup.php');" && \
+          #   composer --version
+
+          composer install -n --prefer-dist --ignore-platform-reqs --optimize-autoloader -d "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s"
+
+          # Tunnel to in-cluster docker registry. Required due to docker push inability to use selfsigned/insecure repositories that ain't local
+          # Find a free port. Credit: stefanobaghino / https://unix.stackexchange.com/posts/423052/revisions
+          DOCKER_REGISTRY_PORT=$(comm -23 <(seq 5000 6000 | sort) <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) | shuf | head -n 1)
+          BRIDGED_DOCKER_REGISTRY="localhost:${DOCKER_REGISTRY_PORT}"
+          kubectl -n silta-cluster port-forward service/silta-cluster-docker-registry $DOCKER_REGISTRY_PORT:80 2>&1 >/dev/null &
+
+          # Build images
+
+          NGINX_IMAGE=/drupal-project-k8s/test-drupal-nginx:latest
+          PHP_IMAGE=/drupal-project-k8s/test-drupal-php:latest
+          SHELL_IMAGE=/drupal-project-k8s/test-drupal-shell:latest
+
+          docker build --tag ${BRIDGED_DOCKER_REGISTRY}${NGINX_IMAGE} -f "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s/silta/nginx.Dockerfile" "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s/web"
+          docker image push ${BRIDGED_DOCKER_REGISTRY}${NGINX_IMAGE}
+          
+          docker build --tag ${BRIDGED_DOCKER_REGISTRY}${PHP_IMAGE} -f "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s/silta/php.Dockerfile" "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s"
+          docker image push ${BRIDGED_DOCKER_REGISTRY}${PHP_IMAGE}
+
+          docker build --tag ${BRIDGED_DOCKER_REGISTRY}${SHELL_IMAGE} -f "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s/silta/shell.Dockerfile" "${K8S_PROJECT_REPO_DIR}/drupal-project-k8s"
+          docker image push ${BRIDGED_DOCKER_REGISTRY}${SHELL_IMAGE}
+
+          # Dependency build for local chart
+          helm dependency build "./drupal"
+
+          silta ci release deploy \
+              --release-name test \
+              --chart-name ./drupal \
+              --branchname test \
+              --silta-environment-name test \
+              --nginx-image-url ${CLUSTER_DOCKER_REGISTRY}${NGINX_IMAGE} \
+              --php-image-url ${CLUSTER_DOCKER_REGISTRY}${PHP_IMAGE} \
+              --shell-image-url ${CLUSTER_DOCKER_REGISTRY}${SHELL_IMAGE} \
+              --cluster-domain "${CLUSTER_DOMAIN}" \
+              --cluster-type minikube \
+              --db-root-pass "rootpw" \
+              --db-user-pass "dbpw" \
+              --gitauth-username "test" \
+              --gitauth-password "test" \
+              --namespace drupal-project-k8s \
+              --helm-flags "--set ssl.issuer=selfsigned" \
+              --deployment-timeout 15m
+
+          kubectl exec -it deploy/test-shell -n drupal-project-k8s -- drush si -y
+
+          # Web request test
+          curl http://test.drupal-project-k8s.${CLUSTER_DOMAIN} \
+              --user silta:demo --location-trusted \
+              --head --insecure --location \
+              --resolve test.drupal-project-k8s.${CLUSTER_DOMAIN}:80:${MINIKUBE_IP} \
+              --resolve test.drupal-project-k8s.${CLUSTER_DOMAIN}:443:${MINIKUBE_IP} \
+              --retry 5 --retry-delay 5 \
+              --fail 
+
+      - name: Build Frontend chart images, deploy and test 
+        run: |
+
+          CLUSTER_DOCKER_REGISTRY=registry.${CLUSTER_DOMAIN}:80
+
+          # Checkout k8s repository
+          if [ -d "${K8S_PROJECT_REPO_DIR}/frontend-project-k8s" ]; then 
+              rm -Rf "${K8S_PROJECT_REPO_DIR}/frontend-project-k8s"; 
+          fi
+          mkdir -p "${K8S_PROJECT_REPO_DIR}/frontend-project-k8s"
+          git clone http://github.com/wunderio/frontend-project-k8s.git "${K8S_PROJECT_REPO_DIR}/frontend-project-k8s"
+
+          # npm install
+          cd "${K8S_PROJECT_REPO_DIR}/frontend-project-k8s/hello" && npm install && cd - 
+          cd "${K8S_PROJECT_REPO_DIR}/frontend-project-k8s/world" && npm install && cd - 
+
+          # Dependency build for local chart
+          helm dependency build ./frontend
+
+          # Tunnel to in-cluster docker registry. Required due to docker push inability to use selfsigned/insecure repositories that ain't local
+          # Find a free port. Credit: stefanobaghino / https://unix.stackexchange.com/posts/423052/revisions
+          DOCKER_REGISTRY_PORT=$(comm -23 <(seq 5000 6000 | sort) <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) | shuf | head -n 1)
+          BRIDGED_DOCKER_REGISTRY="localhost:${DOCKER_REGISTRY_PORT}"
+          kubectl -n silta-cluster port-forward service/silta-cluster-docker-registry $DOCKER_REGISTRY_PORT:80 2>&1 >/dev/null &
+
+          # Build images
+          HELLO_IMAGE=/frontend-project-k8s/test-frontend-hello:latest
+          WORLD_IMAGE=/frontend-project-k8s/test-frontend-world:latest
+
+          docker build --tag ${BRIDGED_DOCKER_REGISTRY}${HELLO_IMAGE} -f "${K8S_PROJECT_REPO_DIR}/frontend-project-k8s/silta/hello.Dockerfile" "${K8S_PROJECT_REPO_DIR}/frontend-project-k8s"
+          docker image push ${BRIDGED_DOCKER_REGISTRY}${HELLO_IMAGE}
+
+          docker build --tag ${BRIDGED_DOCKER_REGISTRY}${WORLD_IMAGE} -f "${K8S_PROJECT_REPO_DIR}/frontend-project-k8s/silta/world.Dockerfile" "${K8S_PROJECT_REPO_DIR}/frontend-project-k8s"
+          docker image push ${BRIDGED_DOCKER_REGISTRY}${WORLD_IMAGE}
+
+          # Deploy
+          silta ci release deploy \
+            --release-name test \
+            --chart-name ./frontend \
+            --branchname test \
+            --silta-environment-name test \
+            --cluster-domain "${CLUSTER_DOMAIN}" \
+            --cluster-type minikube \
+            --namespace frontend-project-k8s \
+            --helm-flags "--set ssl.issuer=selfsigned --set services.hello.image=${CLUSTER_DOCKER_REGISTRY}${HELLO_IMAGE} --set services.world.image=${CLUSTER_DOCKER_REGISTRY}${WORLD_IMAGE} --set services.hello.exposedRoute=/hello --set services.world.exposedRoute=/world" \
+            --deployment-timeout 15m
+
+            # Web request test
+            curl http://test.frontend-project-k8s.${CLUSTER_DOMAIN}/hello \
+              --user silta:demo --location-trusted \
+              --head --insecure --location \
+              --resolve test.frontend-project-k8s.${CLUSTER_DOMAIN}:80:${MINIKUBE_IP} \
+              --resolve test.frontend-project-k8s.${CLUSTER_DOMAIN}:443:${MINIKUBE_IP} \
+              --retry 5 --retry-delay 5 \
+              --fail
+            curl http://test.frontend-project-k8s.${CLUSTER_DOMAIN}/world \
+              --user silta:demo --location-trusted \
+              --head --insecure --location \
+              --resolve test.frontend-project-k8s.${CLUSTER_DOMAIN}:80:${MINIKUBE_IP} \
+              --resolve test.frontend-project-k8s.${CLUSTER_DOMAIN}:443:${MINIKUBE_IP} \
+              --retry 5 --retry-delay 5 \
+              --fail
+
+      - name: Build Simple chart images, deploy and test 
+        run: |
+
+          CLUSTER_DOCKER_REGISTRY=registry.${CLUSTER_DOMAIN}:80
+
+          # Checkout k8s repository
+          if [ -d "${K8S_PROJECT_REPO_DIR}/simple-project-k8s" ]; then 
+              rm -Rf "${K8S_PROJECT_REPO_DIR}/simple-project-k8s"; 
+          fi
+          mkdir -p "${K8S_PROJECT_REPO_DIR}/simple-project-k8s"
+          git clone http://github.com/wunderio/simple-project-k8s.git "${K8S_PROJECT_REPO_DIR}/simple-project-k8s"
+
+          # Dependency build for local chart
+          helm dependency build ./simple
+
+          # Build images
+          SIMPLE_NGINX_IMAGE=/simple-project-k8s/test-simple-nginx:latest
+
+          # Tunnel to in-cluster docker registry. Required due to docker push inability to use selfsigned/insecure repositories that ain't local
+          # Find a free port. Credit: stefanobaghino / https://unix.stackexchange.com/posts/423052/revisions
+          DOCKER_REGISTRY_PORT=$(comm -23 <(seq 5000 6000 | sort) <(ss -Htan | awk '{print $4}' | cut -d':' -f2 | sort -u) | shuf | head -n 1)
+          BRIDGED_DOCKER_REGISTRY="localhost:${DOCKER_REGISTRY_PORT}"
+          kubectl -n silta-cluster port-forward service/silta-cluster-docker-registry $DOCKER_REGISTRY_PORT:80 2>&1 >/dev/null &
+
+          docker build --tag ${BRIDGED_DOCKER_REGISTRY}${SIMPLE_NGINX_IMAGE} -f "${K8S_PROJECT_REPO_DIR}/simple-project-k8s/silta/nginx.Dockerfile" "${K8S_PROJECT_REPO_DIR}/simple-project-k8s/hello"
+          docker image push ${BRIDGED_DOCKER_REGISTRY}${SIMPLE_NGINX_IMAGE}
+
+          silta ci release deploy \
+              --release-name test \
+              --chart-name ./simple \
+              --branchname test \
+              --silta-environment-name test \
+              --cluster-domain "${CLUSTER_DOMAIN}" \
+              --cluster-type minikube \
+              --namespace simple-project-k8s \
+              --nginx-image-url ${CLUSTER_DOCKER_REGISTRY}${SIMPLE_NGINX_IMAGE} \
+              --helm-flags "--set ssl.issuer=selfsigned" \
+              --deployment-timeout 15m
+
+          # Web request test
+          curl http://test.simple-project-k8s.${CLUSTER_DOMAIN} \
+              --user silta:demo --location-trusted \
+              --head --insecure --location \
+              --resolve test.simple-project-k8s.${CLUSTER_DOMAIN}:80:${MINIKUBE_IP} \
+              --resolve test.simple-project-k8s.${CLUSTER_DOMAIN}:443:${MINIKUBE_IP} \
+              --retry 5 --retry-delay 5 \
+              --fail

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.tgz
 .idea
+k8s-project-repositories
+helm-output.log

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.32
+version: 0.2.33
 dependencies:
 - name: traefik
   version: 1.87.x

--- a/silta-cluster/templates/ingress.yaml
+++ b/silta-cluster/templates/ingress.yaml
@@ -1,38 +1,52 @@
 ---
+{{- $ingress := .Values.ingress }}
 apiVersion: {{ include "silta-cluster.ingress-api-version" . | trim }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress.class | quote }}
+    kubernetes.io/ingress.class: {{ $ingress.class | quote }}
     {{- if .Values.ssl.enabled }}
-    {{- if eq .Values.ingress.class "traefik" }}
+    {{- if eq $ingress.class "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http,https"
     {{- end }}
-    ingress.kubernetes.io/ssl-redirect: "true"
+
+    {{- $redirect_https := false }}
+    {{- if (hasKey $ingress "redirect-https") }}
+    {{- $redirect_https = (index $ingress "redirect-https") }}
+    {{- end }}
+    {{- if not $ingress.tls }}
+    {{- $redirect_https = false }}
+    {{- end }}
+    {{- if $redirect_https }}
+    ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- if eq $ingress.type "azure/application-gateway" }}
+    appgw.ingress.kubernetes.io/ssl-redirect: {{ $redirect_https | quote }}
+    {{- end }}
+    {{- end }}
+    
     {{- if eq ( include "silta-cluster.cert-manager-api-version" . | trim ) "cert-manager.io/v1" }}
     acme.cert-manager.io/http01-edit-in-place: "true"
     {{- else }}
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
     {{- end }}
     {{- else }}
-    {{- if eq .Values.ingress.class "traefik" }}
+    {{- if eq $ingress.class "traefik" }}
     traefik.ingress.kubernetes.io/frontend-entry-points: "http"
     {{- end }}
-    ingress.kubernetes.io/ssl-redirect: "false"
     {{- end }}
-    {{- if eq .Values.ingress.class "gce" }}
+    {{- if eq $ingress.class "gce" }}
     cert-manager.io/cluster-issuer: letsencrypt
     {{- end }}
-    {{- if .Values.ingress.staticIpAddressName }}
-    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.staticIpAddressName | quote }}
+    {{- if $ingress.staticIpAddressName }}
+    kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
-    {{- if eq .Values.ingress.class "azure/application-gateway" }}
+    {{- if eq $ingress.class "azure/application-gateway" }}
     cert-manager.io/cluster-issuer: letsencrypt
     appgw.ingress.kubernetes.io/health-probe-status-codes: "200-399, 401-404"
     {{- end }}
-    {{- if .Values.ingress.extraAnnotations }}
-    {{- .Values.ingress.extraAnnotations | toYaml | nindent 4 }}
+    {{- if $ingress.extraAnnotations }}
+    {{- $ingress.extraAnnotations | toYaml | nindent 4 }}
     {{- end }}
 spec:
   {{- if .Values.ssl.enabled }}

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -14,8 +14,9 @@ spec:
   ports:
     - name: ssh
       port: {{ .Values.gitAuth.port }}
+      targetPort: 22
   type: "LoadBalancer"
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: {{ .Values.gitAuth.externalTrafficPolicy }}
 {{- if .Values.gitAuth.loadBalancerIP }}
   loadBalancerIP: {{ .Values.gitAuth.loadBalancerIP }}
 {{- end }}
@@ -58,7 +59,7 @@ spec:
           - name: GITAUTH_PASSWORD
             value: {{ .Values.gitAuth.keyserver.password | default .Values.sshKeyServer.apiPassword | quote }}
           - name: GITAUTH_SCOPE
-            value: {{ required "A valid .Values.gitAuth.scope entry required!" .Values.gitAuth.scope | quote }}
+            value: {{ .Values.gitAuth.scope | quote }}
           - name: OUTSIDE_COLLABORATORS
             value: {{ .Values.gitAuth.outsideCollaborators | default true | quote }}
           {{- end }}

--- a/silta-cluster/test/values/minikube.yaml
+++ b/silta-cluster/test/values/minikube.yaml
@@ -1,0 +1,60 @@
+traefik:
+  replicas: 1
+  ssl:
+    enabled: true
+  service:
+    annotations:
+      metallb.universe.tf/allow-shared-ip: "shared"
+  # metallb shared ip works only with "Cluster" TP
+  externalTrafficPolicy: Cluster
+
+ssl:
+  enabled: true
+  email: admin@example.com
+  issuer: selfsigned
+  
+csi-rclone:
+  enabled: true
+  params:
+    remote: "s3"
+    remotePath: "projectname"
+    
+    # Minio as S3 provider
+    s3-provider: "Minio"
+    s3-endpoint: "http://silta-cluster-minio:9000"
+    # Default credentials of minio chart https://github.com/minio/charts/blob/master/minio/values.yaml
+    s3-access-key-id: "YOURACCESSKEY"
+    s3-secret-access-key: "YOURSECRETKEY"
+  # nodePlugin:
+  #   kubeletBasePath: "/var/snap/microk8s/common/var/lib/kubelet"
+
+minio:
+  enabled: true
+  resources:
+    requests:
+      memory: 512M
+  persistence:
+    size: 5Gi
+
+gitAuth:
+  enabled: true
+  port: 2222
+  keyserver:
+    enabled: false
+  authorizedKeys: []
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "shared"
+  # metallb shared ip works only with "Cluster" TP 
+  externalTrafficPolicy: Cluster
+  
+sshKeyServer:
+  enabled: false
+
+# Deployment remover
+deploymentRemover:
+  enabled: false
+
+docker-registry:
+  enabled: true
+  secrets:
+    htpasswd: false

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -4,10 +4,11 @@ clusterDomain: "silta.wdr.io"
 ingress:
   # Options: traefik, gce, azure/application-gateway, etc.
   class: traefik
+  redirect-https: true
   # Custom ingress annotations
   extraAnnotations: {}
   #  networking.gke.io/suppress-firewall-xpn-error: "true"
-
+  
 # https://github.com/wunderio/charts/blob/master/legacy_traefik/values.yaml
 traefik:
   enabled: true
@@ -111,6 +112,7 @@ gitAuth:
   resources: {}
   # The static IP to be used for the exposed endpoint.
   loadBalancerIP: null
+  externalTrafficPolicy: Local
 
 # SSH keyserver (keys.[clusterDomain])
 sshKeyServer:

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.30
+version: 0.2.31
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/configmap.yaml
+++ b/simple/templates/configmap.yaml
@@ -97,7 +97,7 @@ data:
         }
 
         # List health checks that need to return status 200 here
-        map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; }
+        map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; 'kube-probe' 1; }
                                                                                                                                                      
         include conf.d/*.conf;                                                                                                                             
     }     

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
           httpGet:
             path: /
             port: 8080
+            httpHeaders:
+              - name: User-Agent
+                value: kube-probe
         resources:
 {{ .Values.nginx.resources | toYaml | indent 10 }}
 


### PR DESCRIPTION
simple chart (0.2.31):
  - Set and allow custom UA for http probes (solves 401 for http readiness probes when pod ip range is not allowlisted) 

silta-cluster (0.2.33):
  - Allow disabling ssl redirects for silta-cluster services ingress
  - Allow overriding jumphost externalTrafficPolicy to enable ip sharing on MetalLB
  - Silta chart compatibility tests on different kubernetes versions (via minikube) on Github Actions (weekly and for PR's)   