### PR TITLE
Feature/release 20221006

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.137
+version: 0.3.138
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/drupal-certificate.yaml
+++ b/drupal/templates/drupal-certificate.yaml
@@ -188,7 +188,9 @@ metadata:
     {{- include "drupal.release_labels" $ | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $domain.ssl.ca | default "" | b64enc }}
+  {{- if $domain.ssl.ca }}
+  tls.ca: {{ $domain.ssl.ca | default "" | b64enc }}
+  {{- end }}
   tls.crt: {{ $domain.ssl.crt | default "" | b64enc }}
   tls.key: {{ $domain.ssl.key | default "" | b64enc }}
 ---

--- a/drupal/templates/drupal-deployment.yaml
+++ b/drupal/templates/drupal-deployment.yaml
@@ -178,6 +178,29 @@ spec:
     name: {{ .Release.Name }}-drupal
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if .Values.autoscaling.metrics }}
   metrics:
-    {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+  {{- if eq ( include "drupal.autoscaling.api-version" . | trim ) "autoscaling/v2beta1" }}
+  {{- range .Values.autoscaling.metrics }}
+  - type: Resource
+    resource:
+      name: {{ .resource.name }}
+      {{- if .resource.targetAverageUtilization }}
+      targetAverageUtilization: {{ .resource.targetAverageUtilization }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if eq ( include "drupal.autoscaling.api-version" . | trim ) "autoscaling/v2" }}
+  {{- range .Values.autoscaling.metrics }}
+  - type: Resource
+    resource:
+      name: {{ .resource.name }}
+      {{- if .resource.targetAverageUtilization }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .resource.targetAverageUtilization }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/drupal/templates/drupal-service.yaml
+++ b/drupal/templates/drupal-service.yaml
@@ -7,7 +7,7 @@ metadata:
     auto-downscale/down: "false"
     {{- end }}
     {{- if eq .Values.cluster.type "gke" }}
-    beta.cloud.google.com/backend-config: '{"ports": {"80":"{{ .Release.Name }}-drupal"}}'
+    cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Release.Name }}-drupal"}}'
     {{- end }}
     {{- if .Values.cluster }}
     {{- if .Values.cluster.vpcNative }}

--- a/drupal/templates/varnish-service.yaml
+++ b/drupal/templates/varnish-service.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if (index .Values "silta-release").downscaler.enabled }}
     auto-downscale/down: "false"
     {{- end }}
-    beta.cloud.google.com/backend-config: '{"ports": {"80":"{{ .Release.Name }}-drupal"}}'
+    cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Release.Name }}-drupal"}}'
     {{- if .Values.cluster }}
     {{- if .Values.cluster.vpcNative }}
     cloud.google.com/neg: '{"ingress": true}'

--- a/drupal/tests/drupal_hpa_test.yaml
+++ b/drupal/tests/drupal_hpa_test.yaml
@@ -1,0 +1,70 @@
+suite: HorizontalPodAutoscaler
+templates:
+  - drupal-deployment.yaml
+tests:
+  - it: HPA resource is present when autoscaler is enabled
+    template: drupal-deployment.yaml
+    set:
+      autoscaling:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+  - it: HPA resource is absent when autoscaler is disabled
+    template: drupal-deployment.yaml
+    set:
+      autoscaling:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: HPA defines pre 1.23 format metrics
+    template: drupal-deployment.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 22
+      apiVersions:
+        - autoscaling/v2beta1
+    set:
+      autoscaling:
+        enabled: true
+        metrics:
+        - type: Resource
+          resource:
+            name: foo
+            targetAverageUtilization: bar
+    asserts:
+      - documentIndex: 1
+        contains:
+          path: spec.metrics
+          content:
+            resource:
+              name: foo
+              targetAverageUtilization: bar
+            type: Resource
+  - it: HPA defines 1.23+ format metrics
+    template: drupal-deployment.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 23
+      apiVersions:
+        - autoscaling/v2
+    set:
+      autoscaling:
+        enabled: true
+        metrics:
+        - type: Resource
+          resource:
+            name: foo
+            targetAverageUtilization: bar
+    asserts:
+      - documentIndex: 1
+        contains:
+          path: spec.metrics
+          content:
+            resource:
+              name: foo
+              target:
+                type: Utilization
+                averageUtilization: bar
+            type: Resource

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -41,14 +41,14 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: 80
-    - type: Resource
-      resource:
-        name: memory
-        targetAverageUtilization: 80
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 80
+  - type: Resource
+    resource:
+      name: memory
+      targetAverageUtilization: 80
 
 # Domain names that will be mapped to this deployment.
 # Example of exposing 2 additional domains for this deployment, each with its own certificate.

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.75
+version: 0.2.76
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/certificate.yaml
+++ b/frontend/templates/certificate.yaml
@@ -185,7 +185,9 @@ metadata:
     {{- include "frontend.release_labels" $ | nindent 4 }}
 type: kubernetes.io/tls
 data:
+  {{- if $domain.ssl.ca }}
   ca.crt: {{ $domain.ssl.ca | default "" | b64enc }}
+  {{- end }}
   tls.crt: {{ $domain.ssl.crt | default "" | b64enc }}
   tls.key: {{ $domain.ssl.key | default "" | b64enc }}
 ---

--- a/frontend/templates/nginx.yaml
+++ b/frontend/templates/nginx.yaml
@@ -95,6 +95,29 @@ spec:
     name: {{ .Release.Name }}-nginx
   minReplicas: {{ .Values.nginx.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.nginx.autoscaling.maxReplicas }}
+  {{- if .Values.nginx.autoscaling.metrics }}
   metrics:
-    {{- toYaml .Values.nginx.autoscaling.metrics | nindent 4 }}
+  {{- if eq ( include "frontend.autoscaling.api-version" . | trim ) "autoscaling/v2beta1" }}
+  {{- range .Values.nginx.autoscaling.metrics }}
+  - type: Resource
+    resource:
+      name: {{ .resource.name }}
+      {{- if .resource.targetAverageUtilization }}
+      targetAverageUtilization: {{ .resource.targetAverageUtilization }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if eq ( include "frontend.autoscaling.api-version" . | trim ) "autoscaling/v2" }}
+  {{- range .Values.nginx.autoscaling.metrics }}
+  - type: Resource
+    resource:
+      name: {{ .resource.name }}
+      {{- if .resource.targetAverageUtilization }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .resource.targetAverageUtilization }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/frontend/templates/service.yaml
+++ b/frontend/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     auto-downscale/down: "false"
     {{- if .Values.cluster }}
     {{- if eq .Values.cluster.type "gke" }}
-    beta.cloud.google.com/backend-config: '{"ports": {"80":"{{ .Release.Name }}-nginx"}}'
+    cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Release.Name }}-nginx"}}'
     {{- end }}
     {{- if .Values.cluster.vpcNative }}
     cloud.google.com/neg: '{"ingress": true}'

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -231,11 +231,32 @@ spec:
   minReplicas: {{ default $.Values.serviceDefaults.autoscaling.minReplicas $service.autoscaling.minReplicas }}
   maxReplicas: {{ default $.Values.serviceDefaults.autoscaling.maxReplicas $service.autoscaling.maxReplicas }}
   metrics:
-    {{ if $service.autoscaling.metrics }}
-    {{- toYaml $service.autoscaling.metrics | nindent 4 }}
-    {{ else }}
-    {{- toYaml $.Values.serviceDefaults.autoscaling.metrics | nindent 4 }}
-    {{- end }}
+  {{- $metrics := $.Values.serviceDefaults.autoscaling.metrics }}
+  {{- if $service.autoscaling.metrics }}
+  {{- $metrics = $service.autoscaling.metrics }}
+  {{- end }}
+  {{- if eq ( include "frontend.autoscaling.api-version" $ | trim ) "autoscaling/v2beta1" }}
+  {{- range $metrics }}
+  - type: Resource
+    resource:
+      name: {{ .resource.name }}
+      {{- if .resource.targetAverageUtilization }}
+      targetAverageUtilization: {{ .resource.targetAverageUtilization }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if eq ( include "frontend.autoscaling.api-version" $ | trim ) "autoscaling/v2" }}
+  {{- range $metrics }}
+  - type: Resource
+    resource:
+      name: {{ .resource.name }}
+      {{- if .resource.targetAverageUtilization }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .resource.targetAverageUtilization }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/frontend/tests/nginx-hpa_test.yaml
+++ b/frontend/tests/nginx-hpa_test.yaml
@@ -1,0 +1,74 @@
+suite: HorizontalPodAutoscaler
+templates:
+  - nginx.yaml
+tests:
+  - it: HPA resource is present when autoscaler is enabled
+    template: nginx.yaml
+    set:
+      nginx:
+        autoscaling:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+  - it: HPA resource is absent when autoscaler is disabled
+    template: nginx.yaml
+    set:
+      nginx:
+        autoscaling:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: HPA defines pre 1.23 format metrics
+    template: nginx.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 22
+      apiVersions:
+        - autoscaling/v2beta1
+    set:
+      nginx:
+        autoscaling:
+          enabled: true
+          metrics:
+          - type: Resource
+            resource:
+              name: foo
+              targetAverageUtilization: bar
+    asserts:
+      - documentIndex: 1
+        contains:
+          path: spec.metrics
+          content:
+            resource:
+              name: foo
+              targetAverageUtilization: bar
+            type: Resource
+  - it: HPA defines 1.23+ format metrics
+    template: nginx.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 23
+      apiVersions:
+        - autoscaling/v2
+    set:
+      nginx:
+        autoscaling:
+          enabled: true
+          metrics:
+          - type: Resource
+            resource:
+              name: foo
+              targetAverageUtilization: bar
+    asserts:
+      - documentIndex: 1
+        contains:
+          path: spec.metrics
+          content:
+            resource:
+              name: foo
+              target:
+                type: Utilization
+                averageUtilization: bar
+            type: Resource

--- a/frontend/tests/services-deployment_test.yaml
+++ b/frontend/tests/services-deployment_test.yaml
@@ -218,14 +218,6 @@ tests:
         equal:
           path: spec.maxReplicas
           value: 3
-      - documentIndex: 1
-        contains:
-          path: spec.metrics
-          content:
-            type: Resource
-            resource:
-              name: cpu
-              targetAverageUtilization: 80
 
   - it: can override autoscale values
     template: services-deployment.yaml
@@ -236,11 +228,6 @@ tests:
           enabled: true
           minReplicas: 5
           maxReplicas: 7
-          metrics:
-            - type: Resource
-              resource:
-                name: cpu
-                targetAverageUtilization: 100
     asserts:
       - documentIndex: 1
         isKind:
@@ -253,14 +240,6 @@ tests:
         equal:
           path: spec.maxReplicas
           value: 7
-      - documentIndex: 1
-        contains:
-          path: spec.metrics
-          content:
-            type: Resource
-            resource:
-              name: cpu
-              targetAverageUtilization: 100
 
   - it: uses RollingUpdate as default service deployment strategy
     template: services-deployment.yaml

--- a/frontend/tests/services-hpa_test.yaml
+++ b/frontend/tests/services-hpa_test.yaml
@@ -1,0 +1,124 @@
+suite: Site deployment
+templates:
+  - services-deployment.yaml
+  - configmap.yaml
+tests:
+  - it: can autoscale with default values
+    template: services-deployment.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        autoscaling:
+          enabled: true
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: HorizontalPodAutoscaler
+      - documentIndex: 1
+        equal:
+          path: spec.minReplicas
+          value: 1
+      - documentIndex: 1
+        equal:
+          path: spec.maxReplicas
+          value: 3
+
+  - it: can override autoscale values
+    template: services-deployment.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        autoscaling:
+          enabled: true
+          minReplicas: 5
+          maxReplicas: 7
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: HorizontalPodAutoscaler
+      - documentIndex: 1
+        equal:
+          path: spec.minReplicas
+          value: 5
+      - documentIndex: 1
+        equal:
+          path: spec.maxReplicas
+          value: 7
+
+  - it: HPA resource is present when autoscaler is enabled
+    template: services-deployment.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        autoscaling:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: HPA resource is absent when autoscaler is disabled
+    template: services-deployment.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        autoscaling:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: HPA defines pre 1.23 format metrics
+    template: services-deployment.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 22
+      apiVersions:
+        - autoscaling/v2beta1
+    set:
+      services.foo:
+        image: 'bar'
+        autoscaling:
+          enabled: true
+          metrics:
+          - type: Resource
+            resource:
+              name: foo
+              targetAverageUtilization: bar
+    asserts:
+      - documentIndex: 1
+        contains:
+          path: spec.metrics
+          content:
+            resource:
+              name: foo
+              targetAverageUtilization: bar
+            type: Resource
+
+  - it: HPA defines 1.23+ format metrics
+    template: services-deployment.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 23
+      apiVersions:
+        - autoscaling/v2
+    set:
+      services.foo:
+        image: 'bar'
+        autoscaling:
+          enabled: true
+          metrics:
+          - type: Resource
+            resource:
+              name: foo
+              targetAverageUtilization: bar
+    asserts:
+      - documentIndex: 1
+        contains:
+          path: spec.metrics
+          content:
+            resource:
+              name: foo
+              target:
+                type: Utilization
+                averageUtilization: bar
+            type: Resource

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -109,10 +109,10 @@ nginx:
     minReplicas: 1
     maxReplicas: 3
     metrics:
-      - type: Resource
-        resource:
-          name: cpu
-          targetAverageUtilization: 80
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 80
 
   # The Kubernetes resources for the nginx container.
   # These values are optimised for development environments.
@@ -208,10 +208,10 @@ services: {}
   #     minReplicas: 1
   #     maxReplicas: 3
   #     metrics:
-  #       - type: Resource
-  #         resource:
-  #           name: cpu
-  #           targetAverageUtilization: 80
+  #     - type: Resource
+  #       resource:
+  #         name: cpu
+  #         targetAverageUtilization: 80
 
   #   resources: 
   #     requests:
@@ -322,10 +322,10 @@ serviceDefaults:
     minReplicas: 1
     maxReplicas: 3
     metrics:
-      - type: Resource
-        resource:
-          name: cpu
-          targetAverageUtilization: 80
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 80
 
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.

--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 6.0.5
 - name: csi-rclone
   repository: https://storage.googleapis.com/charts.wdr.io
-  version: 0.2.3
+  version: 0.3.0
 - name: cert-manager
   repository: https://charts.jetstack.io/
   version: v0.10.1
@@ -22,12 +22,12 @@ dependencies:
   version: 0.1.0
 - name: instana-agent
   repository: https://agents.instana.io/helm
-  version: 1.2.43
+  version: 1.2.45
 - name: nfs-subdir-external-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
-  version: 4.0.16
+  version: 4.0.17
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.0
-digest: sha256:bd174290e2cd1a3cddb76ec7cb66f23e43d9dff30a1093a28fdd09ebf2529cef
-generated: "2022-08-02T13:09:43.482216472+03:00"
+digest: sha256:e8a3970e0824d03301cd433fe596b0feb112c084a7e8bd52db0e3b340bbbb72c
+generated: "2022-10-06T16:22:28.662161118+03:00"

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.35
+version: 0.2.36
 dependencies:
 - name: traefik
   version: 1.87.x
@@ -21,7 +21,7 @@ dependencies:
   repository: https://helm.min.io/
   condition: minio.enabled
 - name: csi-rclone
-  version: 0.2.x
+  version: 0.3.x
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: csi-rclone.enabled
 - name: cert-manager

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.34
+version: 0.2.35
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/certificate.yaml
+++ b/simple/templates/certificate.yaml
@@ -123,7 +123,9 @@ metadata:
     {{- include "simple.release_labels" $ | nindent 4 }}
 type: kubernetes.io/tls
 data:
+  {{- if $domain.ssl.ca }}
   ca.crt: {{ $domain.ssl.ca | default "" | b64enc }}
+  {{- end }}
   tls.crt: {{ $domain.ssl.crt | default "" | b64enc }}
   tls.key: {{ $domain.ssl.key | default "" | b64enc }}
 ---

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -101,6 +101,29 @@ spec:
     name: {{ .Release.Name }}-simple
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if .Values.autoscaling.metrics }}
   metrics:
-    {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+  {{- if eq ( include "simple.autoscaling.api-version" . | trim ) "autoscaling/v2beta1" }}
+  {{- range .Values.autoscaling.metrics }}
+  - type: Resource
+    resource:
+      name: {{ .resource.name }}
+      {{- if .resource.targetAverageUtilization }}
+      targetAverageUtilization: {{ .resource.targetAverageUtilization }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if eq ( include "simple.autoscaling.api-version" . | trim ) "autoscaling/v2" }}
+  {{- range .Values.autoscaling.metrics }}
+  - type: Resource
+    resource:
+      name: {{ .resource.name }}
+      {{- if .resource.targetAverageUtilization }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .resource.targetAverageUtilization }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/simple/templates/service.yaml
+++ b/simple/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     auto-downscale/down: "false"
     {{- if .Values.cluster }}
     {{- if eq .Values.cluster.type "gke" }}
-    beta.cloud.google.com/backend-config: '{"ports": {"80":"{{ .Release.Name }}-simple"}}'
+    cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Release.Name }}-simple"}}'
     {{- end }}
     {{- if .Values.cluster.vpcNative }}
     cloud.google.com/neg: '{"ingress": true}'

--- a/simple/tests/hpa_test.yaml
+++ b/simple/tests/hpa_test.yaml
@@ -1,0 +1,70 @@
+suite: HorizontalPodAutoscaler
+templates:
+  - deployment.yaml
+tests:
+  - it: HPA resource is present when autoscaler is enabled
+    template: deployment.yaml
+    set:
+      autoscaling:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+  - it: HPA resource is absent when autoscaler is disabled
+    template: deployment.yaml
+    set:
+      autoscaling:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: HPA defines pre 1.23 format metrics
+    template: deployment.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 22
+      apiVersions:
+        - autoscaling/v2beta1
+    set:
+      autoscaling:
+        enabled: true
+        metrics:
+        - type: Resource
+          resource:
+            name: foo
+            targetAverageUtilization: bar
+    asserts:
+      - documentIndex: 1
+        contains:
+          path: spec.metrics
+          content:
+            resource:
+              name: foo
+              targetAverageUtilization: bar
+            type: Resource
+  - it: HPA defines 1.23+ format metrics
+    template: deployment.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 23
+      apiVersions:
+        - autoscaling/v2
+    set:
+      autoscaling:
+        enabled: true
+        metrics:
+        - type: Resource
+          resource:
+            name: foo
+            targetAverageUtilization: bar
+    asserts:
+      - documentIndex: 1
+        contains:
+          path: spec.metrics
+          content:
+            resource:
+              name: foo
+              target:
+                type: Utilization
+                averageUtilization: bar
+            type: Resource

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -32,10 +32,10 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: 80
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 80
 
 # Domain names that will be mapped to this deployment.
 # Example of exposing 2 additional domains for this deployment, each with its own certificate.


### PR DESCRIPTION
- Silta-cluster (0.2.36): 
  - Use rclone 0.3.x with tini init (https://github.com/wunderio/charts/pull/332); 
    - **Update rclone image overrides to use 1.3.x+ images!**  
  - patch version updates for instana-agent and nfs-provisioner subcharts

- Drupal chart (0.3.138):
  - Abstract HPA rules on top of pre-1.23 style rules to enable compatibility with autoscaling api configuration schema changes ([PR](https://github.com/wunderio/drupal-project-k8s/pull/546))
  - backend-config fix for gce lb neg; make ca optional ([PR](https://github.com/wunderio/drupal-project-k8s/pull/547))

- Frontend chart (0.2.76):
  - Abstract HPA rules on top of pre-1.23 style rules to enable compatibility with autoscaling api configuration schema changes ([PR](https://github.com/wunderio/frontend-project-k8s/pull/79))
  - backend-config fix for gce lb neg; make ca optional ([PR](https://github.com/wunderio/frontend-project-k8s/pull/80))

- Simple chart (0.2.35):
  - Abstract HPA rules on top of pre-1.23 style rules to enable compatibility with autoscaling api configuration schema changes ([PR](https://github.com/wunderio/simple-project-k8s/pull/32))
  - backend-config fix for gce lb neg; make ca optional ([PR](https://github.com/wunderio/simple-project-k8s/pull/33))


