### PR TITLE
accept hpa v2 api configuration snippets in metrics

### DIFF
--- a/legacy_traefik/templates/hpa.yaml
+++ b/legacy_traefik/templates/hpa.yaml
@@ -29,6 +29,9 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .resource.targetAverageUtilization }}
+      {{- else if .resource.target }}
+      target:
+        {{- .resource.target | toYaml | nindent 8 }}
       {{- end }}
   {{- end }}
   {{- else }}

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.2.0
+version: 1.2.1
 # kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx


### PR DESCRIPTION
This fixes issue where v2 api hpa configuration is copied directly into traefik hpa overrides. Allows having both original definition and the new one.

old:
```
 autoscaling:
    metrics:
    - type: Resource
      resource:
        name: cpu
        targetAverageUtilization: 80
    - type: Resource
      resource:
        name: memory
        targetAverageUtilization: 80
```

new:
```
autoscaling:
    metrics:
      - type: Resource
        resource:
          name: cpu
          target:
            type: Utilization
            averageUtilization: 80
      - type: Resource
        resource:
          name: memory
          target:
            type: Utilization
            averageUtilization: 80
```