### PR TITLE
Release 2023-12-12

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ jobs:
       K8S_PROJECT_REPO_DIR: k8s-project-repositories
     if: github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Silta CLI setup
         run: |
           mkdir -p ~/.local/bin

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         # Available minikube kubernetes version list: 
         # "minikube config defaults kubernetes-version"
         # and https://kubernetes.io/releases/patch-releases/
-        kubernetes-version: ["v1.20.15", "v1.21.14", "v1.22.17", "v1.23.17", "v1.24.12", "v1.25.8", "1.26.1", "latest"]
+        kubernetes-version: ["v1.22.17", "v1.23.17", "v1.24.17", "v1.25.16", "1.26.11", "1.27.8", "1.28.4", "latest"]
     env:
       CLUSTER_DOMAIN: minikube.local.wdr.io
       K8S_PROJECT_REPO_DIR: k8s-project-repositories

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 1.1.1
+version: 1.2.0
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -86,7 +86,7 @@ data:
 
   {{- if .Values.nginx.status_page.enabled }}
   nginx_status_conf: |
-    # load_module modules/ngx_http_vhost_traffic_status_module.so;
+    load_module modules/ngx_http_vhost_traffic_status_module.so;
   {{- end }}
     
   nginx_conf: |
@@ -111,9 +111,9 @@ data:
       sigsci_agent_host unix:/sigsci/tmp/sigsci.sock;
       {{- end }}
 
-      # {{- if .Values.nginx.status_page.enabled }}
-      # vhost_traffic_status_zone;
-      # {{- end }}
+      {{- if .Values.nginx.status_page.enabled }}
+      vhost_traffic_status_zone;
+      {{- end }}
 
       # List of upstream proxies we trust to set X-Forwarded-For correctly.
       {{- if kindIs "string" .Values.nginx.realipfrom }}
@@ -355,17 +355,17 @@ data:
         stub_status on;
       }
       # Disabled until base images images are updated
-      # location /nginx_vts {
-      #   satisfy any;
-      #   allow 127.0.0.1;
-      #   {{- range .Values.nginx.noauthips }}
-      #   allow {{ . }};
-      #   {{- end }}
-      #   deny all;
+      location /nginx_vts {
+        satisfy any;
+        allow 127.0.0.1;
+        {{- range .Values.nginx.noauthips }}
+        allow {{ . }};
+        {{- end }}
+        deny all;
 
-      #   vhost_traffic_status_display;
-      #   vhost_traffic_status_display_format html;
-      # }
+        vhost_traffic_status_display;
+        vhost_traffic_status_display_format html;
+      }
       {{- end }}
 
       {{- if .Values.php.fpm.status_page.enabled }}

--- a/frontend/Chart.lock
+++ b/frontend/Chart.lock
@@ -14,8 +14,11 @@ dependencies:
 - name: mongodb
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 10.26.4
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.2.23
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.0
-digest: sha256:c356de05b806d3ca439e2eeea4ee23b206e8c4912818806ae6c65227005c3757
-generated: "2023-11-13T13:00:16.425472744+02:00"
+digest: sha256:65fdb7bf8bb3fd0f284f5bc4325d0c8fe9feb47e64d162dca955b01bc5ee9fb2
+generated: "2023-12-01T19:20:38.495950175+02:00"

--- a/frontend/Chart.lock
+++ b/frontend/Chart.lock
@@ -15,10 +15,10 @@ dependencies:
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 10.26.4
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 13.2.23
+  repository: https://storage.googleapis.com/charts.wdr.io
+  version: 13.2.24
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.0
-digest: sha256:65fdb7bf8bb3fd0f284f5bc4325d0c8fe9feb47e64d162dca955b01bc5ee9fb2
-generated: "2023-12-01T19:20:38.495950175+02:00"
+digest: sha256:95eb80d5b21e1fb9cf5c0bf1b917801d027df824b84fcb6cd4d377fcb6a542b4
+generated: "2023-12-12T18:45:46.652661621+02:00"

--- a/frontend/Chart.lock
+++ b/frontend/Chart.lock
@@ -14,11 +14,8 @@ dependencies:
 - name: mongodb
   repository: https://storage.googleapis.com/charts.wdr.io
   version: 10.26.4
-- name: postgresql
-  repository: https://storage.googleapis.com/charts.wdr.io
-  version: 13.2.24
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.0
-digest: sha256:95eb80d5b21e1fb9cf5c0bf1b917801d027df824b84fcb6cd4d377fcb6a542b4
-generated: "2023-12-12T18:45:46.652661621+02:00"
+digest: sha256:c356de05b806d3ca439e2eeea4ee23b206e8c4912818806ae6c65227005c3757
+generated: "2023-12-12T18:53:09.289992471+02:00"

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -24,11 +24,11 @@ dependencies:
   version: 10.26.x
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: mongodb.enabled
-- name: postgresql
-  version: 13.2.x
-  # repository: https://charts.bitnami.com/bitnami
-  repository: https://storage.googleapis.com/charts.wdr.io
-  condition: postgresql.enabled
+# - name: postgresql
+#   version: 13.2.x
+#   # repository: https://charts.bitnami.com/bitnami
+#   repository: https://storage.googleapis.com/charts.wdr.io
+#   condition: postgresql.enabled
 - name: silta-release
   version: ^1.x
   repository: file://../silta-release

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.1.0
+version: 1.2.0
 dependencies:
 - name: mariadb
   version: 7.10.x
@@ -24,6 +24,10 @@ dependencies:
   version: 10.26.x
   repository: https://storage.googleapis.com/charts.wdr.io
   condition: mongodb.enabled
+- name: postgresql
+  version: 13.2.x
+  repository: https://charts.bitnami.com/bitnami
+  condition: postgresql.enabled
 - name: silta-release
   version: ^1.x
   repository: file://../silta-release

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -26,7 +26,8 @@ dependencies:
   condition: mongodb.enabled
 - name: postgresql
   version: 13.2.x
-  repository: https://charts.bitnami.com/bitnami
+  # repository: https://charts.bitnami.com/bitnami
+  repository: https://storage.googleapis.com/charts.wdr.io
   condition: postgresql.enabled
 - name: silta-release
   version: ^1.x

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -187,11 +187,11 @@ spec:
         args:
         - |
             {{- if $.Release.IsInstall }}
-            {{- if $service.postinstall.command }}
+            {{- if ($service.postinstall).command }}
             {{- $service.postinstall.command | nindent 10 }}
             {{- end }}
             {{- end }}
-            {{- if $service.postupgrade.command }}
+            {{- if ($service.postupgrade).command }}
             {{- $service.postupgrade.command | nindent 10 }}
             {{- end }}
         volumeMounts:

--- a/frontend/values.schema.json
+++ b/frontend/values.schema.json
@@ -436,6 +436,12 @@
         }
       }
     },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
     "elasticsearch": {
       "type": "object",
       "properties": {

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -424,12 +424,19 @@ elasticsearch:
 
 # These settings are not optimized. To see which overrides are available see:
 # https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml
-
 mongodb:
   enabled: false
   image:
     tag: 5.0.3
 
+  # Use a low default to prevent unnecessary storage use.
+  persistence:
+    size: 1Gi
+
+# Posgresql overrides
+# see: https://github.com/bitnami/charts/blob/c3dc56f3679650f1012e497b8a5e71d94dac163e/bitnami/postgresql/values.yaml
+postgresql:
+  enabled: false
   # Use a low default to prevent unnecessary storage use.
   persistence:
     size: 1Gi

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -433,13 +433,13 @@ mongodb:
   persistence:
     size: 1Gi
 
-# Posgresql overrides
-# see: https://github.com/bitnami/charts/blob/c3dc56f3679650f1012e497b8a5e71d94dac163e/bitnami/postgresql/values.yaml
-postgresql:
-  enabled: false
-  # Use a low default to prevent unnecessary storage use.
-  persistence:
-    size: 1Gi
+# # Posgresql overrides
+# # see: https://github.com/bitnami/charts/blob/c3dc56f3679650f1012e497b8a5e71d94dac163e/bitnami/postgresql/values.yaml
+# postgresql:
+#   enabled: false
+#   # Use a low default to prevent unnecessary storage use.
+#   persistence:
+#     size: 1Gi
 
 rabbitmq:
   enabled: false

--- a/legacy_traefik/templates/deployment.yaml
+++ b/legacy_traefik/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
             path: /ping
             port: "{{ .Values.pingEntryPoint | default "http" }}"
           failureThreshold: 1
-          initialDelaySeconds: 10
+          initialDelaySeconds: 45
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2

--- a/legacy_traefik/templates/deployment.yaml
+++ b/legacy_traefik/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
             path: /ping
             port: "{{ .Values.pingEntryPoint | default "http" }}"
           failureThreshold: 1
-          initialDelaySeconds: 45
+          initialDelaySeconds: 60
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.1.0
+version: 1.2.0
 # kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx


### PR DESCRIPTION
Frontend chart (1.2.)
- ~[Add postgresql chart](https://github.com/wunderio/frontend-project-k8s/pull/107) (credit: @badrange)~ (removed due to bitnami common variable conflicts with forked versions.)
- [Fix for empty postinstall command](https://github.com/wunderio/frontend-project-k8s/pull/108)

Drupal chart (1.2.0)
  - [Reenabling nginx vhost_traffic_status_module](https://github.com/wunderio/drupal-project-k8s/pull/677)

Silta-cluster (1.2.0)
  - [Increase Traefik pod readiness probe initial delay](https://github.com/wunderio/charts/pull/408) (credit: @gatis)
  
 Charts
   - Chart integration tests with kubernetes 1.27.8 and 1.28.4 added, testing with 1.20.15 and 1.21.14 removed.