### PR TITLE
Release 2024-05-21

### DIFF
--- a/csi-rclone/Chart.yaml
+++ b/csi-rclone/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: CSI plugin for rclone mount
 name: csi-rclone
-version: 0.3.1
+version: 0.4.0

--- a/csi-rclone/templates/1.13-csi-controller-rbac.yaml
+++ b/csi-rclone/templates/1.13-csi-controller-rbac.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: csi-controller-rclone
   namespace: {{ .Release.Namespace }}
+{{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/csi-rclone/templates/1.13-csi-nodeplugin-rbac.yaml
+++ b/csi-rclone/templates/1.13-csi-nodeplugin-rbac.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: csi-nodeplugin-rclone
   namespace: {{ .Release.Namespace }}
+{{- with .Values.nodePlugin.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/csi-rclone/templates/1.19-csi-controller-rbac.yaml
+++ b/csi-rclone/templates/1.19-csi-controller-rbac.yaml
@@ -4,6 +4,10 @@ kind: ServiceAccount
 metadata:
   name: csi-controller-rclone
   namespace: {{ .Release.Namespace }}
+{{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/csi-rclone/templates/1.19-csi-nodeplugin-rbac.yaml
+++ b/csi-rclone/templates/1.19-csi-nodeplugin-rbac.yaml
@@ -5,6 +5,10 @@ kind: ServiceAccount
 metadata:
   name: csi-nodeplugin-rclone
   namespace: {{ .Release.Namespace }}
+{{- with .Values.nodePlugin.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/csi-rclone/tests/1.13-controller_test.yaml
+++ b/csi-rclone/tests/1.13-controller_test.yaml
@@ -41,3 +41,20 @@ tests:
       - equal:
           path: spec.template.spec.containers[2].resources.requests.cpu
           value: 789m
+
+  - it: can set service account annotations (1.13)
+    template: 1.13-csi-nodeplugin-rbac.yaml
+    documentIndex: 0
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    set:
+      nodePlugin:
+        serviceAccount:
+          annotations:
+            hello: world
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            hello: world

--- a/csi-rclone/tests/1.13-node_plugin_test.yaml
+++ b/csi-rclone/tests/1.13-node_plugin_test.yaml
@@ -34,3 +34,20 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.cpu
           value: 456m
+
+  - it: can set service account annotations (1.13)
+    template: 1.13-csi-nodeplugin-rbac.yaml
+    documentIndex: 0
+    capabilities:
+      majorVersion: 1
+      minorVersion: 18
+    set:
+      nodePlugin:
+        serviceAccount:
+          annotations:
+            hello: world
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            hello: world

--- a/csi-rclone/tests/1.19-controller_test.yaml
+++ b/csi-rclone/tests/1.19-controller_test.yaml
@@ -34,3 +34,20 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.cpu
           value: 789m
+
+  - it: can set service account annotations (1.19)
+    template: 1.19-csi-controller-rbac.yaml
+    documentIndex: 0
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      controller:
+        serviceAccount:
+          annotations:
+            hello: world
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            hello: world

--- a/csi-rclone/tests/1.19-node_plugin_test.yaml
+++ b/csi-rclone/tests/1.19-node_plugin_test.yaml
@@ -34,3 +34,20 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].resources.requests.cpu
           value: 456m
+
+  - it: can set service account annotations (1.19)
+    template: 1.19-csi-nodeplugin-rbac.yaml
+    documentIndex: 0
+    capabilities:
+      majorVersion: 1
+      minorVersion: 19
+    set:
+      nodePlugin:
+        serviceAccount:
+          annotations:
+            hello: world
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            hello: world

--- a/csi-rclone/values.yaml
+++ b/csi-rclone/values.yaml
@@ -33,6 +33,8 @@ nodePlugin:
     resources: {}
   # Some Kubernetes distributions use different kubelet base path (e.g. /var/snap/microk8s/common/var/lib/kubelet in Microk8s).
   kubeletBasePath: "/var/lib/kubelet"
+  serviceAccount:
+    annotations: {}
 
 controller:
   attacher:
@@ -41,3 +43,5 @@ controller:
     resources: {}
   rclone:
     resources: {}
+  serviceAccount:
+    annotations: {}

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 1.8.0
+version: 1.9.0
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/drupal-configmap.yaml
+++ b/drupal/templates/drupal-configmap.yaml
@@ -196,7 +196,7 @@ data:
         {{- end }}
         default  '';
       }
-      add_header                  X-Robots-Tag $x_robots_tag_header;
+      add_header X-Robots-Tag $x_robots_tag_header always;
 
       map $uri $no_slash_uri {
         ~^/(?<no_slash>.*)$ $no_slash;
@@ -519,6 +519,7 @@ data:
           add_header Last-Modified "Wed, 20 Jan 1988 04:20:42 GMT";
           add_header Access-Control-Allow-Origin *;
           add_header X-Header "AdvAgg Generator 2.0 CDN";
+          add_header X-Robots-Tag $x_robots_tag_header always;
           try_files $uri @drupal;
         }
 
@@ -545,6 +546,7 @@ data:
           tcp_nodelay     off;
           expires         365d;
           add_header Cache-Control "public";
+          add_header X-Robots-Tag $x_robots_tag_header always;
           ## Set the OS file cache.
           {{- if .Values.nginx.open_file_cache.enabled }}
           open_file_cache max={{ .Values.nginx.open_file_cache.max }} inactive={{ .Values.nginx.open_file_cache.inactive }};
@@ -571,6 +573,7 @@ data:
           # Set cache rules for webfonts.
           expires 365d;
           add_header Cache-Control "public";
+          add_header X-Robots-Tag $x_robots_tag_header always;
           ## Set the OS file cache.
           {{- if .Values.nginx.open_file_cache.enabled }}
           open_file_cache max={{ .Values.nginx.open_file_cache.max }} inactive={{ .Values.nginx.open_file_cache.inactive }};
@@ -604,6 +607,7 @@ data:
 
         location = /robots.txt {
           add_header  Content-Type  text/plain;
+          add_header X-Robots-Tag $x_robots_tag_header always;
           access_log  off;
           try_files $uri @drupal;
           {{- if .Values.signalsciences.enabled }}

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -831,14 +831,14 @@ signalsciences:
   accesskeyid: ""
   secretaccesskey: ""
   image: signalsciences/sigsci-agent
-  imageTag: 4.40.0
+  imageTag: latest
   # sidecar container resources
   resources:
     requests:
       cpu: 20m
       memory: 40Mi
     limits:
-      cpu: 40m
+      cpu: 200m
       memory: 300Mi
 
 # Logging configurations for services that support them.

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -92,10 +92,10 @@ ingress:
             period: 1s
             average: 32
             burst: 90
-      nginx.ingress.kubernetes.io/limit-rps: "32"
+      nginx.ingress.kubernetes.io/limit-rps: "60"
       nginx.ingress.kubernetes.io/limit-rpm: "300"
-      nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
-      nginx.ingress.kubernetes.io/limit-connections: "20"
+      nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
+      nginx.ingress.kubernetes.io/limit-connections: "100"
   gce:
     type: gce
     # The name of the reserved static IP address.

--- a/frontend/Chart.lock
+++ b/frontend/Chart.lock
@@ -20,5 +20,8 @@ dependencies:
 - name: silta-release
   repository: file://../silta-release
   version: 1.0.0
-digest: sha256:ce1f9c915208446fda93af256bf502b3cd71d978ae2806c0e988c5d2a8b02ca6
-generated: "2024-03-05T15:38:09.328520813+02:00"
+- name: redis
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 19.1.5
+digest: sha256:b494e7a5c8be4e2c9478ba2af95fa91830a6f537bdafc30c1c1399b4024168c3
+generated: "2024-05-02T08:45:24.766124978+03:00"

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.7.0
+version: 1.8.0
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -32,3 +32,7 @@ dependencies:
 - name: silta-release
   version: ^1.x
   repository: file://../silta-release
+- name: redis
+  version: 19.1.5
+  repository: oci://registry-1.docker.io/bitnamicharts
+  condition: redis.enabled

--- a/frontend/templates/_helpers.tpl
+++ b/frontend/templates/_helpers.tpl
@@ -134,6 +134,21 @@ rsync -az /values_mounts/ /backups/current/
 - name: OUTSIDE_COLLABORATORS
   value: {{ .Values.shell.gitAuth.outsideCollaborators | default true | quote }}
 {{- end }}
+{{- if .Values.redis.enabled }}
+{{- if contains "redis" .Release.Name -}}
+{{- fail "Do not use 'redis' in release name or deployment will fail" -}}
+{{- end }}
+{{- if eq .Values.redis.auth.password "" }}
+{{- fail ".Values.redis.auth.password value required." }}
+{{- end }}
+- name: REDIS_HOST
+  value: {{ .Release.Name }}-redis-master
+- name: REDIS_PASS
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-redis
+      key: redis-password
+{{- end }}
 # Proxy
 {{ $proxy := ( index .Values "silta-release" ).proxy }}
 {{ if $proxy.enabled }}
@@ -149,9 +164,9 @@ rsync -az /values_mounts/ /backups/current/
 - name: HTTPS_PROXY
   value: "{{ $proxy.url }}:{{ $proxy.port }}"
 - name: no_proxy
-  value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
+  value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-redis,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 - name: NO_PROXY
-  value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
+  value: .svc.cluster.local,{{ .Release.Name }}-mongodb,{{ .Release.Name }}-redis,{{ .Release.Name }}-es{{ if $proxy.no_proxy }},{{$proxy.no_proxy}}{{ end }}
 {{- end -}}
 {{ if .Values.instana.enabled -}}
 # Instana

--- a/frontend/templates/configmap.yaml
+++ b/frontend/templates/configmap.yaml
@@ -94,7 +94,7 @@ data:
           {{- end }}
           default  '';
       }
-      add_header                  X-Robots-Tag $x_robots_tag_header;
+      add_header X-Robots-Tag $x_robots_tag_header always;
 
       map $uri $no_slash_uri {
           ~^/(?<no_slash>.*)$ $no_slash;
@@ -207,6 +207,8 @@ data:
       {{- range $index, $service := .Values.services }}
       {{- if $service.exposedRoute }}
       location {{ $service.exposedRoute }} {
+
+        add_header X-Robots-Tag $x_robots_tag_header always;
 
         {{- if $.Values.nginx.extra_conditions }}
         {{- $.Values.nginx.extra_conditions | nindent 8 }}

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -50,6 +50,10 @@ spec:
           - name: shell-keys
             mountPath: /etc/ssh/keys
           {{- end }}
+        {{- if $service.lifecycle }}
+        lifecycle:
+        {{- toYaml $service.lifecycle | nindent 10 }}
+        {{- end }}
         livenessProbe:
         {{- if $service.livenessProbe }}
         {{- toYaml $service.livenessProbe | nindent 10 }}

--- a/frontend/test.values.yaml
+++ b/frontend/test.values.yaml
@@ -38,6 +38,12 @@ mongodb:
 rabbitmq:
   enabled: true
 
+redis:
+  enabled: true
+  auth:
+    password: "foo"
+
+
 mounts:
   files:
     enabled: true

--- a/frontend/tests/redis_test.yaml
+++ b/frontend/tests/redis_test.yaml
@@ -6,29 +6,30 @@ capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
-  - it: sets redis hostname in environment if redis is enabled
-    template: services-deployment.yaml
-    set:
-      services.node.enabled: true
-      redis:
-        enabled: true
-        auth:
-          password: "foo"
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: REDIS_HOST
-            value: RELEASE-NAME-redis-master
-
-  - it: sets no redis hostname in frontend environment if redis is disabled
-    template: services-deployment.yaml
-    set:
-      services.node.enabled: true
-      redis.enabled: false
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: REDIS_HOST
-            value: RELEASE-NAME-redis-master
+# FIXME: This test fails because bitnami's common subchart uses multiline helm/sprig snippet that does not work with current unittest version.
+  #- it: sets redis hostname in environment if redis is enabled
+  #  template: services-deployment.yaml
+  #  set:
+  #    services.node.enabled: true
+  #    redis:
+  #      enabled: true
+  #      auth:
+  #        password: "foo"
+  #  asserts:
+  #    - contains:
+  #        path: spec.template.spec.containers[0].env
+  #        content:
+  #          name: REDIS_HOST
+  #          value: RELEASE-NAME-redis-master
+  #
+  #- it: sets no redis hostname in frontend environment if redis is disabled
+  #  template: services-deployment.yaml
+  #  set:
+  #    services.node.enabled: true
+  #    redis.enabled: false
+  #  asserts:
+  #    - notContains:
+  #        path: spec.template.spec.containers[0].env
+  #        content:
+  #          name: REDIS_HOST
+  #          value: RELEASE-NAME-redis-master

--- a/frontend/tests/redis_test.yaml
+++ b/frontend/tests/redis_test.yaml
@@ -1,0 +1,34 @@
+suite: frontend redis
+templates:
+  - services-deployment.yaml
+  - configmap.yaml
+capabilities:
+  apiVersions:
+    - pxc.percona.com/v1
+tests:
+  - it: sets redis hostname in environment if redis is enabled
+    template: services-deployment.yaml
+    set:
+      services.node.enabled: true
+      redis:
+        enabled: true
+        auth:
+          password: "foo"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master
+
+  - it: sets no redis hostname in frontend environment if redis is disabled
+    template: services-deployment.yaml
+    set:
+      services.node.enabled: true
+      redis.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master

--- a/frontend/values.schema.json
+++ b/frontend/values.schema.json
@@ -9,14 +9,14 @@
     "imagePullSecrets": { "type": "array" },
     "app": { "type": "string" },
     "exposeDomains": {
-      "type": "object", 
+      "type": "object",
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
         "properties": {
           "name": { "type": "string" },
           "hostname": { "type": "string" },
-          "ssl": { 
+          "ssl": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
@@ -49,9 +49,9 @@
         "ingress": { "type": "string" }
       }
     },
-    "domainPrefixes": { 
-      "type": "array", 
-      "items": { 
+    "domainPrefixes": {
+      "type": "array",
+      "items": {
         "type": "string"
       }
     },
@@ -68,7 +68,7 @@
       }
     },
     "backendConfig": {
-      "type": [ "array", "object" ], 
+      "type": [ "array", "object" ],
       "items": { "type": "object" }
     },
     "ingress": {
@@ -177,7 +177,7 @@
             }
           }
         },
-        "retry404s": { 
+        "retry404s": {
           "type": ["boolean", "object"],
           "additionalProperties": false,
           "properties": {
@@ -187,7 +187,7 @@
         }
       }
     },
-    "services": { 
+    "services": {
       "type": "object",
       "additionalProperties": {
         "type": "object",
@@ -203,6 +203,14 @@
           "exposedRoute": { "type": "string" },
           "replicas": { "type": "integer" },
           "mounts": { "type": "array" },
+          "lifecycle": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "postStart": { "type": "object" },
+              "preStop": { "type": "object" }
+            }
+          },
           "readinessProbe": { "type": "object" },
           "livenessProbe": { "type": "object" },
           "strategy": { "type": "object" },
@@ -323,7 +331,7 @@
             }
           }
         },
-        "strategy": { 
+        "strategy": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -372,7 +380,7 @@
         }
       }
     },
-    "shell": { 
+    "shell": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -382,7 +390,7 @@
           "additionalProperties": false,
           "properties": {
             "apiToken": { "type": "string" },
-            "keyserver": { 
+            "keyserver": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
@@ -525,6 +533,13 @@
     },
     "instana": {
       "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "redis": {
+      "type": "object",
+      "additionalProperties": true,
       "properties": {
         "enabled": { "type": "boolean" }
       }

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -70,10 +70,10 @@ ingress:
             period: 5s
             average: 150
             burst: 200
-      nginx.ingress.kubernetes.io/limit-rps: "32"
+      nginx.ingress.kubernetes.io/limit-rps: "60"
       nginx.ingress.kubernetes.io/limit-rpm: "300"
-      nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
-      nginx.ingress.kubernetes.io/limit-connections: "20"
+      nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
+      nginx.ingress.kubernetes.io/limit-connections: "100"
   gce:
     type: gce
     # The name of the reserved static IP address.
@@ -545,3 +545,25 @@ mailhog:
     requests:
       cpu: 1m
       memory: 10M
+
+# Redis
+# https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
+redis:
+  enabled: false
+  architecture: standalone
+  auth:
+    # mandatory value
+    password: ""
+  replica:
+    # replicaCount: 1
+    autoscaling:
+      enabled: false
+  master:
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 256Mi
+

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -522,14 +522,14 @@ signalsciences:
   accesskeyid: ""
   secretaccesskey: ""
   image: signalsciences/sigsci-agent
-  imageTag: 4.40.0
+  imageTag: latest
   # sidecar container resources
   resources:
     requests:
       cpu: 20m
       memory: 40Mi
     limits:
-      cpu: 40m
+      cpu: 200m
       memory: 300Mi
 
 # Mailhog service overrides

--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.8.3
+  version: 4.10.0
 - name: nginx-ingress
   repository: https://helm.nginx.com/stable
   version: 0.17.1
@@ -10,7 +10,7 @@ dependencies:
   version: 1.87.7
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.8.3
+  version: 4.10.0
 - name: pxc-operator
   repository: https://percona.github.io/percona-helm-charts/
   version: 1.12.2
@@ -28,7 +28,7 @@ dependencies:
   version: 1.0.0
 - name: instana-agent
   repository: https://agents.instana.io/helm
-  version: 1.2.67
+  version: 1.2.71
 - name: nfs-subdir-external-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
   version: 4.0.18
@@ -38,5 +38,5 @@ dependencies:
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.0
-digest: sha256:476923948f8e9a38d21fea33fe3e588d74630b9e881b30dca32354398a063d9b
-generated: "2024-02-15T17:05:13.666080904+02:00"
+digest: sha256:a5b82b04cb36e9c55428cb7c1b860c62abae5175c08d6b99a7a5934ea6f8e906
+generated: "2024-03-14T13:57:48.971718393+02:00"

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.4.1
+version: 1.5.0
 # kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx
   # check kubernetes version requirements here: https://github.com/kubernetes/ingress-nginx
-  version: 4.8.x
+  version: 4.10.x
   repository: https://kubernetes.github.io/ingress-nginx
   condition: ingress-nginx.enabled
 - name: nginx-ingress
@@ -21,7 +21,7 @@ dependencies:
   condition: traefik.enabled
 - name: ingress-nginx
   # check kubernetes version requirements here: https://github.com/kubernetes/ingress-nginx
-  version: 4.8.x
+  version: 4.10.x
   alias: nginx-traefik
   repository: https://kubernetes.github.io/ingress-nginx
   condition: nginx-traefik.enabled

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -185,7 +185,7 @@ nginx-traefik:
       externalTrafficPolicy: Local
     ingressClass: traefik
     ingressClassResource:
-      default: false
+      default: true
       name: traefik
     watchIngressWithoutClass: false
     autoscaling:
@@ -194,6 +194,11 @@ nginx-traefik:
       maxReplicas: 10
       targetCPUUtilizationPercentage: 80
       targetMemoryUtilizationPercentage: 80
+    # https://github.com/kubernetes/ingress-nginx/issues/6928
+    minReadySeconds: 10
+    # https://github.com/kubernetes/ingress-nginx/issues/6928
+    extraArgs:
+      shutdown-grace-period: 30
     config:
       # Optional CDN configuration
       use-proxy-protocol: false
@@ -211,6 +216,21 @@ nginx-traefik:
       use-geoip: false
       use-gzip: false
       gzip-level: 1
+      # default is too low (1m)
+      proxy-body-size: 0
+      # Extends client timeouts
+      client-header-timeout: 120
+      client-body-timeout: 120
+      proxy-read-timeout: 120
+      # Tackles https://github.com/kubernetes/ingress-nginx/issues/8488
+      lua-shared-dicts: "certificate_data: 100"
+      # Tackles https://github.com/kubernetes/ingress-nginx/issues/5030
+      variables-hash-bucket-size: "256"
+      variables-hash-max-size: "2048"
+      # Different error codes to distinguish rate limit states
+      limit-req-status-code: 420
+      limit-conn-status-code:  529
+      global-rate-limit-status-code: 429
       # ModSecurity https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-modsecurity
       # Off by default, enable using ingress annotations
       enable-modsecurity: false
@@ -232,6 +252,12 @@ nginx-traefik:
       limits:
         cpu: 1
         memory: 1Gi
+    metrics:
+      enabled: false
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "10254"
   # Splash page
   defaultBackend:
     enabled: true

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 1.2.1
+version: 1.3.0
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/configmap.yaml
+++ b/simple/templates/configmap.yaml
@@ -99,7 +99,7 @@ data:
             "~{{ template "simple.domain" $ }}$" "noindex, nofollow, nosnippet, noarchive";
             default  '';
         }
-        add_header                  X-Robots-Tag $x_robots_tag_header;
+        add_header                  X-Robots-Tag $x_robots_tag_header always;
 
         map $uri $no_slash_uri {
             ~^/(?<no_slash>.*)$ $no_slash;

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -31,10 +31,10 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 3
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      targetAverageUtilization: 80
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: 80
 
 # Domain names that will be mapped to this deployment.
 # Example of exposing 2 additional domains for this deployment, each with its own certificate.
@@ -81,16 +81,16 @@ ingress:
     redirect-https: true
     extraAnnotations:
       traefik.ingress.kubernetes.io/rate-limit: |
-        extractorfunc: request.host
+        extractorfunc: client.ip
         rateset:
           default:
             period: 5s
             average: 150
             burst: 200
-      nginx.ingress.kubernetes.io/limit-rps: "32"
+      nginx.ingress.kubernetes.io/limit-rps: "60"
       nginx.ingress.kubernetes.io/limit-rpm: "300"
-      nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
-      nginx.ingress.kubernetes.io/limit-connections: "20"
+      nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
+      nginx.ingress.kubernetes.io/limit-connections: "60"
   gce:
     type: gce
     # The name of the reserved static IP address.


### PR DESCRIPTION
Frontend chart (1.8.0):
- Add lifecycle config with default 5s prestop for frontend services ([PR](https://github.com/wunderio/frontend-project-k8s/pull/120), credits Bernt)
- Add redis support ([PR](https://github.com/wunderio/frontend-project-k8s/pull/120), credits Mario)
- WAF version update. CPU limit increase ([PR](https://github.com/wunderio/charts/pull/431))
- Adds robots header for location scope; adds header for non-200 pages ([PR](https://github.com/wunderio/frontend-project-k8s/pull/126))
- Rate limit adjustment ([PR](https://github.com/wunderio/frontend-project-k8s/pull/125))

Drupal chart (1.9.0):
- WAF version update. CPU limit increase ([PR](https://github.com/wunderio/charts/pull/431))
- Adds robots header for location scope; adds header for non-200 pages ([PR](https://github.com/wunderio/drupal-project-k8s/pull/707))
- Slightly relaxed nginx lb rate limit to accomodate non-aggregated pages ([PR](https://github.com/wunderio/drupal-project-k8s/pull/706))

Simple chart (1.3.0):
- Adds robots header for non-200 pages ([PR](https://github.com/wunderio/simple-project-k8s/pull/56))
- Rate limit adjustment ([PR](https://github.com/wunderio/simple-project-k8s/pull/55))

Silta cluster chart (1.5.0):
- ingress-nginx chart update; nginx-traefik ingressclass as default ([PR](https://github.com/wunderio/charts/pull/430))

CSI Rclone chart (0.4.0):
- Add annotation support for service accounts in csi-rclone chart ([PR](https://github.com/wunderio/charts/pull/428), credits nuwang)