### PR TITLE
csi-rclone image with tini init

### DIFF
--- a/csi-rclone/Chart.yaml
+++ b/csi-rclone/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: CSI plugin for rclone mount
 name: csi-rclone
-version: 0.2.3
+version: 0.3.0

--- a/csi-rclone/README.md
+++ b/csi-rclone/README.md
@@ -6,6 +6,8 @@ This helm chart helps setting up resources for https://github.com/wunderio/csi-r
 
 Service account for setting up resources into kube-system namespace. 
 
+csi-rclone chart version greater than 0.3.0 requires csi-rclone:1.3.0+ images with tini. 1.2.x images will break deployment so value overrides need to be adjusted accordingly!  
+
 ## Usage
 
 1. Set up storage backend. You can use [Minio](https://min.io/), Amazon S3 compatible cloud storage service.

--- a/csi-rclone/templates/1.13-csi-controller-rclone.yaml
+++ b/csi-rclone/templates/1.13-csi-controller-rclone.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: csi-controller-rclone
     spec:
+      enableServiceLinks: false
       serviceAccountName: csi-controller-rclone
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
@@ -52,6 +53,7 @@ spec:
           image: wunderio/csi-rclone:{{- .Values.version }}
           imagePullPolicy: Always
           args :
+            - "/bin/csi-rclone-plugin"
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"

--- a/csi-rclone/templates/1.13-csi-nodeplugin-rclone.yaml
+++ b/csi-rclone/templates/1.13-csi-nodeplugin-rclone.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: csi-nodeplugin-rclone
     spec:
+      enableServiceLinks: false
       serviceAccountName: csi-nodeplugin-rclone
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
@@ -51,6 +52,7 @@ spec:
           image: wunderio/csi-rclone:{{- .Values.version }}
           imagePullPolicy: Always
           args:
+            - "/bin/csi-rclone-plugin"
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"

--- a/csi-rclone/templates/1.19-csi-controller-rclone.yaml
+++ b/csi-rclone/templates/1.19-csi-controller-rclone.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: csi-controller-rclone
     spec:
+      enableServiceLinks: false
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
@@ -39,6 +40,7 @@ spec:
         - name: rclone
           image: wunderio/csi-rclone:{{- .Values.version }}
           args :
+            - "/bin/csi-rclone-plugin"
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
           env:

--- a/csi-rclone/templates/1.19-csi-nodeplugin-rclone.yaml
+++ b/csi-rclone/templates/1.19-csi-nodeplugin-rclone.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: csi-nodeplugin-rclone
     spec:
+      enableServiceLinks: false
       serviceAccountName: csi-nodeplugin-rclone
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
@@ -50,6 +51,7 @@ spec:
             allowPrivilegeEscalation: true
           image: wunderio/csi-rclone:{{- .Values.version }}
           args:
+            - "/bin/csi-rclone-plugin"
             - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
           env:

--- a/csi-rclone/values.yaml
+++ b/csi-rclone/values.yaml
@@ -5,7 +5,7 @@ storageClass:
   name: "rclone"
 
 # rclone CSI plugin image release version. https://cloud.docker.com/u/wunderio/repository/docker/wunderio/csi-rclone
-version: v1.2.8
+version: v1.3.0
 
 # use default parameters. You might want set this to false when using as subchart.
 defaultParams: true


### PR DESCRIPTION
Important notice: this release requires csi-rclone:1.3.0+ images. 1.2.x will break deployment so value overrides need to be adjusted accordingly!