### PR TITLE
limiting drupal cron retries to 0

### DIFF
--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -17,6 +17,7 @@ spec:
   suspend: false
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         metadata:
           labels:


### PR DESCRIPTION
Limiting the cron to the single attempt to run, as majority of the time it will try again anyway in one minute and usually it fails because of either commandline or external error.