### PR TITLE
Release 2023-05-04

### DIFF
--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 0.2.41
+version: 0.2.42
 # kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx

--- a/silta-cluster/templates/downscaler-cron.yaml
+++ b/silta-cluster/templates/downscaler-cron.yaml
@@ -33,4 +33,6 @@ spec:
                 value: {{ index (index .Values "silta-downscaler") "defaultMinAge" | quote }}
               - name: RELEASE_MIN_AGE
                 value: '{{ index (index .Values "silta-downscaler") "releaseMinAge" | toJson }}'
+              - name: PLACEHOLDER_PROXY_IMAGE
+                value: '{{ index (index (index .Values "silta-downscaler") "proxy") "image" }}:{{ index (index (index .Values "silta-downscaler") "proxy") "imageTag" }}'
 {{- end }}

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -280,6 +280,9 @@ silta-downscaler:
     requests:
       cpu: 10m
       memory: 50Mi
+  proxy:
+    image: wunderio/silta-downscaler
+    imageTag: v0.2-proxy
 
 # https://github.com/wunderio/charts/blob/master/silta-proxy
 silta-proxy:


### PR DESCRIPTION
Silta cluster chart (0.2.42):
- Adds missing PLACEHOLDER_PROXY_IMAGE ([PR](https://github.com/wunderio/charts/pull/366))