### PR TITLE
ingress-nginx chart update; nginx-traefik ingressclass as default

### DIFF
--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.8.3
+  version: 4.10.0
 - name: nginx-ingress
   repository: https://helm.nginx.com/stable
   version: 0.17.1
@@ -10,7 +10,7 @@ dependencies:
   version: 1.87.7
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.8.3
+  version: 4.10.0
 - name: pxc-operator
   repository: https://percona.github.io/percona-helm-charts/
   version: 1.12.2
@@ -28,7 +28,7 @@ dependencies:
   version: 1.0.0
 - name: instana-agent
   repository: https://agents.instana.io/helm
-  version: 1.2.67
+  version: 1.2.71
 - name: nfs-subdir-external-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
   version: 4.0.18
@@ -38,5 +38,5 @@ dependencies:
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.0
-digest: sha256:476923948f8e9a38d21fea33fe3e588d74630b9e881b30dca32354398a063d9b
-generated: "2024-02-15T17:05:13.666080904+02:00"
+digest: sha256:a5b82b04cb36e9c55428cb7c1b860c62abae5175c08d6b99a7a5934ea6f8e906
+generated: "2024-03-14T13:57:48.971718393+02:00"

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.4.1
+version: 1.5.0
 # kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx
   # check kubernetes version requirements here: https://github.com/kubernetes/ingress-nginx
-  version: 4.8.x
+  version: 4.10.x
   repository: https://kubernetes.github.io/ingress-nginx
   condition: ingress-nginx.enabled
 - name: nginx-ingress
@@ -21,7 +21,7 @@ dependencies:
   condition: traefik.enabled
 - name: ingress-nginx
   # check kubernetes version requirements here: https://github.com/kubernetes/ingress-nginx
-  version: 4.8.x
+  version: 4.10.x
   alias: nginx-traefik
   repository: https://kubernetes.github.io/ingress-nginx
   condition: nginx-traefik.enabled

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -194,6 +194,11 @@ nginx-traefik:
       maxReplicas: 10
       targetCPUUtilizationPercentage: 80
       targetMemoryUtilizationPercentage: 80
+    # https://github.com/kubernetes/ingress-nginx/issues/6928
+    minReadySeconds: 10
+    # https://github.com/kubernetes/ingress-nginx/issues/6928
+    extraArgs:
+      shutdown-grace-period: 30
     config:
       # Optional CDN configuration
       use-proxy-protocol: false

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -185,7 +185,7 @@ nginx-traefik:
       externalTrafficPolicy: Local
     ingressClass: traefik
     ingressClassResource:
-      default: false
+      default: true
       name: traefik
     watchIngressWithoutClass: false
     autoscaling:

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -252,6 +252,12 @@ nginx-traefik:
       limits:
         cpu: 1
         memory: 1Gi
+    metrics:
+      enabled: false
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "10254"
   # Splash page
   defaultBackend:
     enabled: true

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -216,6 +216,12 @@ nginx-traefik:
       use-geoip: false
       use-gzip: false
       gzip-level: 1
+      # default is too low (1m)
+      proxy-body-size: 0
+      # Extends client timeouts
+      client-header-timeout: 120
+      client-body-timeout: 120
+      proxy-read-timeout: 120
       # ModSecurity https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-modsecurity
       # Off by default, enable using ingress annotations
       enable-modsecurity: false

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -222,6 +222,11 @@ nginx-traefik:
       client-header-timeout: 120
       client-body-timeout: 120
       proxy-read-timeout: 120
+      # Tackles https://github.com/kubernetes/ingress-nginx/issues/8488
+      lua-shared-dicts: "certificate_data: 100"
+      # Tackles https://github.com/kubernetes/ingress-nginx/issues/5030
+      variables-hash-bucket-size: "256"
+      variables-hash-max-size: "2048"
       # ModSecurity https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-modsecurity
       # Off by default, enable using ingress annotations
       enable-modsecurity: false

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -227,6 +227,10 @@ nginx-traefik:
       # Tackles https://github.com/kubernetes/ingress-nginx/issues/5030
       variables-hash-bucket-size: "256"
       variables-hash-max-size: "2048"
+      # Different error codes to distinguish rate limit states
+      limit-req-status-code: 420
+      limit-conn-status-code:  529
+      global-rate-limit-status-code: 429
       # ModSecurity https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-modsecurity
       # Off by default, enable using ingress annotations
       enable-modsecurity: false


### PR DESCRIPTION
- ingress-nginx subchart update to latest
- Default configuration tweaks for nginx-traefik (ingress-nginx)
  - sets ingressClass to default for nginx-traefik replacement (fixes cert-manager acme ingress issue)
  - Zero downtime upgrade 
  - Proxy connection defaults
  - Error fixes (variables_hash; certificate.lua)
  - custom rate limiter status codes (default value is a nondescriptive 503). This sets [arbitrary codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) as a replacement, will make it easier to identify which limit is hit. If ingress-nginx would send "[Retry-After](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429)" header with status code 429, would use that instead.
  - metrics endpoint example (might as well enable this by default)
