### PR TITLE
Feature/release 20221020

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.3.139
+version: 0.3.140
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
 data:
   gdpr-dump: |
-    [mysqldump]
-    gdpr-replacements='{{ .Values.gdprDump | toJson }}'
+    # [mysqldump]
+    # gdpr-replacements='{{ .Values.gdprDump | toJson }}'
 
   {{- if eq .Values.php.drupalCoreVersion "7" }}
   settings_silta_php: |{{ .Files.Get "files/settings.silta.d7.php" | nindent 4 }}

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -6,8 +6,8 @@ metadata:
     {{- include "drupal.release_labels" . | nindent 4 }}
 data:
   gdpr-dump: |
-    # [mysqldump]
-    # gdpr-replacements='{{ .Values.gdprDump | toJson }}'
+    [mysqldump]
+    gdpr-replacements='{{ .Values.gdprDump | toJson }}'
 
   {{- if eq .Values.php.drupalCoreVersion "7" }}
   settings_silta_php: |{{ .Files.Get "files/settings.silta.d7.php" | nindent 4 }}

--- a/drupal/templates/drupal-ingress.yaml
+++ b/drupal/templates/drupal-ingress.yaml
@@ -1,4 +1,11 @@
 {{- $ingress := .Values.ingress.default }}
+{{- $context_ssl := .Values.ssl }}
+{{- $letsencrypt_in_use := false }}
+{{- if $ingress.tls }}
+{{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+{{- $letsencrypt_in_use = true }}
+{{- end }}
+{{- end }}
 apiVersion: {{ include "ingress.api-version" . | trim }}
 kind: Ingress
 metadata:
@@ -35,14 +42,18 @@ metadata:
     {{- end }}
 
     {{- if eq $ingress.type "gce" }}
+    {{- if $letsencrypt_in_use }}
     cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     {{- end }}
     {{- if $ingress.staticIpAddressName }}
     kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
     
     {{- if eq $ingress.type "azure/application-gateway" }}
+    {{- if $letsencrypt_in_use }}
     cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     appgw.ingress.kubernetes.io/health-probe-status-codes: "200-399, 401-404"
     {{- end }}
     
@@ -132,6 +143,20 @@ spec:
   {{- end }}
 {{- end }}
 
+{{- $letsencrypt_in_use := false }}
+{{- range $index, $domain := $.Values.exposeDomains }}
+{{ $domain := merge $domain $.Values.exposeDomainsDefaults}}
+{{- if eq $domain.ingress $ingress_index }}
+{{- if $domain.ssl }}
+{{- if $domain.ssl.enabled }}
+{{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+{{- $letsencrypt_in_use = true }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- if $ingress_in_use }}
 apiVersion: {{ include "ingress.api-version" $ | trim }}
 kind: Ingress
@@ -169,14 +194,18 @@ metadata:
     {{- end }}
 
     {{- if eq $ingress.type "gce" }}
+    {{- if $letsencrypt_in_use }}
     cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     {{- end }}
     {{- if $ingress.staticIpAddressName }}
     kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
     
     {{- if eq $ingress.type "azure/application-gateway" }}
+    {{- if $letsencrypt_in_use }}
     cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     appgw.ingress.kubernetes.io/health-probe-status-codes: "200-399, 401-404"
     {{- end }}
     

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -421,7 +421,6 @@ referenceData:
 
 # Parameters for sanitizing reference data with gdpr-dump.
 # Uses formatters from https://packagist.org/packages/fzaninotto/faker.
-# ! This functionality has been temporary disabled
 gdprDump:
   users_field_data:
     name:

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.2.77
+version: 0.2.78
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/ingress.yaml
+++ b/frontend/templates/ingress.yaml
@@ -1,4 +1,11 @@
 {{- $ingress := .Values.ingress.default }}
+{{- $context_ssl := .Values.ssl }}
+{{- $letsencrypt_in_use := false }}
+{{- if $ingress.tls }}
+{{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+{{- $letsencrypt_in_use = true }}
+{{- end }}
+{{- end }}
 apiVersion: {{ include "ingress.api-version" . | trim }}
 kind: Ingress
 metadata:
@@ -35,13 +42,18 @@ metadata:
     {{- end }}
     
     {{- if eq $ingress.type "gce" }}
+    {{- if $letsencrypt_in_use }}
     cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     {{- end }}
     {{- if $ingress.staticIpAddressName }}
     kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
 
     {{- if eq $ingress.type "azure/application-gateway" }}
+    {{- if $letsencrypt_in_use }}
+    cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     appgw.ingress.kubernetes.io/health-probe-status-codes: "200-399, 401-404"
     {{- end }}
 
@@ -123,6 +135,19 @@ spec:
   {{- end }}
 {{- end }}
 
+{{- $letsencrypt_in_use := false }}
+{{- range $index, $domain := $.Values.exposeDomains }}
+{{ $domain := merge $domain $.Values.exposeDomainsDefaults}}
+{{- if eq $domain.ingress $ingress_index }}
+{{- if $domain.ssl }}
+{{- if $domain.ssl.enabled }}
+{{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+{{- $letsencrypt_in_use = true }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- if $ingress_in_use }}
 apiVersion: {{ include "ingress.api-version" $ | trim }}
 kind: Ingress
@@ -160,13 +185,18 @@ metadata:
     {{- end }}
     
     {{- if eq $ingress.type "gce" }}
+    {{- if $letsencrypt_in_use }}
     cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     {{- end }}
     {{- if $ingress.staticIpAddressName }}
     kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
 
     {{- if eq $ingress.type "azure/application-gateway" }}
+    {{- if $letsencrypt_in_use }}
+    cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     appgw.ingress.kubernetes.io/health-probe-status-codes: "200-399, 401-404"
     {{- end }}
 

--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -26,8 +26,11 @@ dependencies:
 - name: nfs-subdir-external-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
   version: 4.0.17
+- name: nfs-subdir-external-provisioner
+  repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
+  version: 4.0.17
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.0
-digest: sha256:ebc1b074b597eee2391fec9f62c7e979a205c67b9bda0fd8de68cc539820e7b2
-generated: "2022-10-20T14:33:15.121410542+03:00"
+digest: sha256:46d8857c85396d3f5d75143b4437e05ad1080eb18dfeb2914fd9faef2886704c
+generated: "2022-10-20T14:57:29.848831782+03:00"

--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 6.0.5
 - name: csi-rclone
   repository: https://storage.googleapis.com/charts.wdr.io
-  version: 0.3.0
+  version: 0.3.1
 - name: cert-manager
   repository: https://charts.jetstack.io/
   version: v0.10.1
@@ -29,5 +29,5 @@ dependencies:
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.0
-digest: sha256:e8a3970e0824d03301cd433fe596b0feb112c084a7e8bd52db0e3b340bbbb72c
-generated: "2022-10-06T16:22:28.662161118+03:00"
+digest: sha256:ebc1b074b597eee2391fec9f62c7e979a205c67b9bda0fd8de68cc539820e7b2
+generated: "2022-10-20T14:33:15.121410542+03:00"

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.36
+version: 0.2.37
 dependencies:
 - name: traefik
   version: 1.87.x

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -40,6 +40,11 @@ dependencies:
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
   version: 4.0.x
   condition: nfs-subdir-external-provisioner.enabled
+- name: nfs-subdir-external-provisioner
+  repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
+  version: 4.0.x
+  alias: silta-shared-nfs
+  condition: silta-shared-nfs.enabled
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.x

--- a/silta-cluster/templates/downscaler-cron.yaml
+++ b/silta-cluster/templates/downscaler-cron.yaml
@@ -12,6 +12,7 @@ spec:
         spec:
           restartPolicy: OnFailure
           serviceAccountName: {{ .Release.Name }}-downscaler
+          enableServiceLinks: false
           containers:
           - name: downscaler-cron
             image: '{{ index (index .Values "silta-downscaler") "image" }}:{{ index (index .Values "silta-downscaler") "imageTag" }}'

--- a/silta-cluster/templates/k8s-controller-sidecars.yaml
+++ b/silta-cluster/templates/k8s-controller-sidecars.yaml
@@ -48,6 +48,7 @@ spec:
         name: {{ .Release.Name }}-sidecar-controller
     spec:
       serviceAccountName: {{ .Release.Name }}-sidecar-job-controller
+      enableServiceLinks: false
       containers:
         - image: "{{ .Values.k8sControllerSidecars.image.repository }}:{{ .Values.k8sControllerSidecars.image.tag }}"
           imagePullPolicy: {{ .Values.k8sControllerSidecars.image.pullPolicy }}

--- a/silta-cluster/templates/nfs-server.yaml
+++ b/silta-cluster/templates/nfs-server.yaml
@@ -1,0 +1,79 @@
+{{- if index (index .Values "nfs-server") "enabled" }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-nfs-server
+  namespace: {{ .Release.Namespace }}
+spec:
+  serviceName: {{ .Release.Name }}-nfs-server
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-nfs-server
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-nfs-server
+    spec:
+      enableServiceLinks: false
+      containers:
+      - name: nfs-server
+        image: '{{ index (index .Values "nfs-server") "image" }}:{{ index (index .Values "nfs-server") "imageTag" }}'
+        imagePullPolicy: {{ index (index .Values "nfs-server") "imagePullPolicy" }}
+        # TODO: resources:
+        ports:
+        - name: nfs
+          containerPort: 2049
+        - name: mountd
+          containerPort: 20048
+        - name: rpcbind
+          containerPort: 111
+        securityContext:
+          privileged: true
+        livenessProbe:
+          initialDelaySeconds: 30
+          tcpSocket:
+            port: 111
+        readinessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 20
+          tcpSocket:
+            port: 111
+        resources:
+          {{- index (index .Values "nfs-server") "resources" | toYaml | nindent 10 }}
+        volumeMounts:
+        - name: {{ .Release.Name }}-nfs-server-data
+          mountPath: /exports
+  volumeClaimTemplates:
+  - metadata:
+      name: {{ .Release.Name }}-nfs-server-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      {{- if index (index (index (index .Values "nfs-server") "persistence") "data") "storageClassName" }}
+      storageClassName: {{ index (index (index (index .Values "nfs-server") "persistence") "data") "storageClassName" }}
+      {{- end }}
+      {{- if index (index (index (index .Values "nfs-server") "persistence") "data") "csiDriverName" }}
+      csiDriverName: {{ index (index (index (index .Values "nfs-server") "persistence") "data") "csiDriverName" }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ index (index (index (index .Values "nfs-server") "persistence") "data") "size" }}
+      accessModes: {{ index (index (index (index .Values "nfs-server") "persistence") "data") "accessModes" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-nfs-server
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: nfs
+    port: 2049
+  - name: mountd
+    port: 20048
+  - name: rpcbind
+    port: 111
+  selector:
+    app: {{ .Release.Name }}-nfs-server
+
+{{- end }}

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -196,6 +196,42 @@ nfs-subdir-external-provisioner:
     pathPattern: "${.PVC.namespace}/${.PVC.annotations.storage.silta/storage-path}"
     onDelete: delete
 
+# Uses nfs-subdir-external-provisioner. 
+# see: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/blob/master/charts/nfs-subdir-external-provisioner/values.yaml
+silta-shared-nfs:
+  enabled: false
+  nfs:
+    server: silta-cluster-nfs-server.silta-cluster.svc.cluster.local
+    path: /
+  storageClass:
+    name: silta-nfs-shared
+    # Set volume bindinng mode - Immediate or WaitForFirstConsumer
+    volumeBindingMode: WaitForFirstConsumer
+    pathPattern: "${.PVC.namespace}/${.PVC.annotations.storage.silta/storage-path}"
+    onDelete: delete
+
+nfs-server:
+  enabled: false
+  image: k8s.gcr.io/volume-nfs
+  imageTag: 0.8
+  imagePullPolicy: IfNotPresent
+  # Kubernetes resource assignments.
+  resources:
+    requests:
+      cpu: 10m
+      memory: 256M
+    limits:
+      cpu: 100m
+      memory: 512M
+  persistence:
+    data:
+      size: 10Gi
+      # storageClassName: standard
+      # Provide driver name if using CSI driver backed storage class (optional).
+      # csiDriverName: csi-driver-name
+      accessModes:
+        - ReadWriteOnce
+
 # This should be replaced when an actual sidecar implementation is available. 
 # https://github.com/kubernetes/enhancements/issues/753#issuecomment-713471597
 k8sControllerSidecars:

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 0.2.36
+version: 0.2.37
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/ingress.yaml
+++ b/simple/templates/ingress.yaml
@@ -1,4 +1,11 @@
 {{- $ingress := .Values.ingress.default }}
+{{- $context_ssl := .Values.ssl }}
+{{- $letsencrypt_in_use := false }}
+{{- if $ingress.tls }}
+{{- if has $context_ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+{{- $letsencrypt_in_use = true }}
+{{- end }}
+{{- end }}
 apiVersion: {{ include "ingress.api-version" . | trim }}
 kind: Ingress
 metadata:
@@ -35,14 +42,18 @@ metadata:
     {{- end }}
 
     {{- if eq $ingress.type "gce" }}
+    {{- if $letsencrypt_in_use }}
     cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     {{- end }}
     {{- if $ingress.staticIpAddressName }}
     kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
 
     {{- if eq $ingress.type "azure/application-gateway" }}
+    {{- if $letsencrypt_in_use }}
     cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     appgw.ingress.kubernetes.io/health-probe-status-codes: "200-399, 401-404"
     {{- end }}
 
@@ -91,6 +102,20 @@ spec:
   {{- end }}
 {{- end }}
 
+{{- $letsencrypt_in_use := false }}
+{{- range $index, $domain := $.Values.exposeDomains }}
+{{ $domain := merge $domain $.Values.exposeDomainsDefaults}}
+{{- if eq $domain.ingress $ingress_index }}
+{{- if $domain.ssl }}
+{{- if $domain.ssl.enabled }}
+{{- if has $domain.ssl.issuer (list "letsencrypt" "letsencrypt-staging") }}
+{{- $letsencrypt_in_use = true }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- if $ingress_in_use }}
 apiVersion: {{ include "ingress.api-version" $ | trim }}
 kind: Ingress
@@ -128,14 +153,18 @@ metadata:
     {{- end }}
     
     {{- if eq $ingress.type "gce" }}
+    {{- if $letsencrypt_in_use }}
     cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     {{- end }}
     {{- if $ingress.staticIpAddressName }}
     kubernetes.io/ingress.global-static-ip-name: {{ $ingress.staticIpAddressName | quote }}
     {{- end }}
 
     {{- if eq $ingress.type "azure/application-gateway" }}
+    {{- if $letsencrypt_in_use }}
     cert-manager.io/cluster-issuer: letsencrypt
+    {{- end }}
     appgw.ingress.kubernetes.io/health-probe-status-codes: "200-399, 401-404"
     {{- end }}
     


### PR DESCRIPTION
Silta-cluster chart
  - Disabling serviceLinks in forked subcharts ([PR](https://github.com/wunderio/charts/pull/339))
  - Hosted nfs server with a dedicated nfs provisioner and storageclass ([PR](https://github.com/wunderio/charts/pull/333))

Drupal chart
  - Set cluster-issuer for ingress only if le is in use ([PR](https://github.com/wunderio/drupal-project-k8s/pull/552))

Frontend chart
  - Set cluster-issuer for ingress only if le is in use ([PR](https://github.com/wunderio/frontend-project-k8s/pull/82))

Simple chart
  - Set cluster-issuer for ingress only if le is in use ([PR](https://github.com/wunderio/simple-project-k8s/pull/36))
