### PR TITLE
drupal: specifies undefined targetPort so helm does not merge with downscaled 8080

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.4.1
+version: 0.4.2
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/varnish-service.yaml
+++ b/drupal/templates/varnish-service.yaml
@@ -24,9 +24,11 @@ spec:
   - name: web
     protocol: TCP
     port: 80
+    targetPort: 80
   - name: admin
     protocol: TCP
-    port: 6082 
+    port: 6082
+    targetPort: 6082
   selector:
     {{- include "drupal.release_selector_labels" . | nindent 4 }}
     service: varnish


### PR DESCRIPTION
This should fix the "Bad gateway" issue for downscaled sites. Helm does not replace spec.ports, just merges and since varnish service does not define targetPort, it just leaves the 8080 from downscaler.  