### PR TITLE
Drupal: nginx configuration snippet templating

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.133
+version: 0.3.134
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -173,6 +173,8 @@ imagePullSecrets:
   value: "{{ .Values.projectName | default .Release.Namespace }}"
 - name: ENVIRONMENT_NAME
   value: "{{ .Values.environmentName }}"
+- name: RELEASE_NAME
+  value: "{{ .Release.Name }}"
 - name: DRUSH_OPTIONS_URI
   value: "http://{{- template "drupal.domain" . }}"
 {{- include "drupal.db-env" . }}

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -313,7 +313,7 @@ data:
 
         {{- if .Values.nginx.serverExtraConfig }}
         # Custom configuration gets included here
-        {{- .Values.nginx.serverExtraConfig | nindent 8 }}
+        {{- tpl .Values.nginx.serverExtraConfig . | nindent 8 }}
         {{- end }}
 
         {{- if .Values.mailhog.enabled }}
@@ -354,7 +354,7 @@ data:
 
             # Custom configuration gets included here
             {{ if .Values.nginx.locationExtraConfig }}
-            {{ .Values.nginx.locationExtraConfig | nindent 10 }}
+            {{ tpl .Values.nginx.locationExtraConfig . | nindent 10 }}
             {{- end }}
 
             location ~* /system/files/ {
@@ -680,7 +680,7 @@ data:
 
 {{- if .Values.nginx.extraConfig }}
   extraConfig: |
-  {{ .Values.nginx.extraConfig | nindent 4 }}
+  {{ tpl .Values.nginx.extraConfig . | nindent 4 }}
 {{- end }}
 
 {{ $proxy := ( index .Values "silta-release" ).proxy }}

--- a/drupal/templates/drupal-deployment.yaml
+++ b/drupal/templates/drupal-deployment.yaml
@@ -52,6 +52,10 @@ spec:
       - name: nginx
         image: {{ .Values.nginx.image | quote }}
         env:
+        - name: RELEASE_NAME
+          value: "{{ .Release.Name }}"
+        - name: PROJECT_NAME
+          value: "{{ .Values.projectName | default .Release.Namespace }}"
         ports:
         - containerPort: 8080
           name: drupal

--- a/drupal/tests/nginx-extra-config_test.yaml
+++ b/drupal/tests/nginx-extra-config_test.yaml
@@ -6,6 +6,33 @@ capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
+  - it: extraConfig templating
+    template: drupal-configmap.yaml
+    set:
+      nginx.extraConfig: |
+        add_header X-Release-Name extraconfig-{{ .Release.Name }};  
+    asserts:
+    - matchRegex:
+        path: data.extraConfig
+        pattern: "add_header X-Release-Name extraconfig-RELEASE-NAME;"
+  - it: serverExtraConfig templating
+    template: drupal-configmap.yaml
+    set:
+      nginx.serverExtraConfig: |
+        # serverextraconfig test {{ .Release.Name }}  
+    asserts:
+    - matchRegex:
+        path: data.drupal_conf
+        pattern: "# serverextraconfig test RELEASE-NAME"
+  - it: locationExtraConfig templating
+    template: drupal-configmap.yaml
+    set:
+      nginx.locationExtraConfig: |
+        # locationextraconfig test {{ .Release.Name }}  
+    asserts:
+    - matchRegex:
+        path: data.drupal_conf
+        pattern: "# locationextraconfig test RELEASE-NAME"
   - it: populates extraConfig variable and check if its configmap gets mad
     template: drupal-deployment.yaml
     set:


### PR DESCRIPTION
1. Adds RELEASE_NAME and PROJECT_NAME environment variables to nginx container for potential envplate configuration file templating
2. Adds RELEASE_NAME environment variable to drupal/shell/cron containers. This can be used for pointing internal requests to related deployments.
3. Treats nginx extra configuration snippets as templates by wrapping variables into tpl function. This allows using helm variables in configuration snippets. Useful for internal request creation.