### PR TITLE
Feature/release 20221013

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         # Available minikube kubernetes version list: 
         # "minikube config defaults kubernetes-version"
         # and https://kubernetes.io/releases/patch-releases/
-        kubernetes-version: ["v1.21.14", "v1.22.12", "v1.23.9", "v1.24.3", "latest"]
+        kubernetes-version: ["v1.21.14", "v1.22.13", "v1.23.10", "v1.24.4", "v1.25.0", "latest"]
     env:
       CLUSTER_DOMAIN: minikube.local.wdr.io
       K8S_PROJECT_REPO_DIR: k8s-project-repositories
@@ -55,6 +55,7 @@ jobs:
             && helm repo add percona https://percona.github.io/percona-helm-charts/ \
             && helm repo add elastic https://helm.elastic.co \
             && helm repo add codecentric https://codecentric.github.io/helm-charts \
+            && helm plugin install https://github.com/quintush/helm-unittest --version 0.2.4 \
             && helm repo update
 
       - name: Download and start minikube
@@ -190,6 +191,12 @@ jobs:
           # Dependency build for local chart
           helm dependency build "./drupal"
 
+          # Chart unit tests
+          helm unittest ./drupal --helm3
+
+          # Dry-run drupal chart with test values
+          helm install --dry-run --generate-name ./drupal --values drupal/test.values.yaml
+
           silta ci release deploy \
               --release-name test \
               --chart-name ./drupal \
@@ -237,6 +244,12 @@ jobs:
 
           # Dependency build for local chart
           helm dependency build ./frontend
+
+          # Chart unit tests
+          helm unittest ./frontend --helm3
+
+          # Dry-run drupal chart with test values
+          helm install --dry-run --generate-name ./frontend --values frontend/test.values.yaml
 
           # Tunnel to in-cluster docker registry. Required due to docker push inability to use selfsigned/insecure repositories that ain't local
           # Find a free port. Credit: stefanobaghino / https://unix.stackexchange.com/posts/423052/revisions
@@ -296,6 +309,12 @@ jobs:
 
           # Dependency build for local chart
           helm dependency build ./simple
+
+          # Chart unit tests
+          helm unittest ./simple --helm3
+
+          # Dry-run drupal chart with test values
+          helm install --dry-run --generate-name ./simple --values simple/test.values.yaml
 
           # Build images
           SIMPLE_NGINX_IMAGE=/simple-project-k8s/test-simple-nginx:latest

--- a/csi-rclone/Chart.yaml
+++ b/csi-rclone/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: CSI plugin for rclone mount
 name: csi-rclone
-version: 0.3.0
+version: 0.3.1

--- a/csi-rclone/templates/1.13-csi-nodeplugin-rclone.yaml
+++ b/csi-rclone/templates/1.13-csi-nodeplugin-rclone.yaml
@@ -8,6 +8,10 @@ spec:
   selector:
     matchLabels:
       app: csi-nodeplugin-rclone
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 35%
   template:
     metadata:
       labels:

--- a/csi-rclone/templates/1.19-csi-nodeplugin-rclone.yaml
+++ b/csi-rclone/templates/1.19-csi-nodeplugin-rclone.yaml
@@ -8,6 +8,10 @@ spec:
   selector:
     matchLabels:
       app: csi-nodeplugin-rclone
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 35%
   template:
     metadata:
       labels:

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.138
+version: 0.3.139
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/drupal-service.yaml
+++ b/drupal/templates/drupal-service.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- if (index .Values "silta-release").downscaler.enabled }}
     auto-downscale/down: "false"
     {{- end }}
-    {{- if eq .Values.cluster.type "gke" }}
-    cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Release.Name }}-drupal"}}'
+    {{- if and (eq .Values.cluster.type "gke") (.Values.backendConfig) }}
+    cloud.google.com/backend-config: '{"default":"{{ .Release.Name }}-drupal"}'
     {{- end }}
     {{- if .Values.cluster }}
     {{- if .Values.cluster.vpcNative }}
@@ -25,7 +25,8 @@ spec:
   # We explicitly unset this, in case the application is currently downscaled.
   externalName: null
   ports:
-    - port: 80
+    - name: web
+      port: 80
       targetPort: 8080
   selector:
     {{- include "drupal.release_selector_labels" . | nindent 4 }}

--- a/drupal/templates/varnish-service.yaml
+++ b/drupal/templates/varnish-service.yaml
@@ -7,7 +7,9 @@ metadata:
     {{- if (index .Values "silta-release").downscaler.enabled }}
     auto-downscale/down: "false"
     {{- end }}
-    cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Release.Name }}-drupal"}}'
+    {{- if and (eq .Values.cluster.type "gke") (.Values.backendConfig) }}
+    cloud.google.com/backend-config: '{"default":"{{ .Release.Name }}-drupal"}'
+    {{- end }}
     {{- if .Values.cluster }}
     {{- if .Values.cluster.vpcNative }}
     cloud.google.com/neg: '{"ingress": true}'
@@ -20,8 +22,10 @@ spec:
   type: NodePort
   ports:
   - name: web
+    protocol: TCP
     port: 80
   - name: admin
+    protocol: TCP
     port: 6082 
   selector:
     {{- include "drupal.release_selector_labels" . | nindent 4 }}

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.76
+version: 0.2.77
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/service.yaml
+++ b/frontend/templates/service.yaml
@@ -7,8 +7,8 @@ metadata:
   annotations:
     auto-downscale/down: "false"
     {{- if .Values.cluster }}
-    {{- if eq .Values.cluster.type "gke" }}
-    cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Release.Name }}-nginx"}}'
+    {{- if and (eq .Values.cluster.type "gke") (.Values.backendConfig) }}
+    cloud.google.com/backend-config: '{"default":"{{ .Release.Name }}-nginx"}'
     {{- end }}
     {{- if .Values.cluster.vpcNative }}
     cloud.google.com/neg: '{"ingress": true}'
@@ -20,7 +20,9 @@ spec:
   # We explicitly unset this, in case the application is currently downscaled.
   externalName: null
   ports:
-    - port: 80
+    - name: web
+      port: 80
+      protocol: TCP
       targetPort: 8080
   selector:
     {{ include "frontend.release_labels" . | indent 4 }}

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.35
+version: 0.2.36
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/_helpers.tpl
+++ b/simple/templates/_helpers.tpl
@@ -32,11 +32,6 @@ release: {{ .Release.Name }}
   {{- if .Values.nginx.basicauth.enabled }}
   satisfy any;
   allow 127.0.0.1;
-  {{- if .Values.nginx.basicauth.noauthips }}
-  {{- range .Values.nginx.basicauth.noauthips }}
-  allow {{ . }};
-  {{- end }}
-  {{- end }}
   {{- if .Values.nginx.noauthips }}
   {{- range .Values.nginx.noauthips }}
   allow {{ . }};

--- a/simple/templates/checks.yaml
+++ b/simple/templates/checks.yaml
@@ -1,0 +1,6 @@
+{{ if .Values.nginx.basicauth.realipfrom }}
+{{- fail "nginx.basicauth.realipfrom configuration schema is depreciated migrate configuration to nginx.realipfrom" -}}
+{{- end }}
+{{ if .Values.nginx.basicauth.noauthips }}
+{{- fail "nginx.basicauth.noauthips configuration schema is depreciated migrate configuration to nginx.noauthips" -}}
+{{- end }}

--- a/simple/templates/configmap.yaml
+++ b/simple/templates/configmap.yaml
@@ -29,11 +29,6 @@ data:
         {{- end }}
         {{- end }}
 
-        {{ if .Values.nginx.basicauth.realipfrom }}
-        # This will be depreciated, migrate this setting to nginx.realipfrom
-        set_real_ip_from            {{ .Values.nginx.basicauth.realipfrom }};
-        {{- end }}
-
         real_ip_header              {{ .Values.nginx.real_ip_header }};
 
         include                     /etc/nginx/mime.types;                                 

--- a/simple/templates/service.yaml
+++ b/simple/templates/service.yaml
@@ -7,8 +7,8 @@ metadata:
   annotations:
     auto-downscale/down: "false"
     {{- if .Values.cluster }}
-    {{- if eq .Values.cluster.type "gke" }}
-    cloud.google.com/backend-config: '{"ports": {"8080":"{{ .Release.Name }}-simple"}}'
+    {{- if and (eq .Values.cluster.type "gke") (.Values.backendConfig) }}
+    cloud.google.com/backend-config: '{"default":"{{ .Release.Name }}-simple"}'
     {{- end }}
     {{- if .Values.cluster.vpcNative }}
     cloud.google.com/neg: '{"ingress": true}'
@@ -18,7 +18,9 @@ spec:
   type: NodePort
   externalTrafficPolicy: Local
   ports:
-    - port: 80
+    - name: web
+      protocol: TCP
+      port: 80
       targetPort: 8080
   selector:
     {{ include "simple.release_labels" . | indent 4 }}

--- a/simple/tests/configmap_test.yaml
+++ b/simple/tests/configmap_test.yaml
@@ -28,7 +28,7 @@ tests:
         loglevel: 'debug'
         basicauth:
           enabled: true
-          realipfrom: '1.2.3.4'
+        realipfrom: '1.2.3.4'
     asserts:
     - template: configmap.yaml
       matchRegex:

--- a/simple/values.schema.json
+++ b/simple/values.schema.json
@@ -36,14 +36,6 @@
                 "username": { "type": "string"},
                 "password": { "type": "string"}
               }
-            },
-            "realipfrom": {
-              "type": ["string"],
-              "deprecated": true
-            },
-            "noauthips": {
-              "type": ["object"],
-              "deprecated": true
             }
           },
           "additionalProperties": false

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -129,15 +129,6 @@ nginx:
     credentials:
       username: silta
       password: demo
-
-    # Trust X-Forwarded-For from these hosts for getting external IP 
-    # This will be deprecated soon in favor of nginx.realipfrom 
-    # realipfrom: 10.0.0.0/8
-
-    # Add IP addresses that should be excluded from basicauth
-    # This will be deprecated soon in favor of nginx.noauthips 
-    # noauthips:
-    #   gke-internal: 10.0.0.0/8
   
   # Trust X-Forwarded-For from these hosts for getting external IP
   realipfrom: 


### PR DESCRIPTION
Drupal chart (0.3.139)
  - Do not add backendConfig annotation to service when it's unset ([PR](https://github.com/wunderio/drupal-project-k8s/pull/551))

Frontend chart (0.2.77)
  - Do not add backendConfig annotation to service when it's unset ([PR](https://github.com/wunderio/frontend-project-k8s/pull/81))

Simple chart (0.2.36)
  - Do not add backendConfig annotation to service when it's unset ([PR](https://github.com/wunderio/simple-project-k8s/pull/35))
  - `nginx.basicauth.realipfrom` and `nginx.basicauth.noauthips` depreciation ([PR](https://github.com/wunderio/simple-project-k8s/pull/34))

rclone-csi chart (0.3.1)
  - maxUnavailable pods for quicker rclone nodeplugin updates ([PR](https://github.com/wunderio/charts/pull/337))

Test charts on kubernetes 1.25 ([PR](https://github.com/wunderio/charts/pull/326))
