### PR TITLE
SLT-1026: Update helm unit tests to work with latest version of the helm-unittest plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,10 @@ version: 2.1
 orbs:
   silta: silta/silta@1
 
-executors:
-  cicd82:
-    docker:
-      - image: wunderio/silta-cicd:circleci-php8.2-node20-composer2-helm-unittest-upgrade-test20240614
-
 jobs:
 
   build:
-    executor: cicd82
+    executor: silta/silta
     resource_class: small
 
     steps:
@@ -72,7 +67,7 @@ jobs:
             - /tmp/charts
 
   deploy:
-    executor: cicd82
+    executor: silta/silta
     resource_class: small
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,15 @@ version: 2.1
 orbs:
   silta: silta/silta@1
 
+executors:
+  cicd82:
+    docker:
+      - image: wunderio/silta-cicd:circleci-php8.2-node20-composer2-helm-unittest-upgrade-test20240614
+
 jobs:
 
   build:
-    executor: silta/silta
+    executor: cicd82
     resource_class: small
 
     steps:
@@ -52,7 +57,7 @@ jobs:
               
               helm dependency build $CHART
               helm lint $CHART
-              helm unittest $CHART --helm3
+              helm unittest $CHART
               if [ -f "$CHART/test.values.yaml" ]; then
                 helm install --dry-run --generate-name --values "$CHART/test.values.yaml" $CHART
               fi
@@ -67,7 +72,7 @@ jobs:
             - /tmp/charts
 
   deploy:
-    executor: silta/silta
+    executor: cicd82
     resource_class: small
 
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,11 +1,11 @@
 # Create minikube test deployments on different kubernetes versions
-name: Silta chart tests 
+name: Silta chart tests
 
 on:
   # Run for pull requests, but there's an additional draft filter later on
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Available minikube kubernetes version list: 
+        # Available minikube kubernetes version list:
         # "minikube config defaults kubernetes-version"
         # and https://kubernetes.io/releases/patch-releases/
         kubernetes-version: ["v1.22.17", "v1.23.17", "v1.24.17", "v1.25.16", "1.26.11", "1.27.8", "1.28.4", "latest"]
@@ -56,7 +56,7 @@ jobs:
             && helm repo add codecentric https://codecentric.github.io/helm-charts \
             && helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx \
             && helm repo add nginx-stable https://helm.nginx.com/stable \
-            && helm plugin install https://github.com/quintush/helm-unittest --version 0.2.4 \
+            && helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.5.1 \
             && helm repo update
 
       - name: Download and start minikube
@@ -69,9 +69,9 @@ jobs:
             --kubernetes-version "${{ matrix.kubernetes-version }}" \
             --insecure-registry "${CLUSTER_DOCKER_REGISTRY}" \
             --cni auto \
-            --wait all 
+            --wait all
       # Could use "medyagh/setup-minikube" but it does not have a way to pass "--insecure-registry" flag
-      # https://github.com/medyagh/setup-minikube/pull/33  
+      # https://github.com/medyagh/setup-minikube/pull/33
       # - name: Start minikube 1.21.14
       #   with:
       #     # "stable" for the latest stable build, or "latest" for the latest development build
@@ -168,7 +168,7 @@ jobs:
           curl --resolve ${CLUSTER_DOMAIN}:443:${MINIKUBE_IP} https://${CLUSTER_DOMAIN} -ILk --fail
           curl --resolve ${CLUSTER_DOMAIN}:80:${MINIKUBE_IP} --resolve ${CLUSTER_DOMAIN}:443:${MINIKUBE_IP} http://${CLUSTER_DOMAIN} -IL --fail
 
-      - name: Build Drupal chart images, deploy and test 
+      - name: Build Drupal chart images, deploy and test
         run: |
 
           MINIKUBE_IP=$(minikube ip)
@@ -215,7 +215,7 @@ jobs:
           helm dependency build "./drupal"
 
           # Chart unit tests
-          helm unittest ./drupal --helm3
+          helm unittest ./drupal
 
           # Dry-run drupal chart with test values
           helm install --dry-run --generate-name ./drupal --values drupal/test.values.yaml
@@ -249,7 +249,7 @@ jobs:
               --retry 5 --retry-delay 5 \
               --fail 
 
-      - name: Build Frontend chart images, deploy and test 
+      - name: Build Frontend chart images, deploy and test
         run: |
 
           MINIKUBE_IP=$(minikube ip)
@@ -270,7 +270,7 @@ jobs:
           helm dependency build ./frontend
 
           # Chart unit tests
-          helm unittest ./frontend --helm3
+          helm unittest ./frontend
 
           # Dry-run drupal chart with test values
           helm install --dry-run --generate-name ./frontend --values frontend/test.values.yaml
@@ -319,7 +319,7 @@ jobs:
               --retry 5 --retry-delay 5 \
               --fail
 
-      - name: Build Simple chart images, deploy and test 
+      - name: Build Simple chart images, deploy and test
         run: |
 
           MINIKUBE_IP=$(minikube ip)
@@ -336,7 +336,7 @@ jobs:
           helm dependency build ./simple
 
           # Chart unit tests
-          helm unittest ./simple --helm3
+          helm unittest ./simple
 
           # Dry-run drupal chart with test values
           helm install --dry-run --generate-name ./simple --values simple/test.values.yaml

--- a/csi-rclone/tests/1.13-controller_test.yaml
+++ b/csi-rclone/tests/1.13-controller_test.yaml
@@ -1,7 +1,7 @@
 suite: Controller
 templates:
   - 1.13-csi-controller-rclone.yaml
-  - 1.19-csi-controller-rclone.yaml
+  - 1.13-csi-nodeplugin-rbac.yaml
 tests:
   - it: is a stateful set (1.13)
     template: 1.13-csi-controller-rclone.yaml

--- a/csi-rclone/tests/1.13-node_plugin_test.yaml
+++ b/csi-rclone/tests/1.13-node_plugin_test.yaml
@@ -1,7 +1,7 @@
 suite: CSI Node Plugin
 templates:
+  - 1.13-csi-nodeplugin-rbac.yaml
   - 1.13-csi-nodeplugin-rclone.yaml
-  - 1.19-csi-nodeplugin-rclone.yaml
 tests:
   - it: is a daemon (1.13)
     template: 1.13-csi-nodeplugin-rclone.yaml

--- a/csi-rclone/tests/1.19-controller_test.yaml
+++ b/csi-rclone/tests/1.19-controller_test.yaml
@@ -1,6 +1,6 @@
 suite: Controller
 templates:
-  - 1.13-csi-controller-rclone.yaml
+  - 1.19-csi-controller-rbac.yaml
   - 1.19-csi-controller-rclone.yaml
 tests:
   - it: is a stateful set (1.19)

--- a/csi-rclone/tests/1.19-node_plugin_test.yaml
+++ b/csi-rclone/tests/1.19-node_plugin_test.yaml
@@ -1,6 +1,6 @@
 suite: CSI Node Plugin
 templates:
-  - 1.13-csi-nodeplugin-rclone.yaml
+  - 1.19-csi-nodeplugin-rbac.yaml
   - 1.19-csi-nodeplugin-rclone.yaml
 tests:
   - it: is a daemon (1.19)


### PR DESCRIPTION
### Blocked by https://github.com/wunderio/silta-images/pull/216

Proposed changes:
- Update helm unit tests to work with latest version of the helm-unittest plugin
- Upgrade the helm-unittest plugin in pull-request.yml

The drupal, frontend and simple chart tests are fixed in separate PRs and will eventually be merged to the release branch in this repo:
- https://github.com/wunderio/simple-project-k8s/pull/59
- https://github.com/wunderio/drupal-project-k8s/pull/711
- https://github.com/wunderio/frontend-project-k8s/pull/129