### PR TITLE
SLT-968: Use unique randomizeText for gdprDump name converter.

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -482,9 +482,8 @@ gdprDump:
           parameters:
             key: 'processed_data.mail'
         name:
-          converter: 'faker'
-          parameters:
-            formatter: 'name'
+          converter: 'randomizeText'
+          unique: true
         pass:
           converter: 'randomizeText'
     commerce_order:


### PR DESCRIPTION
Ticket: https://wunder.atlassian.net/browse/SLT-968

## Changes

The `faker` converter does not guarantee unique names as `gdprDump` name converter and therefore could cause disabling randomizing in projects.

Let's use `randomizeText` with unique flag instead as used in [Drupal 7](https://github.com/Smile-SA/gdpr-dump/blob/main/app/config/templates/drupal7.yaml) & [Drupal 8](https://github.com/Smile-SA/gdpr-dump/blob/main/app/config/templates/drupal8.yaml) templates.

## Todo

- Rethink how to ensure `main` & `master` branch personal data is randomized.
- Document (in [Drupal project template](https://github.com/wunderio/drupal-project)?) how to exclude some (test)users from randomizing data. An example:

```yml
gdprDump:
  tables:
    users_field_data:
      # Skip test users with `uid` 1, 2, 3 from sanitizing.
      skip_conversion_if: 'in_array({{uid}}, [1, 2, 3])'
      converters:
        init:
          converter: fromContext
          parameters:
            key: processed_data.mail
        mail:
          converter: randomizeEmail
          unique: true
        name:
          converter: randomizeText
          unique: true
        pass:
          converter: randomizeText
```
