### PR TITLE
Fixes querying non-initialized cronjobs

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 1.6.0
+version: 1.6.1
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -785,8 +785,9 @@ data:
     > /dev/null
 
 {{- range $index, $job := .Values.php.cron -}}
-{{ if $job.php_ini }}
+{{- $jobExists := $job | default dict }}
+{{- if $jobExists.php_ini }}
   php_ini_{{ $index }}: |
-    {{- tpl $job.php_ini . | nindent 4 }}
+    {{- tpl $jobExists.php_ini . | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -42,7 +42,7 @@ spec:
                 mountPath: /usr/local/etc/php/conf.d/silta_cron.ini
                 readOnly: true
                 subPath: php_ini_{{ $index }}
-              {{ end }}
+              {{- end }}
             command: ["/bin/bash", "-c"]
             args:
               - |


### PR DESCRIPTION
Drupal chart:
- Fixes an error where cronjobs get set to `null`