### PR TITLE
Additional handling for other env value types

### DIFF
--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -255,7 +255,7 @@ imagePullSecrets:
 # Environment overrides via values file
 {{- range $key, $val := .Values.php.env }}
 - name: {{ $key }}
-{{- if kindIs "string" $val }}
+{{- if or (kindIs "string" $val) (kindIs "int" $val) (kindIs "float64" $val) }}
   value: {{ $val | quote }}
 {{- else }}
   {{ $val | toYaml | indent 4 | trim }}

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -41,7 +41,7 @@ spec:
             {{- include "services.env" (dict "Values" $.Values "Release" $.Release "service" $service) | nindent 12 }}
             {{- range $key, $val := $service.env }}
             - name: {{ $key }}
-            {{- if kindIs "string" $val }}
+            {{- if or (kindIs "string" $val) (kindIs "int" $val) (kindIs "float64" $val) }}
               value: {{ $val | quote }}
             {{- else }}
               {{ $val | toYaml | indent 14 | trim }}

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -66,7 +66,7 @@ spec:
         {{- include "services.env" (dict "Values" $.Values "Release" $.Release "service" $service) | nindent 8 }}
         {{- range $key, $val := $service.env }}
         - name: {{ $key }}
-        {{- if kindIs "string" $val }}
+        {{- if or (kindIs "string" $val) (kindIs "int" $val) (kindIs "float64" $val) }}
           value: {{ $val | quote }}
         {{- else }}
           {{ $val | toYaml | indent 12 | trim }}
@@ -206,7 +206,7 @@ spec:
         {{- include "services.env" (dict "Values" $.Values "Release" $.Release "service" $service) | nindent 8 }}
         {{- range $key, $val := $service.env }}
         - name: {{ $key }}
-        {{- if kindIs "string" $val }}
+        {{- if or (kindIs "string" $val) (kindIs "int" $val) (kindIs "float64" $val) }}
           value: {{ $val | quote }}
         {{- else }}
           {{ $val | toYaml | indent 4 | trim }}


### PR DESCRIPTION
Current code generates incorrect template when value is of integer or float type. This adds additional types.

Before:
```
- name: FOO: 
  value: "bar"
- name: BAR
  "123"
```

After:
```
- name: FOO: 
  value: "bar"
- name: BAR
  value: "123"
```


