### PR TITLE
Release 2024-03-05

### DIFF
--- a/drupal/templates/backup-cron.yaml
+++ b/drupal/templates/backup-cron.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
     cronjob-type: backup
+    cronjob: "true"
 spec:
   {{- if .Values.timezone }}
   {{- if eq ( include "drupal.cron.timezone-support" . ) "true" }}
@@ -30,6 +31,10 @@ spec:
         metadata:
           annotations:
             nrmitchi.com/sidecars: mariadb
+          labels:
+            {{- include "drupal.release_labels" . | nindent 12 }}
+            cronjob-type: backup
+            cronjob: "true"
         spec:
           enableServiceLinks: false
           containers:

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -88,7 +88,7 @@ data:
   nginx_status_conf: |
     load_module modules/ngx_http_vhost_traffic_status_module.so;
   {{- end }}
-    
+
   nginx_conf: |
 
     include modules/*.conf;
@@ -133,7 +133,7 @@ data:
 
       log_format  main            '$remote_addr - $remote_user [$time_local] "$request" '
                                   '$status $body_bytes_sent "$http_referer" '
-                                  '"$http_user_agent" "$http_x_forwarded_for"';
+                                  '"$http_user_agent" "$http_x_forwarded_for" $host "$http_ja3"';
 
       access_log                  /proc/self/fd/1 main;
 
@@ -313,10 +313,6 @@ data:
 
     # List health checks that need to return status 200 here
     map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; }
-    {{- if ne .Values.nginx.x_proxy_auth "" }}
-    # Verify if x_proxy_auth value is correct
-    map $http_x_proxy_auth $proxy_auth { default 0; '{{ .Values.nginx.x_proxy_auth }}' 1; }
-    {{- end}}
 
     server {
       server_name drupal;
@@ -324,10 +320,6 @@ data:
 
       # Loadbalancer health checks need to be fed with http 200
       if ($hc_ua) { return 200; }
-      {{- if ne .Values.nginx.x_proxy_auth "" }}
-      # Block request if proxy header is set but does not match required value
-      if ($proxy_auth = 0) { return 403; }
-      {{- end}}
 
       {{- if .Values.nginx.redirects }}
       # Redirects to specified path if map returns anything
@@ -359,7 +351,7 @@ data:
         allow {{ . }};
         {{- end }}
         deny all;
-        
+
         stub_status on;
       }
       # Disabled until base images images are updated
@@ -390,9 +382,9 @@ data:
         fastcgi_param SCRIPT_FILENAME $document_root/status;
         fastcgi_index index.php;
         fastcgi_pass php;
-      }  
+      }
       {{- end }}
-      
+
       {{- if .Values.mailhog.enabled }}
       location /mailhog {
 
@@ -428,6 +420,11 @@ data:
       {{- end}}
 
       location / {
+
+        {{- if ne .Values.nginx.x_proxy_auth "" }}
+        # Verify if x_proxy_auth value is correct
+        if ( $http_x_proxy_auth != '{{ .Values.nginx.x_proxy_auth }}') { return 403; }
+        {{- end}}
 
         {{- if .Values.nginx.locationExtraConfig }}
         # Custom configuration gets included here
@@ -787,3 +784,9 @@ data:
     cgi-fcgi -bind -connect localhost:9000 \
     > /dev/null
 
+{{- range $index, $job := .Values.php.cron -}}
+{{ if $job.php_ini }}
+  php_ini_{{ $index }}: |
+    {{- tpl $job.php_ini . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -9,6 +9,7 @@ metadata:
   name: {{ $releaseNameTrimmed }}-cron-{{ $nameAppendix }}
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
+    cronjob: "true"
 spec:
   {{- if $.Values.timezone }}
   {{- if eq ( include "drupal.cron.timezone-support" $ ) "true" }}
@@ -36,6 +37,12 @@ spec:
             {{- include "drupal.php-container" $ | nindent 12 }}
             volumeMounts:
               {{- include "drupal.volumeMounts" $ | nindent 14 }}
+              {{- if $job.php_ini }}
+              - name: config
+                mountPath: /usr/local/etc/php/conf.d/silta_cron.ini
+                readOnly: true
+                subPath: php_ini_{{ $index }}
+              {{ end }}
             command: ["/bin/bash", "-c"]
             args:
               - |

--- a/drupal/templates/reference-data-cron.yaml
+++ b/drupal/templates/reference-data-cron.yaml
@@ -6,6 +6,8 @@ metadata:
   name: {{ .Release.Name }}-refdata
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
+    cronjob: "true"
+    cronjob-type: reference-data
 spec:
   {{- if .Values.timezone }}
   {{- if eq ( include "drupal.cron.timezone-support" . ) "true" }}
@@ -20,6 +22,11 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            {{- include "drupal.release_labels" . | nindent 12 }}
+            cronjob: "true"
+            cronjob-type: reference-data
         spec:
           enableServiceLinks: false
           containers:

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -252,6 +252,7 @@
               "command": { "type": "string" },
               "backoffLimit": { "type": "integer" },
               "nodeSelector": { "type": ["object", "null"] },
+              "php_ini": { "type": "string" },
               "resources": {
                 "type": "object",
                 "additionalProperties": false,

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -272,6 +272,15 @@ php:
           drush cron;
         fi
 
+    # Add custom php.ini file overrides for the cronjob.
+    # Use the same syntax as in php.ini file
+    # Example:
+    # php_ini: |
+        # [PHP]
+        # memory_limit=128M
+
+    # php_ini: |
+
       # Set a nodeSelector specifically for cron jobs.
       nodeSelector: {}
 

--- a/frontend/templates/nginx.yaml
+++ b/frontend/templates/nginx.yaml
@@ -47,7 +47,7 @@ spec:
           mountPath: /sigsci/tmp
         {{- end }}
         {{- if .Values.nginx.extraConfig }}
-        - name: config
+        - name: nginx-conf
           # provide empty configuration file in /etc/nginx/conf.d for users to populate
           mountPath: /etc/nginx/conf.d/misc.conf
           readOnly: true

--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -8,6 +8,9 @@ dependencies:
 - name: traefik
   repository: file://../legacy_traefik
   version: 1.87.7
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.8.3
 - name: pxc-operator
   repository: https://percona.github.io/percona-helm-charts/
   version: 1.12.2
@@ -25,7 +28,7 @@ dependencies:
   version: 1.0.0
 - name: instana-agent
   repository: https://agents.instana.io/helm
-  version: 1.2.66
+  version: 1.2.67
 - name: nfs-subdir-external-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
   version: 4.0.18
@@ -35,5 +38,5 @@ dependencies:
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.0
-digest: sha256:df6f7b163fe7389617d938a7f80da42bd46ca249820e5e32313ff7abedfa8b21
-generated: "2023-11-30T11:31:16.305257237+02:00"
+digest: sha256:476923948f8e9a38d21fea33fe3e588d74630b9e881b30dca32354398a063d9b
+generated: "2024-02-15T17:05:13.666080904+02:00"

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -19,6 +19,12 @@ dependencies:
   version: 1.87.x
   repository: file://../legacy_traefik
   condition: traefik.enabled
+- name: ingress-nginx
+  # check kubernetes version requirements here: https://github.com/kubernetes/ingress-nginx
+  version: 4.8.x
+  alias: nginx-traefik
+  repository: https://kubernetes.github.io/ingress-nginx
+  condition: nginx-traefik.enabled
 - name: pxc-operator
   version: 1.12.x
   repository: https://percona.github.io/percona-helm-charts/

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -170,6 +170,77 @@ ssl:
   # ca: ""
   # key: ""
   # crt: ""
+
+# Community ingress-nginx chart
+# https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
+# https://github.com/kubernetes/ingress-nginx/blob/e4a66fd2f625de3bcc7aaa793b31f529a0662009/charts/ingress-nginx/values.yaml
+# This is a duplicate of the ingress-nginx chart, but with a different name, meant to immitate traefik ingress class and replace it.
+nginx-traefik:
+  enabled: false
+  controller:
+    # see autoscaling section below
+    replicaCount: 1
+    service:
+      # loadBalancerIP: 1.2.3.4
+      externalTrafficPolicy: Local
+    ingressClass: traefik
+    ingressClassResource:
+      default: false
+      name: traefik
+    watchIngressWithoutClass: false
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 80
+    config:
+      # Optional CDN configuration
+      use-proxy-protocol: false
+      use-forwarded-headers: true
+      compute-full-forwarded-for: true
+      # forwarded-for-header: "X-Forwarded-For"
+      # proxy-real-ip-cidr: "1.1.1.1/32, 2.2.2.2/32"
+      # Logging configuration
+      disable-access-log: false
+      disable-http-access-log: false
+      disable-stream-access-log: false
+      upstream-keepalive-requests: 16378
+      upstream-keepalive-connections: 4096
+      keep-alive-requests: 16378
+      use-geoip: false
+      use-gzip: false
+      gzip-level: 1
+      # ModSecurity https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-modsecurity
+      # Off by default, enable using ingress annotations
+      enable-modsecurity: false
+      enable-owasp-modsecurity-crs: false
+      # Required minimum configuration since SecRuleEngine is set to "DetectionOnly" by default
+      # modsecurity-snippet: |
+      #   SecRuleEngine On
+      #   SecRequestBodyAccess On
+    # Admission webhook is broken in GKE private clusters and requires additional configuration
+    # so we disable it by default. Enable when possible.
+    # Reference: https://github.com/kubernetes/ingress-nginx/issues/5401
+    admissionWebhooks:
+      enabled: false
+    priorityClassName: "high-priority"
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "256Mi"
+      limits:
+        cpu: 1
+        memory: 1Gi
+  # Splash page
+  defaultBackend:
+    enabled: true
+    name: defaultbackend
+    image:
+      registry: wunderio
+      image: silta-splash
+      tag: "v1"
+      readOnlyRootFilesystem: false
   
 # https://github.com/wunderio/charts/blob/master/csi-rclone/values.yaml
 csi-rclone:

--- a/simple/templates/configmap.yaml
+++ b/simple/templates/configmap.yaml
@@ -50,7 +50,7 @@ data:
 
         log_format  main            '$remote_addr - $remote_user [$time_local] "$request" '
                                     '$status $body_bytes_sent "$http_referer" '
-                                    '"$http_user_agent" "$http_x_forwarded_for"';
+                                    '"$http_user_agent" "$http_x_forwarded_for" $host "$http_ja3"';
 
 
         access_log                  /proc/self/fd/1 main;
@@ -107,10 +107,6 @@ data:
 
         # List health checks that need to return status 200 here
         map $http_user_agent $hc_ua { default 0; 'GoogleHC/1.0' 1; 'kube-probe' 1; }
-        {{- if ne .Values.nginx.x_proxy_auth "" }}
-        # Verify if x_proxy_auth value is correct
-        map $http_x_proxy_auth $proxy_auth { default 0; '{{ .Values.nginx.x_proxy_auth }}' 1; }
-        {{- end}}
 
         include conf.d/*.conf;
     }
@@ -149,11 +145,6 @@ data:
         # Loadbalancer health checks need to be fed with http 200
         if ($hc_ua) { return 200; }
 
-        {{- if ne .Values.nginx.x_proxy_auth "" }}
-        # Block request if proxy header is set but does not match required value
-        if ($proxy_auth = 0) { return 403; }
-        {{- end}}
-
         {{- if .Values.nginx.redirects }}
         # Redirects to specified path if map returns anything
         if ($redirect_uri) {
@@ -180,6 +171,11 @@ data:
         }
 
         location / {
+
+          {{- if ne .Values.nginx.x_proxy_auth "" }}
+          # Verify if x_proxy_auth value is correct
+          if ( $http_x_proxy_auth != '{{ .Values.nginx.x_proxy_auth }}') { return 403; }
+          {{- end}}
 
             # Custom configuration include
             {{ if .Values.nginx.locationExtraConfig }}


### PR DESCRIPTION
Simple chart:
- SLT-997: Proxy auth header & JA3 logging ([PR](https://github.com/wunderio/simple-project-k8s/pull/52))

Drupal chart:
- Release labels for pods created by cronjobs ([PR](https://github.com/wunderio/drupal-project-k8s/pull/696))
- SLT-810: Overwrite PHP settings for individual cronjobs ([PR](https://github.com/wunderio/drupal-project-k8s/pull/695))
- SLT-997: Proxy auth header & JA3 logging ([PR](https://github.com/wunderio/drupal-project-k8s/pull/697), credis Artis)

Frontend chart:
- extraConfig volume name fix ([PR](https://github.com/wunderio/frontend-project-k8s/pull/114))

Silta cluster chart:
- nginx LB replacement for traefik ([PR](https://github.com/wunderio/charts/pull/420))