### PR TITLE
SLT-1044: proxy buffer size

### DIFF
--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.5.0
+version: 1.6.0
 # kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -48,6 +48,7 @@ ingress-nginx:
       use-geoip: false
       use-gzip: false
       gzip-level: 1
+      proxy-buffer-size: 8k
       # ModSecurity https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-modsecurity
       # Off by default, enable using ingress annotations
       enable-modsecurity: false
@@ -216,6 +217,7 @@ nginx-traefik:
       use-geoip: false
       use-gzip: false
       gzip-level: 1
+      proxy-buffer-size: 8k
       # default is too low (1m)
       proxy-body-size: 0
       # Extends client timeouts


### PR DESCRIPTION
Increases nginx LB proxy-buffer-size to 8k to solve nodejs auth issues