### PR TITLE
Fix varnish static file extension matching regex in vcl_backend_response

### DIFF
--- a/drupal/templates/varnish-configmap-vcl.yaml
+++ b/drupal/templates/varnish-configmap-vcl.yaml
@@ -183,7 +183,7 @@ data:
         set beresp.http.x-ttl = "10m";
       }
 
-      if (bereq.url ~ "\.(jpg|jpeg|gif|png|svg|ico|webp|css|js|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|flv|swf|html|htm|otf)\??.*$") {
+      if (bereq.url ~ "^[^?]*\.(jpg|jpeg|gif|png|svg|ico|webp|css|js|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|flv|swf|html|htm|otf)(\?.*)?$") {
         # Strip any cookies before static files are inserted into cache.
         unset beresp.http.set-cookie;
         if(beresp.status == 200){


### PR DESCRIPTION
The regex currently in use is faulty and matches cases where the file extension appears inside the query string e.g. `example.com/path?foo=image.jpg`. Use the same improved pattern that we already have a few lines below in: https://github.com/wunderio/charts/blob/master/drupal/templates/varnish-configmap-vcl.yaml#L202