### PR TITLE
Feature: Configurable backoff limit.

### DIFF
--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -17,7 +17,7 @@ spec:
   suspend: false
   jobTemplate:
     spec:
-      backoffLimit: {{- default 1 $job.backoffLimit}}
+      backoffLimit: {{ default 1 $job.backoffLimit }}
       template:
         metadata:
           labels:

--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -17,7 +17,7 @@ spec:
   suspend: false
   jobTemplate:
     spec:
-      backoffLimit: 1
+      backoffLimit: {{- default 1 $job.backoffLimit}}
       template:
         metadata:
           labels:

--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -17,7 +17,7 @@ spec:
   suspend: false
   jobTemplate:
     spec:
-      backoffLimit: {{ default 1 $job.backoffLimit }}
+      backoffLimit: {{ $job.backoffLimit | default 1 }}
       template:
         metadata:
           labels:

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -248,6 +248,7 @@
             "properties": {
               "schedule": { "type": "string" },
               "command": { "type": "string" },
+              "backoffLimit": { "type": "integer" },
               "nodeSelector": { "type": ["object", "null"] },
               "resources": {
                 "type": "object",

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -267,6 +267,9 @@ php:
       # Set a nodeSelector specifically for cron jobs.
       nodeSelector: {}
 
+      # Specify a how many attempts should be made before considering a cron job as failed.
+      backoffLimit: 1
+
       # Set resources specifically for cron jobs. If not set, they will be
       # inherited from php.resources.
       resources:


### PR DESCRIPTION
**BackoffLimits should not be hardcoded and reduced to 1 attempt without option to change that.**

In specific sites there is need for increased backoff limit. Example:
Migrations are run every night against API that is not reliable and might not respond in time. In that case my only option is to   run them multiple times even if first attempt was successful.

Changes proposed:
- Set backoffLimit to 1 by default
- Allow setting backoffLimit per cron job


FYI: this is urgent as currently there is no other way to run migrations except for running them multiple times with no reason just because its not clear if they have finalised successfully. 

Tested: https://github.com/wunderio/drupal-project-k8s/tree/backoff 
