### PR TITLE
Feature/release 20221103

### DIFF
--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.37
+version: 0.2.38
 dependencies:
 - name: traefik
   version: 1.87.x

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -14,7 +14,7 @@ traefik:
   enabled: true
   externalTrafficPolicy: Local
   priorityClassName: "high-priority"
-  image: eu.gcr.io/silta-images/traefik
+  image: wunderio/silta-traefik
   imageTag: 1.7.34-mod
   rbac:
     enabled: true
@@ -238,7 +238,7 @@ k8sControllerSidecars:
   enabled: true
   replicaCount: 1
   image:
-    repository: eu.gcr.io/silta-images/silta-k8s-controller-sidecars
+    repository: wunderio/silta-k8s-controller-sidecars
     tag: latest
     pullPolicy: IfNotPresent
   resources:


### PR DESCRIPTION
silta-cluster (0.2.38): 
- Load traefik and sidecar images from docker hub