### PR TITLE
Changed frontend rate limit trigger from host to client ip. This way …

### DIFF
--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -64,7 +64,7 @@ ingress:
     redirect-https: true
     extraAnnotations:
       traefik.ingress.kubernetes.io/rate-limit: |
-        extractorfunc: request.host
+        extractorfunc: client.ip
         rateset:
           default:
             period: 5s


### PR DESCRIPTION
…its unified and working as intended. Otherwise it starts to rate limit any excess traffic hitting the site.