### PR TITLE
use forked minio subchart

### DIFF
--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.0.2
+version: 1.1.0
 # kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx


### PR DESCRIPTION
silta-cluster chart version increase to start using the forked minio (6.0.5) subchart. Related PR: https://github.com/wunderio/charts/pull/404