### PR TITLE
Release 2023-09-26

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 0.8.0
+version: 0.9.0
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -665,3 +665,9 @@ autoscaling/v2
 autoscaling/v2beta1
 {{- end }}
 {{- end }}
+
+{{- define "masking.prefix-alert" -}}
+{{ if $.Values.domainPrefixes }}
+{{ fail "Cannot use domain prefixes together with domain masking"}}
+{{- end -}}
+{{- end -}}

--- a/drupal/templates/backup-volume.yaml
+++ b/drupal/templates/backup-volume.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.backup.enabled }}
+{{- if eq .Values.backup.storageClassName "silta-shared" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -20,6 +21,7 @@ spec:
       remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/backups
   {{- end }}
 ---
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/drupal/templates/drupal-volumes.yaml
+++ b/drupal/templates/drupal-volumes.yaml
@@ -54,6 +54,7 @@ spec:
 
 {{- if .Values.referenceData.enabled }}
 {{- if eq .Values.referenceData.referenceEnvironment .Values.environmentName }}
+{{- if eq .Values.referenceData.storageClassName "silta-shared" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -75,6 +76,7 @@ spec:
       remotePathSuffix: /{{ .Release.Namespace }}/{{ .Values.environmentName }}/reference-data
   {{- end }}
 ---
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/drupal/templates/shell-volume.yaml
+++ b/drupal/templates/shell-volume.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.shell.enabled }}
 {{- $releaseNameTrimmed := substr 0 (int (sub 54 (len "ssh-keys"))) $.Release.Name }}
+{{- if eq .Values.shell.mount.storageClassName "silta-shared" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -22,6 +23,8 @@ spec:
       umask: "077"
   {{- end }}
 ---
+{{- end }}
+
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/drupal/tests/drupal_deployment_test.yaml
+++ b/drupal/tests/drupal_deployment_test.yaml
@@ -35,14 +35,138 @@ tests:
     template: drupal-deployment.yaml
     set:
       php.env:
-        foo: bar
+        string_with_double_quotes: "This is a string."
+        string_with_single_quotes: 'This is a string.'
+        string_without_quotes: This is a string.
+        special_char_with_double_quotes: "This is a\nstring.\n"
+        special_char_with_single_quotes: 'This is a\nstring.\n'
+        special_char_without_quotes: This is a\nstring.\n
+        integer_without_quotes: 12345
+        integer_with_double_quotes: "12345"
+        integer_with_single_quotes: '12345'
+        float_without_quotes: 3.14159
+        float_with_double_quotes: "3.14159"
+        float_with_single_quotes: '3.14159'
+        boolean_without_quotes: true
+        boolean_with_double_quotes: "true"
+        boolean_with_single_quotes: 'true'
+        boolean_on: on
+        boolean_off: off
+        value_from_secret:
+          valueFrom:
+            secretKeyRef:
+              name: secret-resource
+              key: somefield
+        value_from_configmap:
+          valueFrom:
+            configMapKeyRef:
+              name: configmap-resource
+              key: somefield
       environmentName: baz
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: foo
-            value: bar
+            name: string_with_double_quotes
+            value: This is a string.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: string_with_single_quotes
+            value: This is a string.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: string_without_quotes
+            value: This is a string.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: special_char_with_double_quotes
+            value:  |
+              This is a
+              string.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: special_char_with_single_quotes
+            value: This is a\nstring.\n
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: special_char_without_quotes
+            value: This is a\nstring.\n
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: integer_without_quotes
+            value: "12345"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: integer_with_double_quotes
+            value: "12345"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: integer_with_single_quotes
+            value: "12345"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: float_without_quotes
+            value: "3.14159"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: float_with_double_quotes
+            value: "3.14159"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: float_with_single_quotes
+            value: "3.14159"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: boolean_without_quotes
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: boolean_with_double_quotes
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: boolean_with_single_quotes
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: boolean_on
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: boolean_off
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: value_from_secret
+            valueFrom:
+              secretKeyRef:
+                name: secret-resource
+                key: somefield
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: value_from_configmap
+            valueFrom:
+              configMapKeyRef:
+                name: configmap-resource
+                key: somefield
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -160,7 +284,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.limits.memory
           value: 2G
- 
+
   - it: sets varnish environment variables if varnish is enabled
     template: drupal-deployment.yaml
     set:
@@ -184,7 +308,7 @@ tests:
               secretKeyRef:
                 key: control_key
                 name: RELEASE-NAME-secrets-varnish
-  
+
   - it: does not have varnish environment variables if varnish is disabled
     template: drupal-deployment.yaml
     set:

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -21,6 +21,7 @@
     "exposeDomainsDefaults": { "type": "object"},
     "domainPrefixes": { "type": "array", "items": { "type": "string"}},
     "singleSubdomain": { "type": "boolean"},
+    "maskSubdomains": {"type": "string"},
     "ssl": { "type": "object" },
     "backendConfig": { "type": ["array","object"], "items": { "type": "object"}},
     "ingress": { "type": "object" },

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -514,6 +514,9 @@ backup:
 # see: https://github.com/bitnami/charts/blob/91fcd1eb5d00c33cc74e24502a85ce656ac1e963/bitnami/mariadb/values.yaml
 mariadb:
   enabled: true
+  image:
+    # https://hub.docker.com/r/bitnami/mariadb/tags
+    tag: 10.6.15-debian-11-r24
   replication:
     enabled: false
   db:
@@ -813,3 +816,10 @@ signalsciences:
 logging:
   # Currently supported formats are "default" and "json".
   format: default
+
+# Obfuscate parts of the full domain name.
+# Available values for maskSubdomains are:
+# - releaseName (scrambles release name subdomain, e.g., xxx.project.silta.tld)
+# - projectName (scrambles project name subdomain, e.g., release.yyy.silta.tld)
+# - both (obfuscates both, e.g., zzz.silta.tld)
+# maskSubdomains: both

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 0.6.0
+version: 0.7.0
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -51,9 +51,7 @@ spec:
             args:
               - |
                  set -ex
-                 echo "starting cron run"
                  {{ $job.command | nindent 18 }}
-                 echo "cron run completed"
             resources:
               {{- if $job.resources }}
               {{- if $service.resources }}

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -336,6 +336,9 @@ serviceDefaults:
 # see: https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
 mariadb:
   enabled: false
+  image:
+    # https://hub.docker.com/r/bitnami/mariadb/tags
+    tag: 10.6.15-debian-11-r24
   replication:
     enabled: false
   db:


### PR DESCRIPTION
Drupal chart (0.9.0)

- Added more tests for php env vars ([PR](https://github.com/wunderio/drupal-project-k8s/pull/650))
- SLT-883: Upgrade default MariaDB version to 10.6 ([PR](https://github.com/wunderio/drupal-project-k8s/pull/656))
- Added support for subdomain masking ([PR](https://github.com/wunderio/drupal-project-k8s/pull/653))
- Create backup and referenceData PersistentVolume only when using silta-shared storageclass ([PR](https://github.com/wunderio/drupal-project-k8s/pull/643))

Frontend chart (0.7.0)

- SLT-883: Upgrade default Maria DB version to 10.6 ([PR](https://github.com/wunderio/frontend-project-k8s/pull/99))
- Remove extra "echo" lines from cronjobs ([PR](https://github.com/wunderio/frontend-project-k8s/pull/97))