### PR TITLE
Single subdomain option

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.129
+version: 0.3.130
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/_domains.tpl
+++ b/drupal/templates/_domains.tpl
@@ -1,5 +1,13 @@
 
 
+{{- define "drupal.domainSeperator" -}}
+{{- if .Values.singleSubdomain -}}
+-
+{{- else -}}
+.
+{{- end -}}
+{{- end -}}
+
 {{- define "drupal.domain" -}}
 {{- $projectName := regexReplaceAll "[^[:alnum:]]" (.Values.projectName | default .Release.Namespace) "-"  | trimSuffix "-" | lower }}
 {{- $projectNameHash := sha256sum $projectName | trunc 3 }}
@@ -10,11 +18,11 @@
 {{- if .prefix -}}
 {{- $maxEnvironmentNameLength := int (sub 61 (add (len .Values.clusterDomain) (len $projectName) (len .prefix))) }}
 {{- $environmentName := (ge (len $environmentName) $maxEnvironmentNameLength) | ternary (print ($environmentName | trunc (int (sub $maxEnvironmentNameLength 3))) $environmentNameHash) $environmentName -}}
-{{ .prefix }}.{{ $environmentName }}.{{ $projectName }}.{{ .Values.clusterDomain }}
+{{ .prefix }}{{ include "drupal.domainSeperator" . }}{{ $environmentName }}{{ include "drupal.domainSeperator" . }}{{ $projectName }}.{{ .Values.clusterDomain }}
 {{- else -}}
 {{- $maxEnvironmentNameLength := int (sub 62 (add (len .Values.clusterDomain) (len $projectName))) }}
 {{- $environmentName := (ge (len $environmentName) $maxEnvironmentNameLength) | ternary (print ($environmentName | trunc (int (sub $maxEnvironmentNameLength 3))) $environmentNameHash) $environmentName -}}
-{{ $environmentName }}.{{ $projectName }}.{{ .Values.clusterDomain }}
+{{ $environmentName }}{{ include "drupal.domainSeperator" . }}{{ $projectName }}.{{ .Values.clusterDomain }}
 {{- end -}}
 {{- end -}}
 

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -20,6 +20,7 @@
     "exposeDomains": { "type": "object", "items": { "type": "object"}},
     "exposeDomainsDefaults": { "type": "object"},
     "domainPrefixes": { "type": "array", "items": { "type": "string"}},
+    "singleSubdomain": { "type": "boolean"},
     "ssl": { "type": "object" },
     "backendConfig": { "type": ["array","object"], "items": { "type": "object"}},
     "ingress": { "type": "object" },

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -113,6 +113,10 @@ backendConfig:
 # domainPrefixes: ['en', 'fi']
 domainPrefixes: []
 
+# Domains by default are created following pattern branch.repository.cluster
+# By enabling single subdomain it will be converted to branch-repository.cluster
+singleSubdomain: false
+
 # Settings for default site provided by this deployment
 ssl:
   # Enable HTTPS for this deployment


### PR DESCRIPTION
**Allows setting single subdomain.**

**Reasoning:**
_By default sites use branch.repo.cluster. If prefixes are enabled then there are even higher level of subdomains. This block using custom wildcard certificates._

**Features:**
-  Adds "singleSubdomain" flag to set "-" as a prefix, branch and repo separator.
- Set flag to "false" by default to not break any existing implementations

Tested on [drupal-project-k8s](https://github.com/wunderio/drupal-project-k8s/tree/single-subdomain). 
CI output [here](https://app.circleci.com/pipelines/github/wunderio/drupal-project-k8s/4195/workflows/5286f7c4-7113-4204-b182-b615ffdf8dc5/jobs/14298).