### PR TITLE
rclone as optional storage backend for nfs server

### DIFF
--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.2.0
+version: 1.3.0
 # kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx

--- a/silta-cluster/templates/nfs-server.yaml
+++ b/silta-cluster/templates/nfs-server.yaml
@@ -1,4 +1,5 @@
-{{- if index (index .Values "nfs-server") "enabled" }}
+{{- $nfsserver := index .Values "nfs-server" }}
+{{- if $nfsserver.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -18,9 +19,8 @@ spec:
       enableServiceLinks: false
       containers:
       - name: nfs-server
-        image: '{{ index (index .Values "nfs-server") "image" }}:{{ index (index .Values "nfs-server") "imageTag" }}'
-        imagePullPolicy: {{ index (index .Values "nfs-server") "imagePullPolicy" }}
-        # TODO: resources:
+        image: '{{ $nfsserver.image }}:{{ $nfsserver.imageTag }}'
+        imagePullPolicy: {{ $nfsserver.imagePullPolicy }}
         ports:
         - name: nfs
           containerPort: 2049
@@ -40,25 +40,74 @@ spec:
           tcpSocket:
             port: 111
         resources:
-          {{- index (index .Values "nfs-server") "resources" | toYaml | nindent 10 }}
+          {{- $nfsserver.resources | toYaml | nindent 10 }}
         volumeMounts:
+        {{- if $nfsserver.persistence.rclone.enabled }}
+        - name: exports
+          mountPath: /exports
+          mountPropagation: Bidirectional
+        {{- else }}
         - name: {{ .Release.Name }}-nfs-server-data
           mountPath: /exports
+        {{- end }}
+      {{- if $nfsserver.persistence.rclone.enabled }}
+      - name: rclone
+        image: {{ $nfsserver.persistence.rclone.image }}
+        imagePullPolicy: {{ $nfsserver.persistence.rclone.imagePullPolicy }}
+        # TODO: cache modes and other options + expose flags in values.yaml
+        command: [
+          "/usr/local/bin/rclone", 
+          "mount", 
+          "backend:{{ $nfsserver.persistence.rclone.remotePath }}", 
+          "/exports", 
+          "--allow-non-empty", 
+          "--allow-other",
+          {{- range $key, $value := $nfsserver.persistence.rclone.params }}
+          "--{{ $key }}={{ $value }}",
+          {{- end }}
+        ]
+        securityContext:
+          # Required by fuse mount
+          privileged: true
+          capabilities:
+            add:
+              - SYS_ADMIN
+        resources:
+          {{- $nfsserver.persistence.rclone.resources | toYaml | nindent 10 }}
+        volumeMounts:
+          - name: rclone-config
+            mountPath: /config/rclone/rclone.conf
+            subPath: rclone.conf
+          - name: exports
+            mountPath: /exports
+            mountPropagation: Bidirectional
+      {{- end }}
+      volumes:
+      - name: rclone-config
+        configMap:
+          name: {{ .Release.Name }}-nfs-server-rclone-config
+      {{- if $nfsserver.persistence.rclone.enabled}}
+      - name: exports
+        emptyDir: {}
+      {{- end }}
+
+  {{- if not $nfsserver.persistence.rclone.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: {{ .Release.Name }}-nfs-server-data
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      {{- if index (index (index (index .Values "nfs-server") "persistence") "data") "storageClassName" }}
-      storageClassName: {{ index (index (index (index .Values "nfs-server") "persistence") "data") "storageClassName" }}
+      {{- if $nfsserver.persistence.data.storageClassName }}
+      storageClassName: {{ $nfsserver.persistence.data.storageClassName }}
       {{- end }}
-      {{- if index (index (index (index .Values "nfs-server") "persistence") "data") "csiDriverName" }}
-      csiDriverName: {{ index (index (index (index .Values "nfs-server") "persistence") "data") "csiDriverName" }}
+      {{- if $nfsserver.persistence.data.csiDriverName }}
+      csiDriverName: {{ $nfsserver.persistence.data.csiDriverName }}
       {{- end }}
       resources:
         requests:
-          storage: {{ index (index (index (index .Values "nfs-server") "persistence") "data") "size" }}
-      accessModes: {{ index (index (index (index .Values "nfs-server") "persistence") "data") "accessModes" }}
+          storage: {{ $nfsserver.persistence.data.size }}
+      accessModes: {{ $nfsserver.persistence.data.accessModes }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -75,5 +124,18 @@ spec:
     port: 111
   selector:
     app: {{ .Release.Name }}-nfs-server
+
+{{- if $nfsserver.persistence.rclone.enabled }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-nfs-server-rclone-config
+  namespace: {{ .Release.Namespace }}
+data:
+  rclone.conf: |
+    [backend]
+    {{- $nfsserver.persistence.rclone.backend_config | nindent 4 }}
+{{- end }}
 
 {{- end }}

--- a/silta-cluster/templates/nfs-server.yaml
+++ b/silta-cluster/templates/nfs-server.yaml
@@ -54,7 +54,6 @@ spec:
       - name: rclone
         image: {{ $nfsserver.persistence.rclone.image }}
         imagePullPolicy: {{ $nfsserver.persistence.rclone.imagePullPolicy }}
-        # TODO: cache modes and other options + expose flags in values.yaml
         command: [
           "/usr/local/bin/rclone", 
           "mount", 
@@ -82,11 +81,11 @@ spec:
             mountPath: /exports
             mountPropagation: Bidirectional
       {{- end }}
+      {{- if $nfsserver.persistence.rclone.enabled }}
       volumes:
       - name: rclone-config
         configMap:
           name: {{ .Release.Name }}-nfs-server-rclone-config
-      {{- if $nfsserver.persistence.rclone.enabled}}
       - name: exports
         emptyDir: {}
       {{- end }}
@@ -137,5 +136,7 @@ data:
     [backend]
     {{- $nfsserver.persistence.rclone.backend_config | nindent 4 }}
 {{- end }}
+
+---
 
 {{- end }}

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -336,7 +336,35 @@ nfs-server:
     limits:
       cpu: 100m
       memory: 512M
-  persistence:
+  persistence:    
+    rclone:
+      enabled: false
+      image: rclone/rclone:1.63
+      # bucket
+      remotePath: ""
+      # rclone config file content (except [remote] header)
+      # https://rclone.org/docs/#config-config-file
+      backend_config: |
+        # type = google cloud storage
+        # project_number = test-project-123
+        # service_account_credentials = { escaped json, convert newlines to \n }
+        # location = region
+        # links = true
+        # gcs_directory_markers = true
+        # bucket_policy_only = true
+      # rclone mount commmand flags
+      # https://rclone.org/commands/rclone_mount/
+      params:
+        cache-chunk-clean-interval: 15m
+        dir-cache-time: 5s
+        vfs-cache-mode: writes
+        cache-info-age: 72h
+        allow-non-empty: true
+        allow-other: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128M
     data:
       size: 10Gi
       # storageClassName: standard

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -317,7 +317,7 @@ silta-shared-nfs:
     server: silta-cluster-nfs-server.silta-cluster.svc.cluster.local
     path: /
   storageClass:
-    name: silta-nfs-shared
+    name: silta-shared-nfs
     # Set volume bindinng mode - Immediate or WaitForFirstConsumer
     volumeBindingMode: WaitForFirstConsumer
     pathPattern: "${.PVC.namespace}/${.PVC.annotations.storage.silta/storage-path}"


### PR DESCRIPTION
Adds rclone as optional storage backend for built in nfs server. NFS share is provisioned when `silta-nfs-shared` storageClass is defined for the storage.

Minimum setup instructions for GCS:
1. GCS bucket
2. ServiceAccount with access to bucket.
3. Deploy silta-cluster with additional values -  
```yaml
nfs-server:
  enabled: true
  persistence:    
    rclone:
      enabled: true
      remotePath: gcs-bucket-name
      # rclone config file content (except [remote] header)
      # https://rclone.org/docs/#config-config-file
      backend_config: |
        # type = google cloud storage
        # project_number = gcp-test-project-123
        # service_account_credentials = { escaped json, convert newlines to \n }
        # location = region
        # links = true
        # gcs_directory_markers = true
        # bucket_policy_only = true
```