### PR TITLE
Shell now has default values for resources

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -356,7 +356,10 @@ shell:
     storage: 1M
 
   # Extend resources defined under php.resources.
-  resources: {}
+  resources:
+    requests:
+      cpu: 5m
+      memory: 64Mi
 
   # Set a restriction on where the shell pod are provisioned.
   # This can be used for example to get a static IP for egress traffic.


### PR DESCRIPTION
Set a baseline resource request for shell instead of using PHP resources as a default