### PR TITLE
maxUnavailable pods for quicker rclone nodeplugin updates

### DIFF
--- a/csi-rclone/Chart.yaml
+++ b/csi-rclone/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: CSI plugin for rclone mount
 name: csi-rclone
-version: 0.3.0
+version: 0.3.1

--- a/csi-rclone/templates/1.13-csi-nodeplugin-rclone.yaml
+++ b/csi-rclone/templates/1.13-csi-nodeplugin-rclone.yaml
@@ -8,6 +8,10 @@ spec:
   selector:
     matchLabels:
       app: csi-nodeplugin-rclone
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 35%
   template:
     metadata:
       labels:

--- a/csi-rclone/templates/1.19-csi-nodeplugin-rclone.yaml
+++ b/csi-rclone/templates/1.19-csi-nodeplugin-rclone.yaml
@@ -8,6 +8,10 @@ spec:
   selector:
     matchLabels:
       app: csi-nodeplugin-rclone
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 35%
   template:
     metadata:
       labels:


### PR DESCRIPTION
csi-rclone: maxUnavailable pods for quicker rclone nodeplugin updates