### PR TITLE
Update wunderio/sshd-gitauth image to v1.0 in sshd-jumpserver.yaml

### DIFF
--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -46,7 +46,7 @@ spec:
       enableServiceLinks: false
       containers:
       - name: {{ .Release.Name }}-jumpserver
-        image: wunderio/sshd-gitauth:v0.2
+        image: wunderio/sshd-gitauth:v1.0
         imagePullPolicy: Always
         ports:
           - containerPort: 22


### PR DESCRIPTION
Only change in the new version is this PR: https://github.com/wunderio/sshd-gitauth/pull/1