### PR TITLE
Improve file backup job to ignore tar warnings

### DIFF
--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -488,7 +488,7 @@ fi
   # File backup for {{ $index }} volume.
   # If files get changed while the tar command is running, tar will exit with code 1. We ignore this as we want the rest of the job to still get run.
   echo "Starting {{ $index }} volume backup."
-  tar -czP --exclude=css --exclude=js --exclude=styles -f $BACKUP_LOCATION/{{ $index }}.tar.gz {{ $mount.mountPath }}  || ( export exitcode=$?; [[ $exitcode -eq 1 ]] || exit
+  tar -czP --exclude=css --exclude=js --exclude=styles -f $BACKUP_LOCATION/{{ $index }}.tar.gz {{ $mount.mountPath }} || ( export exitcode=$?; [[ $exitcode -eq 1 ]] || exit )
   {{- end -}}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
Identical to https://github.com/wunderio/drupal-project-k8s/pull/524

*Changes proposed:**
- Append the drupal backup tar command in order to ignore tar exit code 1

**Reasoning:**

I noticed the backup cron job to fail multiple times, and the last line in logs was `backup tar: /app/web/sites/default/files: file changed as we read it`.

If any files change while tar is creating an archive, it will exit with code 1 and the rest of the backup job will not get run.
From [tar docs](https://www.gnu.org/software/tar/manual/html_section/Synopsis.html): 

> If tar was given ‘--create’, ‘--append’ or ‘--update’ option, this exit code [1] means that some files were changed while being archived and so the resulting archive does not contain the exact copy of the file set.

Changes are based on https://stackoverflow.com/a/49112839/12416374
