### PR TITLE
WAF version update. CPU limit increase

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -831,14 +831,14 @@ signalsciences:
   accesskeyid: ""
   secretaccesskey: ""
   image: signalsciences/sigsci-agent
-  imageTag: 4.40.0
+  imageTag: latest
   # sidecar container resources
   resources:
     requests:
       cpu: 20m
       memory: 40Mi
     limits:
-      cpu: 40m
+      cpu: 200m
       memory: 300Mi
 
 # Logging configurations for services that support them.

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -522,14 +522,14 @@ signalsciences:
   accesskeyid: ""
   secretaccesskey: ""
   image: signalsciences/sigsci-agent
-  imageTag: 4.40.0
+  imageTag: latest
   # sidecar container resources
   resources:
     requests:
       cpu: 20m
       memory: 40Mi
     limits:
-      cpu: 40m
+      cpu: 200m
       memory: 300Mi
 
 # Mailhog service overrides


### PR DESCRIPTION
Updated the signal sciences waf container to use the latest container version. Updated cpu limits to avoid rare throttling situations that slows down the website.