### PR TITLE
Test charts on kubernetes 1.25

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         # Available minikube kubernetes version list: 
         # "minikube config defaults kubernetes-version"
         # and https://kubernetes.io/releases/patch-releases/
-        kubernetes-version: ["v1.21.14", "v1.22.13", "v1.23.10", "v1.24.4", "1.25.1", "latest"]
+        kubernetes-version: ["v1.21.14", "v1.22.13", "v1.23.10", "v1.24.4", "v1.25.0", "latest"]
     env:
       CLUSTER_DOMAIN: minikube.local.wdr.io
       K8S_PROJECT_REPO_DIR: k8s-project-repositories

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         # Available minikube kubernetes version list: 
         # "minikube config defaults kubernetes-version"
         # and https://kubernetes.io/releases/patch-releases/
-        kubernetes-version: ["v1.21.14", "v1.22.12", "v1.23.9", "v1.24.3", "latest"]
+        kubernetes-version: ["v1.21.14", "v1.22.13", "v1.23.10", "v1.24.4", "1.25.1", "latest"]
     env:
       CLUSTER_DOMAIN: minikube.local.wdr.io
       K8S_PROJECT_REPO_DIR: k8s-project-repositories

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -55,6 +55,7 @@ jobs:
             && helm repo add percona https://percona.github.io/percona-helm-charts/ \
             && helm repo add elastic https://helm.elastic.co \
             && helm repo add codecentric https://codecentric.github.io/helm-charts \
+            && helm plugin install https://github.com/quintush/helm-unittest --version 0.2.4 \
             && helm repo update
 
       - name: Download and start minikube
@@ -190,6 +191,12 @@ jobs:
           # Dependency build for local chart
           helm dependency build "./drupal"
 
+          # Chart unit tests
+          helm unittest ./drupal --helm3
+
+          # Dry-run drupal chart with test values
+          helm install --dry-run --generate-name ./drupal --values drupal/test.values.yaml
+
           silta ci release deploy \
               --release-name test \
               --chart-name ./drupal \
@@ -237,6 +244,12 @@ jobs:
 
           # Dependency build for local chart
           helm dependency build ./frontend
+
+          # Chart unit tests
+          helm unittest ./frontend --helm3
+
+          # Dry-run drupal chart with test values
+          helm install --dry-run --generate-name ./frontend --values frontend/test.values.yaml
 
           # Tunnel to in-cluster docker registry. Required due to docker push inability to use selfsigned/insecure repositories that ain't local
           # Find a free port. Credit: stefanobaghino / https://unix.stackexchange.com/posts/423052/revisions
@@ -296,6 +309,12 @@ jobs:
 
           # Dependency build for local chart
           helm dependency build ./simple
+
+          # Chart unit tests
+          helm unittest ./simple --helm3
+
+          # Dry-run drupal chart with test values
+          helm install --dry-run --generate-name ./simple --values simple/test.values.yaml
 
           # Build images
           SIMPLE_NGINX_IMAGE=/simple-project-k8s/test-simple-nginx:latest


### PR DESCRIPTION
This PR is for testing 1.25 compatibility.
- adds helm unittests
- adds helm dry-run tests