### PR TITLE
Use updated mariadb subchart fork, disable mariadb enableServiceLinks by default

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.136
+version: 0.3.137
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -500,6 +500,7 @@ mariadb:
               operator: NotIn
               values:
               - static-ip
+  enableServiceLinks: false
 
 varnish:
   # See https://github.com/wunderio/silta/blob/master/docs/silta-examples.md#using-varnish

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.74
+version: 0.2.75
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -358,6 +358,7 @@ mariadb:
               operator: NotIn
               values:
               - static-ip
+  enableServiceLinks: false
 
 elasticsearch:
   enabled: false


### PR DESCRIPTION
- Uses updated mariadb subchart fork (https://github.com/wunderio/charts/pull/331 and https://github.com/wunderio/charts/pull/334)
- Disable mariadb enableServiceLinks in `drupal` and `frontend` charts by default