### PR TITLE
Silta container base image migration to Docker Hub

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -505,7 +505,7 @@ varnish:
     requests:
       cpu: 25m
       memory: 32Mi
-  image: eu.gcr.io/silta-images/varnish
+  image: wunderio/silta-varnish
   imageTag: 6-v0.2
   # https://varnish-cache.org/docs/6.6/users-guide/storage-backends.html
   storageBackend: 'file,/var/lib/varnish/varnish_storage.bin,512M'
@@ -615,7 +615,7 @@ mailhog:
   enabled: false
   image:
     # Set image repository to "mailhog/mailhog" to reenable logging.
-    repository: eu.gcr.io/silta-images/silta-mailhog
+    repository: wunderio/silta-mailhog
     # Set image tag to "" to reenable logging.
     tag: silent
   resources:
@@ -635,7 +635,7 @@ smtp:
 solr:
   enabled: false
   # Available image tags: https://hub.docker.com/r/geerlingguy/solr/tags
-  image: eu.gcr.io/silta-images/solr
+  image: wunderio/silta-solr
   imageTag: 8
 
   # Solr 4.x and 5.x does not support "-force" argument (optional override)

--- a/frontend/templates/backup-cron.yaml
+++ b/frontend/templates/backup-cron.yaml
@@ -21,7 +21,7 @@ spec:
           enableServiceLinks: false
           initContainers:
             - name: backup-linking
-              image: eu.gcr.io/silta-images/rsync:latest
+              image: wunderio/silta-rsync:latest
               command: ["/bin/bash", "-c"]
               args:
                 - |
@@ -39,7 +39,7 @@ spec:
                   name: shared-data
           containers:
           - name: backup
-            image: eu.gcr.io/silta-images/rsync:latest
+            image: wunderio/silta-rsync:latest
             volumeMounts:
               {{- range $index, $mount := $.Values.mounts -}}
               {{- if eq $mount.enabled true }}

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -96,7 +96,7 @@ domainPrefixes: []
 
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:
-  image: 'wunderio/drupal-nginx:v0.1'
+  image: 'wunderio/silta-nginx:v0.1'
 
   replicas: 1
 

--- a/silta-proxy/values.yaml
+++ b/silta-proxy/values.yaml
@@ -1,6 +1,6 @@
 # Default values for silta-proxy.
 
-image: eu.gcr.io/silta-images/silta-proxy
+image: wunderio/silta-proxy
 tag: "latest"
 
 service:


### PR DESCRIPTION
Silta docker container images are being migrated from [Google Container Registry](https://eu.gcr.io/silta-images/) to [Docker Hub](https://hub.docker.com/u/wunderio).
This PR changes base image location to the new image registry and adjusts some image names.

Please review adjusted image paths and make sure this PR only changes relevant configuration files.

This pull request was created with https://github.com/wunderio/internal-mass-updater.