### PR TITLE
Add annotation support for service accounts in csi-rclone chart

### DIFF
--- a/csi-rclone/templates/1.13-csi-controller-rbac.yaml
+++ b/csi-rclone/templates/1.13-csi-controller-rbac.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: csi-controller-rclone
   namespace: {{ .Release.Namespace }}
+{{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/csi-rclone/templates/1.13-csi-nodeplugin-rbac.yaml
+++ b/csi-rclone/templates/1.13-csi-nodeplugin-rbac.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: csi-nodeplugin-rclone
   namespace: {{ .Release.Namespace }}
+{{- with .Values.nodePlugin.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/csi-rclone/templates/1.19-csi-controller-rbac.yaml
+++ b/csi-rclone/templates/1.19-csi-controller-rbac.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: csi-controller-rclone
   namespace: {{ .Release.Namespace }}
+{{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/csi-rclone/templates/1.19-csi-nodeplugin-rbac.yaml
+++ b/csi-rclone/templates/1.19-csi-nodeplugin-rbac.yaml
@@ -5,6 +5,10 @@ kind: ServiceAccount
 metadata:
   name: csi-nodeplugin-rclone
   namespace: {{ .Release.Namespace }}
+{{- with .Values.nodePlugin.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/csi-rclone/tests/1.13-controller_test.yaml
+++ b/csi-rclone/tests/1.13-controller_test.yaml
@@ -44,6 +44,7 @@ tests:
 
   - it: can set service account annotations (1.13)
     template: 1.13-csi-nodeplugin-rbac.yaml
+    documentIndex: 0
     capabilities:
       majorVersion: 1
       minorVersion: 18

--- a/csi-rclone/tests/1.13-controller_test.yaml
+++ b/csi-rclone/tests/1.13-controller_test.yaml
@@ -41,3 +41,19 @@ tests:
       - equal:
           path: spec.template.spec.containers[2].resources.requests.cpu
           value: 789m
+
+  - it: can set service account annotations (1.13)
+    template: 1.13-csi-nodeplugin-rbac.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    set:
+      nodePlugin:
+        serviceAccount:
+          annotations:
+            hello: world
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            hello: world

--- a/csi-rclone/tests/1.13-node_plugin_test.yaml
+++ b/csi-rclone/tests/1.13-node_plugin_test.yaml
@@ -34,3 +34,19 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.cpu
           value: 456m
+
+  - it: can set service account annotations (1.13)
+    template: 1.13-csi-nodeplugin-rbac.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    set:
+      nodePlugin:
+        serviceAccount:
+          annotations:
+            hello: world
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            hello: world

--- a/csi-rclone/tests/1.13-node_plugin_test.yaml
+++ b/csi-rclone/tests/1.13-node_plugin_test.yaml
@@ -37,6 +37,7 @@ tests:
 
   - it: can set service account annotations (1.13)
     template: 1.13-csi-nodeplugin-rbac.yaml
+    documentIndex: 0
     capabilities:
       majorVersion: 1
       minorVersion: 18

--- a/csi-rclone/tests/1.19-controller_test.yaml
+++ b/csi-rclone/tests/1.19-controller_test.yaml
@@ -34,3 +34,19 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.cpu
           value: 789m
+
+  - it: can set service account annotations (1.19)
+    template: 1.19-csi-controller-rbac.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      controller:
+        serviceAccount:
+          annotations:
+            hello: world
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            hello: world

--- a/csi-rclone/tests/1.19-controller_test.yaml
+++ b/csi-rclone/tests/1.19-controller_test.yaml
@@ -37,6 +37,7 @@ tests:
 
   - it: can set service account annotations (1.19)
     template: 1.19-csi-controller-rbac.yaml
+    documentIndex: 0
     capabilities:
       majorVersion: 1
       minorVersion: 19

--- a/csi-rclone/tests/1.19-node_plugin_test.yaml
+++ b/csi-rclone/tests/1.19-node_plugin_test.yaml
@@ -37,6 +37,7 @@ tests:
 
   - it: can set service account annotations (1.19)
     template: 1.19-csi-nodeplugin-rbac.yaml
+    documentIndex: 0
     capabilities:
       majorVersion: 1
       minorVersion: 19

--- a/csi-rclone/tests/1.19-node_plugin_test.yaml
+++ b/csi-rclone/tests/1.19-node_plugin_test.yaml
@@ -34,3 +34,19 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.cpu
           value: 456m
+
+  - it: can set service account annotations (1.19)
+    template: 1.19-csi-nodeplugin-rbac.yaml
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      nodePlugin:
+        serviceAccount:
+          annotations:
+            hello: world
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            hello: world

--- a/csi-rclone/values.yaml
+++ b/csi-rclone/values.yaml
@@ -33,6 +33,8 @@ nodePlugin:
     resources: {}
   # Some Kubernetes distributions use different kubelet base path (e.g. /var/snap/microk8s/common/var/lib/kubelet in Microk8s).
   kubeletBasePath: "/var/lib/kubelet"
+  serviceAccount:
+    annotations: {}
 
 controller:
   attacher:
@@ -41,3 +43,5 @@ controller:
     resources: {}
   rclone:
     resources: {}
+  serviceAccount:
+    annotations: {}


### PR DESCRIPTION
This PR
- adds support for service account annotations (so that IAM role annotations can be passed in)