### PR TITLE
SLT-965: Increase Traefik pod readiness probe initial delay

### DIFF
--- a/legacy_traefik/templates/deployment.yaml
+++ b/legacy_traefik/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
             path: /ping
             port: "{{ .Values.pingEntryPoint | default "http" }}"
           failureThreshold: 1
-          initialDelaySeconds: 10
+          initialDelaySeconds: 45
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2

--- a/legacy_traefik/templates/deployment.yaml
+++ b/legacy_traefik/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
             path: /ping
             port: "{{ .Values.pingEntryPoint | default "http" }}"
           failureThreshold: 1
-          initialDelaySeconds: 45
+          initialDelaySeconds: 60
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2


### PR DESCRIPTION
This increases Traefik pod readiness probe initial delay from 10 to 45 seconds to mitigate the issue that Traefik starts to pass requests to pods in project namespaces before it is actually ready to do so.

Based on recent tests Traefik pods need around 36 seconds to start up in dev cluster.

The downside of this change if we just hard-code the delay value is that time for scaling-up traefik will increase (also in production) by 35 seconds and in case of rapid load spikes and little resource reserve that may not be ideal.
In ideal case we would have different value for development and production clusters.