### PR TITLE
Drupal: disabling nginx vts stats page until base images images are updated

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.7.0
+version: 0.7.1
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -354,17 +354,18 @@ data:
         
         stub_status on;
       }
-      location /nginx_vts {
-        satisfy any;
-        allow 127.0.0.1;
-        {{- range .Values.nginx.noauthips }}
-        allow {{ . }};
-        {{- end }}
-        deny all;
+      # Disabled until base images images are updated
+      # location /nginx_vts {
+      #   satisfy any;
+      #   allow 127.0.0.1;
+      #   {{- range .Values.nginx.noauthips }}
+      #   allow {{ . }};
+      #   {{- end }}
+      #   deny all;
 
-        vhost_traffic_status_display;
-        vhost_traffic_status_display_format html;
-      }
+      #   vhost_traffic_status_display;
+      #   vhost_traffic_status_display_format html;
+      # }
       {{- end }}
 
       {{- if .Values.php.fpm.status_page.enabled }}


### PR DESCRIPTION
Reverts https://github.com/wunderio/drupal-project-k8s/pull/644
Projects are having hard times with builds as base image is not pulled in docker builds unless the codebase has changed. Let's disable nginx vts module for few months until more or less all builds have pulled a more recent base image. 
