### PR TITLE
nginx LB replacement for traefik

### DIFF
--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -8,6 +8,9 @@ dependencies:
 - name: traefik
   repository: file://../legacy_traefik
   version: 1.87.7
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.8.3
 - name: pxc-operator
   repository: https://percona.github.io/percona-helm-charts/
   version: 1.12.2
@@ -25,7 +28,7 @@ dependencies:
   version: 1.0.0
 - name: instana-agent
   repository: https://agents.instana.io/helm
-  version: 1.2.66
+  version: 1.2.67
 - name: nfs-subdir-external-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
   version: 4.0.18
@@ -35,5 +38,5 @@ dependencies:
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.0
-digest: sha256:df6f7b163fe7389617d938a7f80da42bd46ca249820e5e32313ff7abedfa8b21
-generated: "2023-11-30T11:31:16.305257237+02:00"
+digest: sha256:476923948f8e9a38d21fea33fe3e588d74630b9e881b30dca32354398a063d9b
+generated: "2024-02-15T17:05:13.666080904+02:00"

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -19,6 +19,12 @@ dependencies:
   version: 1.87.x
   repository: file://../legacy_traefik
   condition: traefik.enabled
+- name: ingress-nginx
+  # check kubernetes version requirements here: https://github.com/kubernetes/ingress-nginx
+  version: 4.8.x
+  alias: nginx-traefik
+  repository: https://kubernetes.github.io/ingress-nginx
+  condition: nginx-traefik.enabled
 - name: pxc-operator
   version: 1.12.x
   repository: https://percona.github.io/percona-helm-charts/

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -170,6 +170,77 @@ ssl:
   # ca: ""
   # key: ""
   # crt: ""
+
+# Community ingress-nginx chart
+# https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
+# https://github.com/kubernetes/ingress-nginx/blob/e4a66fd2f625de3bcc7aaa793b31f529a0662009/charts/ingress-nginx/values.yaml
+# This is a duplicate of the ingress-nginx chart, but with a different name, meant to immitate traefik ingress class and replace it.
+nginx-traefik:
+  enabled: false
+  controller:
+    # see autoscaling section below
+    replicaCount: 1
+    service:
+      # loadBalancerIP: 1.2.3.4
+      externalTrafficPolicy: Local
+    ingressClass: traefik
+    ingressClassResource:
+      default: false
+      name: traefik
+    watchIngressWithoutClass: false
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 80
+    config:
+      # Optional CDN configuration
+      use-proxy-protocol: false
+      use-forwarded-headers: true
+      compute-full-forwarded-for: true
+      # forwarded-for-header: "X-Forwarded-For"
+      # proxy-real-ip-cidr: "1.1.1.1/32, 2.2.2.2/32"
+      # Logging configuration
+      disable-access-log: false
+      disable-http-access-log: false
+      disable-stream-access-log: false
+      upstream-keepalive-requests: 16378
+      upstream-keepalive-connections: 4096
+      keep-alive-requests: 16378
+      use-geoip: false
+      use-gzip: false
+      gzip-level: 1
+      # ModSecurity https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-modsecurity
+      # Off by default, enable using ingress annotations
+      enable-modsecurity: false
+      enable-owasp-modsecurity-crs: false
+      # Required minimum configuration since SecRuleEngine is set to "DetectionOnly" by default
+      # modsecurity-snippet: |
+      #   SecRuleEngine On
+      #   SecRequestBodyAccess On
+    # Admission webhook is broken in GKE private clusters and requires additional configuration
+    # so we disable it by default. Enable when possible.
+    # Reference: https://github.com/kubernetes/ingress-nginx/issues/5401
+    admissionWebhooks:
+      enabled: false
+    priorityClassName: "high-priority"
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "256Mi"
+      limits:
+        cpu: 1
+        memory: 1Gi
+  # Splash page
+  defaultBackend:
+    enabled: true
+    name: defaultbackend
+    image:
+      registry: wunderio
+      image: silta-splash
+      tag: "v1"
+      readOnlyRootFilesystem: false
   
 # https://github.com/wunderio/charts/blob/master/csi-rclone/values.yaml
 csi-rclone:


### PR DESCRIPTION
Allows replacing traefik with nginx (not enabled by default, but i'd say this should be default with silta 2.x)
Note: projects that redefine traefik annotations via `ingress.[ingress name].extraAnnotations` won't work anymore (i.e. custom rate limits). Chart defaults include both traefik and nginx annotations for default values.

Minimal configuration override for drop-in replacement:
```yaml
traefik:
  enabled: false
nginx-traefik:
  enabled: true
  controller:
    service:
      loadBalancerIP: 1.1.1.1
    config:
      # upstream reverse proxies / cdn's
      forwarded-for-header: "X-Forwarded-For"
      proxy-real-ip-cidr: "1.1.1.1/1, 2.2.2.2/2"
```
Other settings available in chart defaults and ingress-nginx chart values. 