### PR TITLE
Release 2024-08-27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
               
               helm dependency build $CHART
               helm lint $CHART
-              helm unittest $CHART --helm3
+              helm unittest $CHART
               if [ -f "$CHART/test.values.yaml" ]; then
                 helm install --dry-run --generate-name --values "$CHART/test.values.yaml" $CHART
               fi

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,11 +1,11 @@
 # Create minikube test deployments on different kubernetes versions
-name: Silta chart tests 
+name: Silta chart tests
 
 on:
   # Run for pull requests, but there's an additional draft filter later on
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Available minikube kubernetes version list: 
+        # Available minikube kubernetes version list:
         # "minikube config defaults kubernetes-version"
         # and https://kubernetes.io/releases/patch-releases/
         kubernetes-version: ["v1.22.17", "v1.23.17", "v1.24.17", "v1.25.16", "1.26.11", "1.27.8", "1.28.4", "latest"]
@@ -56,7 +56,7 @@ jobs:
             && helm repo add codecentric https://codecentric.github.io/helm-charts \
             && helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx \
             && helm repo add nginx-stable https://helm.nginx.com/stable \
-            && helm plugin install https://github.com/quintush/helm-unittest --version 0.2.4 \
+            && helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.5.1 \
             && helm repo update
 
       - name: Download and start minikube
@@ -69,9 +69,9 @@ jobs:
             --kubernetes-version "${{ matrix.kubernetes-version }}" \
             --insecure-registry "${CLUSTER_DOCKER_REGISTRY}" \
             --cni auto \
-            --wait all 
+            --wait all
       # Could use "medyagh/setup-minikube" but it does not have a way to pass "--insecure-registry" flag
-      # https://github.com/medyagh/setup-minikube/pull/33  
+      # https://github.com/medyagh/setup-minikube/pull/33
       # - name: Start minikube 1.21.14
       #   with:
       #     # "stable" for the latest stable build, or "latest" for the latest development build
@@ -168,7 +168,7 @@ jobs:
           curl --resolve ${CLUSTER_DOMAIN}:443:${MINIKUBE_IP} https://${CLUSTER_DOMAIN} -ILk --fail
           curl --resolve ${CLUSTER_DOMAIN}:80:${MINIKUBE_IP} --resolve ${CLUSTER_DOMAIN}:443:${MINIKUBE_IP} http://${CLUSTER_DOMAIN} -IL --fail
 
-      - name: Build Drupal chart images, deploy and test 
+      - name: Build Drupal chart images, deploy and test
         run: |
 
           MINIKUBE_IP=$(minikube ip)
@@ -215,7 +215,7 @@ jobs:
           helm dependency build "./drupal"
 
           # Chart unit tests
-          helm unittest ./drupal --helm3
+          helm unittest ./drupal
 
           # Dry-run drupal chart with test values
           helm install --dry-run --generate-name ./drupal --values drupal/test.values.yaml
@@ -249,7 +249,7 @@ jobs:
               --retry 5 --retry-delay 5 \
               --fail 
 
-      - name: Build Frontend chart images, deploy and test 
+      - name: Build Frontend chart images, deploy and test
         run: |
 
           MINIKUBE_IP=$(minikube ip)
@@ -270,7 +270,7 @@ jobs:
           helm dependency build ./frontend
 
           # Chart unit tests
-          helm unittest ./frontend --helm3
+          helm unittest ./frontend
 
           # Dry-run drupal chart with test values
           helm install --dry-run --generate-name ./frontend --values frontend/test.values.yaml
@@ -319,7 +319,7 @@ jobs:
               --retry 5 --retry-delay 5 \
               --fail
 
-      - name: Build Simple chart images, deploy and test 
+      - name: Build Simple chart images, deploy and test
         run: |
 
           MINIKUBE_IP=$(minikube ip)
@@ -336,7 +336,7 @@ jobs:
           helm dependency build ./simple
 
           # Chart unit tests
-          helm unittest ./simple --helm3
+          helm unittest ./simple
 
           # Dry-run drupal chart with test values
           helm install --dry-run --generate-name ./simple --values simple/test.values.yaml

--- a/csi-rclone/Chart.yaml
+++ b/csi-rclone/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: CSI plugin for rclone mount
 name: csi-rclone
-version: 0.4.0
+version: 0.5.0

--- a/csi-rclone/tests/1.13-controller_test.yaml
+++ b/csi-rclone/tests/1.13-controller_test.yaml
@@ -1,7 +1,7 @@
 suite: Controller
 templates:
   - 1.13-csi-controller-rclone.yaml
-  - 1.19-csi-controller-rclone.yaml
+  - 1.13-csi-nodeplugin-rbac.yaml
 tests:
   - it: is a stateful set (1.13)
     template: 1.13-csi-controller-rclone.yaml

--- a/csi-rclone/tests/1.13-node_plugin_test.yaml
+++ b/csi-rclone/tests/1.13-node_plugin_test.yaml
@@ -1,7 +1,7 @@
 suite: CSI Node Plugin
 templates:
+  - 1.13-csi-nodeplugin-rbac.yaml
   - 1.13-csi-nodeplugin-rclone.yaml
-  - 1.19-csi-nodeplugin-rclone.yaml
 tests:
   - it: is a daemon (1.13)
     template: 1.13-csi-nodeplugin-rclone.yaml

--- a/csi-rclone/tests/1.19-controller_test.yaml
+++ b/csi-rclone/tests/1.19-controller_test.yaml
@@ -1,6 +1,6 @@
 suite: Controller
 templates:
-  - 1.13-csi-controller-rclone.yaml
+  - 1.19-csi-controller-rbac.yaml
   - 1.19-csi-controller-rclone.yaml
 tests:
   - it: is a stateful set (1.19)

--- a/csi-rclone/tests/1.19-node_plugin_test.yaml
+++ b/csi-rclone/tests/1.19-node_plugin_test.yaml
@@ -1,6 +1,6 @@
 suite: CSI Node Plugin
 templates:
-  - 1.13-csi-nodeplugin-rclone.yaml
+  - 1.19-csi-nodeplugin-rbac.yaml
   - 1.19-csi-nodeplugin-rclone.yaml
 tests:
   - it: is a daemon (1.19)

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 1.10.0
+version: 1.11.0
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/backup-cron.yaml
+++ b/drupal/templates/backup-cron.yaml
@@ -61,8 +61,7 @@ spec:
             - containerPort: 3306
               name: mariadb
             resources:
-              requests:
-                {{- .Values.backup.resources | toYaml | nindent 14 }}
+              {{- .Values.backup.resources | toYaml | nindent 14 }}
           restartPolicy: Never
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}

--- a/drupal/templates/varnish-deployment.yaml
+++ b/drupal/templates/varnish-deployment.yaml
@@ -31,9 +31,6 @@ spec:
           name: web
         - containerPort: 6082
           name: admin
-        livenessProbe:
-          tcpSocket:
-            port: 80
         env:
         - name: VARNISH_STORAGE_BACKEND
           value: {{ .Values.varnish.storageBackend | quote }}

--- a/drupal/tests/db_test.yaml
+++ b/drupal/tests/db_test.yaml
@@ -1,7 +1,8 @@
 suite: drupal database
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
@@ -96,5 +97,3 @@ tests:
           content:
             name: DB_HOST
             value: RELEASE-NAME-proxysql
-
-  

--- a/drupal/tests/drupal_cache_tags_test.yaml
+++ b/drupal/tests/drupal_cache_tags_test.yaml
@@ -1,7 +1,7 @@
 suite: drupal cache tag exposure
 templates:
-  - varnish-configmap-vcl.yaml
   - drupal-configmap.yaml
+  - varnish-configmap-vcl.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/drupal/tests/drupal_cron_test.yaml
+++ b/drupal/tests/drupal_cron_test.yaml
@@ -119,6 +119,19 @@ tests:
           limits:
             cpu: 234m
             memory: 2G
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.cpu
+          value: 123m
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.requests.memory
+          value: 1G
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.cpu
+          value: 234m
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].resources.limits.memory
+          value: 2G
 
   - it: uses default resource requests and limits overriden by cronJobDefaults resources
     template: drupal-cron.yaml

--- a/drupal/tests/drupal_deployment_test.yaml
+++ b/drupal/tests/drupal_deployment_test.yaml
@@ -1,7 +1,8 @@
 suite: drupal deployment
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
@@ -145,12 +146,12 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: boolean_on
-            value: "true"
+            value: "on"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: boolean_off
-            value: "false"
+            value: "off"
       - contains:
           path: spec.template.spec.containers[0].env
           content:

--- a/drupal/tests/drupal_hpa_test.yaml
+++ b/drupal/tests/drupal_hpa_test.yaml
@@ -1,6 +1,8 @@
 suite: HorizontalPodAutoscaler
 templates:
+  - drupal-configmap.yaml
   - drupal-deployment.yaml
+  - drupal-secret.yaml
 tests:
   - it: HPA resource is present when autoscaler is enabled
     template: drupal-deployment.yaml

--- a/drupal/tests/drupal_ingress_test.yaml
+++ b/drupal/tests/drupal_ingress_test.yaml
@@ -20,7 +20,7 @@ tests:
         - networking.k8s.io/v1beta1
     asserts:
       - equal:
-          path: 'metadata.annotations.kubernetes\.io/ingress\.class'
+          path: metadata.annotations['kubernetes.io/ingress.class']
           value: 'traefik'
 
   - it: uses traefik ingress class (1.18+)
@@ -39,18 +39,18 @@ tests:
     template: drupal-ingress.yaml
     set:
       environmentName: 'foo'
-      projectName: 'bar' 
-      clusterDomain: 'baz' 
+      projectName: 'bar'
+      clusterDomain: 'baz'
     asserts:
       - equal:
           path: spec.rules[0].host
           value: 'foo.bar.baz'
-  
+
   - it: sets correct hostname for deployment when projectName is absent
     template: drupal-ingress.yaml
     set:
       environmentName: 'foo'
-      clusterDomain: 'baz' 
+      clusterDomain: 'baz'
     asserts:
       - equal:
           path: spec.rules[0].host
@@ -81,7 +81,7 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
           value: 'RELEASE-NAME-drupal'
-  
+
   - it: directs traefik requests to varnish service when varnish is enabled (cm 0.8)
     template: drupal-ingress.yaml
     set:
@@ -206,7 +206,7 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.kubernetes\.io/ingress\.class'
+          path: metadata.annotations['kubernetes.io/ingress.class']
           value: 'foo'
 
   - it: exposeDomains - uses default ingress type and has correct hostname (1.18+)
@@ -241,6 +241,18 @@ tests:
           path: spec.rules[0].host
           value: 'foo.bar'
 
+  - it: exposeDomains - ssl redirect is enabled by default
+    template: drupal-ingress.yaml
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.bar
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations['ingress.kubernetes.io/ssl-redirect']
+          value: 'true'
+
   - it: exposeDomains - can disable ssl for a certain ingress
     template: drupal-ingress.yaml
     set:
@@ -255,12 +267,11 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.traefik\.ingress\.kubernetes\.io\/frontend-entry-points'
+          path: metadata.annotations['traefik.ingress.kubernetes.io/frontend-entry-points']
           value: 'http'
       - documentIndex: 1
-        equal:
-          path: 'ingress\.kubernetes\.io\/ssl-redirect'
-          value: null
+        notExists:
+          path: metadata.annotations['ingress.kubernetes.io/ssl-redirect']
 
   - it: exposeDomains - can disable ssl redirect
     template: drupal-ingress.yaml
@@ -274,11 +285,10 @@ tests:
           ingress: nossl
     asserts:
       - documentIndex: 1
-        equal:
-          path: 'metadata.annotations.ingress\.kubernetes\.io\/ssl-redirect'
-          value: null
+        notExists:
+          path: metadata.annotations['ingress.kubernetes.io/ssl-redirect']
 
-  - it: exposeDomains - multiple hostnames can use the same ingress 
+  - it: exposeDomains - multiple hostnames can use the same ingress
     template: drupal-ingress.yaml
     set:
       exposeDomains:
@@ -286,7 +296,7 @@ tests:
           hostname: foo.baz
         bar:
           hostname: bar.baz
-        
+
     asserts:
       - documentIndex: 1
         equal:
@@ -310,7 +320,7 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.kubernetes\.io\/ingress\.global-static-ip-name'
+          path: metadata.annotations['kubernetes.io/ingress.global-static-ip-name']
           value: 'baz'
 
   - it: exposeDomains - non-gce ingress path wildcard for kubernetes <1.19

--- a/drupal/tests/drupal_node_selector_test.yaml
+++ b/drupal/tests/drupal_node_selector_test.yaml
@@ -1,9 +1,11 @@
 suite: node selector test
 templates:
-  - drupal-deployment.yaml
-  - drupal-cron.yaml
-  - shell-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-cron.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
+  - shell-configmap.yaml
+  - shell-deployment.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/drupal/tests/drupal_php_env_test.yaml
+++ b/drupal/tests/drupal_php_env_test.yaml
@@ -1,5 +1,9 @@
 suite: drupal php env
 templates:
+  - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
+  - shell-configmap.yaml
   - shell-deployment.yaml
 capabilities:
   apiVersions:

--- a/drupal/tests/elasticsearch_test.yaml
+++ b/drupal/tests/elasticsearch_test.yaml
@@ -1,7 +1,8 @@
 suite: drupal elasticsearch
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/drupal/tests/memcached_test.yaml
+++ b/drupal/tests/memcached_test.yaml
@@ -1,7 +1,8 @@
 suite: drupal memcached
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/drupal/tests/nginx-extra-config_test.yaml
+++ b/drupal/tests/nginx-extra-config_test.yaml
@@ -1,7 +1,8 @@
 suite: additional nginx configuration file
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
@@ -10,7 +11,7 @@ tests:
     template: drupal-configmap.yaml
     set:
       nginx.extraConfig: |
-        add_header X-Release-Name extraconfig-{{ .Release.Name }};  
+        add_header X-Release-Name extraconfig-{{ .Release.Name }};
     asserts:
     - matchRegex:
         path: data.extraConfig
@@ -19,7 +20,7 @@ tests:
     template: drupal-configmap.yaml
     set:
       nginx.serverExtraConfig: |
-        # serverextraconfig test {{ .Release.Name }}  
+        # serverextraconfig test {{ .Release.Name }}
     asserts:
     - matchRegex:
         path: data.drupal_conf
@@ -28,7 +29,7 @@ tests:
     template: drupal-configmap.yaml
     set:
       nginx.locationExtraConfig: |
-        # locationextraconfig test {{ .Release.Name }}  
+        # locationextraconfig test {{ .Release.Name }}
     asserts:
     - matchRegex:
         path: data.drupal_conf
@@ -39,7 +40,7 @@ tests:
       nginx.extraConfig: |
         server {
           server_name exists.test;
-        }  
+        }
     asserts:
       - contains:
           path: spec.template.spec.containers[1].volumeMounts

--- a/drupal/tests/private_docker_image_test.yaml
+++ b/drupal/tests/private_docker_image_test.yaml
@@ -1,9 +1,10 @@
 suite: private docker image
 templates:
-  - drupal-deployment.yaml
-  - drupal-cron.yaml
-  - post-release.yaml
   - drupal-configmap.yaml
+  - drupal-cron.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
+  - post-release.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/drupal/tests/private_files_test.yaml
+++ b/drupal/tests/private_files_test.yaml
@@ -1,10 +1,11 @@
 suite: drupal private files
 templates:
+  - drupal-configmap.yaml
+  - drupal-cron.yaml
   - drupal-deployment.yaml
+  - drupal-secret.yaml
   - drupal-volumes.yaml
   - post-release.yaml
-  - drupal-cron.yaml
-  - drupal-configmap.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/drupal/tests/redis_test.yaml
+++ b/drupal/tests/redis_test.yaml
@@ -1,7 +1,8 @@
 suite: drupal redis
 templates:
-  - drupal-deployment.yaml
   - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/drupal/tests/reference_data_test.yaml
+++ b/drupal/tests/reference_data_test.yaml
@@ -1,10 +1,11 @@
 suite: reference data
 templates:
+  - drupal-configmap.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
+  - drupal-volumes.yaml
   - post-release.yaml
   - reference-data-cron.yaml
-  - drupal-deployment.yaml
-  - drupal-volumes.yaml
-  - drupal-configmap.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
@@ -38,7 +39,7 @@ tests:
           readOnly: true
 
   - it: is not mounted on the main deployment
-    template: post-release.yaml    
+    template: post-release.yaml
     asserts:
     - template: drupal-deployment.yaml
       notContains:
@@ -53,7 +54,7 @@ tests:
         content:
           name: "reference-data-volume"
           mountPath: "/app/reference-data"
-            
+
   - it: takes reference data information
     template: post-release.yaml
     set:
@@ -130,7 +131,7 @@ tests:
         content:
           name: "reference-data-volume"
           persistentVolumeClaim:
-            claimName: foo-reference-data  
+            claimName: foo-reference-data
     - notContains:
         path: spec.template.spec.containers[0].volumeMounts
         content:

--- a/drupal/tests/shell_configmap_test.yaml
+++ b/drupal/tests/shell_configmap_test.yaml
@@ -1,12 +1,14 @@
 suite: shell configmap
 templates:
+  - drupal-configmap.yaml
+  - drupal-secret.yaml
   - shell-configmap.yaml
   - shell-deployment.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
-  
+
   - it: Secret ConfigMap is created
     template: shell-configmap.yaml
     set:
@@ -17,7 +19,7 @@ tests:
       - equal:
           path: metadata.labels.app
           value: drupal
-  
+
   - it: Authorized keys addition is reflected into shell configmap
     template: shell-configmap.yaml
     set:
@@ -26,25 +28,25 @@ tests:
         - foo
         - bar
     asserts:
-      - template: shell-configmap.yaml 
+      - template: shell-configmap.yaml
         equal:
           path: data.authorizedKeys
           value: |-
             foo
             bar
-  
+
   - it: No extra authorized keys are present in template
     template: shell-configmap.yaml
     set:
       shell.enabled: true
       shell.authorizedKeys: []
     asserts:
-      - template: shell-configmap.yaml 
+      - template: shell-configmap.yaml
         equal:
           path: data.authorizedKeys
           value: ""
 
-  - it: Adds keyserver environment variables when shell is enabled 
+  - it: Adds keyserver environment variables when shell is enabled
     template: shell-deployment.yaml
     set:
       shell.enabled: true
@@ -58,14 +60,14 @@ tests:
             value: foo.bar
       - contains:
           path: spec.template.spec.containers[0].env
-          content: 
+          content:
             name: GITAUTH_USERNAME
             valueFrom:
               secretKeyRef:
                 key: keyserver.username
                 name: RELEASE-NAME-secrets-shell
 
-  - it: Keyserver environment variables not present when shell is disabled 
+  - it: Keyserver environment variables not present when shell is disabled
     template: shell-deployment.yaml
     set:
       shell.enabled: true

--- a/drupal/tests/shell_deployment_test.yaml
+++ b/drupal/tests/shell_deployment_test.yaml
@@ -1,5 +1,8 @@
 suite: shell deployment
 templates:
+  - drupal-configmap.yaml
+  - drupal-secret.yaml
+  - shell-configmap.yaml
   - shell-deployment.yaml
 capabilities:
   apiVersions:

--- a/drupal/tests/varnish_test.yaml
+++ b/drupal/tests/varnish_test.yaml
@@ -1,7 +1,7 @@
 suite: varnish deployment
 templates:
-  - varnish-deployment.yaml
   - varnish-configmap-vcl.yaml
+  - varnish-deployment.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1
@@ -11,7 +11,7 @@ tests:
     set:
       varnish.enabled: true
       varnish.storageBackend: 'type,/storage/location,size'
-    asserts: 
+    asserts:
       - documentIndex: 0
         contains:
           path: 'spec.template.spec.containers[0].env'
@@ -23,7 +23,7 @@ tests:
     set:
       varnish.enabled: true
       varnish.extraParams: '-foo -bar'
-    asserts: 
+    asserts:
       - documentIndex: 0
         contains:
           path: 'spec.template.spec.containers[0].env'

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.9.0
+version: 1.10.0
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/tests/elasticsearch_test.yaml
+++ b/frontend/tests/elasticsearch_test.yaml
@@ -1,7 +1,7 @@
 suite: frontend elasticsearch
 templates:
-  - services-deployment.yaml
   - configmap.yaml
+  - services-deployment.yaml
 capabilities:
   apiVersions:
     - pxc.percona.com/v1

--- a/frontend/tests/ingress_test.yaml
+++ b/frontend/tests/ingress_test.yaml
@@ -17,7 +17,7 @@ tests:
         - networking.k8s.io/v1beta1
     asserts:
       - equal:
-          path: 'metadata.annotations.kubernetes\.io/ingress\.class'
+          path: metadata.annotations['kubernetes.io/ingress.class']
           value: 'traefik'
 
   - it: uses traefik ingress class (1.18+)
@@ -36,18 +36,18 @@ tests:
     template: ingress.yaml
     set:
       environmentName: 'foo'
-      projectName: 'bar' 
-      clusterDomain: 'baz' 
+      projectName: 'bar'
+      clusterDomain: 'baz'
     asserts:
       - equal:
           path: spec.rules[0].host
           value: 'foo.bar.baz'
-  
+
   - it: sets correct hostname for deployment when projectName is absent
     template: ingress.yaml
     set:
       environmentName: 'foo'
-      clusterDomain: 'baz' 
+      clusterDomain: 'baz'
     asserts:
       - equal:
           path: spec.rules[0].host
@@ -78,7 +78,7 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
           value: 'RELEASE-NAME-nginx'
-  
+
   - it: uses correct ingress api version (1.17)
     template: ingress.yaml
     capabilities:
@@ -169,7 +169,7 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.kubernetes\.io/ingress\.class'
+          path: metadata.annotations['kubernetes.io/ingress.class']
           value: 'foo'
 
   - it: exposeDomains - uses default ingress type and has correct hostname (1.18+)
@@ -191,7 +191,7 @@ tests:
         equal:
           path: 'spec.ingressClassName'
           value: 'foo'
-  
+
   - it: exposeDomains - has correct hostname
     template: ingress.yaml
     set:
@@ -203,6 +203,18 @@ tests:
         equal:
           path: spec.rules[0].host
           value: 'foo.bar'
+
+  - it: exposeDomains - ssl redirect is enabled by default
+    template: ingress.yaml
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.bar
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations['ingress.kubernetes.io/ssl-redirect']
+          value: 'true'
 
   - it: exposeDomains - can disable ssl for a certain ingress
     template: ingress.yaml
@@ -218,12 +230,11 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.traefik\.ingress\.kubernetes\.io\/frontend-entry-points'
+          path: metadata.annotations['traefik.ingress.kubernetes.io/frontend-entry-points']
           value: 'http'
       - documentIndex: 1
-        equal:
-          path: 'ingress\.kubernetes\.io\/ssl-redirect'
-          value: null
+        notExists:
+          path: ingress.kubernetes.io/ssl-redirect
 
   - it: exposeDomains - can disable ssl redirect
     template: ingress.yaml
@@ -237,11 +248,10 @@ tests:
           ingress: nossl
     asserts:
       - documentIndex: 1
-        equal:
-          path: 'metadata.annotations.ingress\.kubernetes\.io\/ssl-redirect'
-          value: null
+        notExists:
+          path: metadata.annotations['ingress.kubernetes.io/ssl-redirect']
 
-  - it: exposeDomains - multiple hostnames can use the same ingress 
+  - it: exposeDomains - multiple hostnames can use the same ingress
     template: ingress.yaml
     set:
       exposeDomains:
@@ -249,7 +259,7 @@ tests:
           hostname: foo.baz
         bar:
           hostname: bar.baz
-        
+
     asserts:
       - documentIndex: 1
         equal:
@@ -273,5 +283,5 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.kubernetes\.io\/ingress\.global-static-ip-name'
+          path: metadata.annotations['kubernetes.io/ingress.global-static-ip-name']
           value: 'baz'

--- a/frontend/tests/mongodb_test.yaml
+++ b/frontend/tests/mongodb_test.yaml
@@ -1,28 +1,28 @@
 suite: MongoDB
 templates:
-  - services-deployment.yaml
+  - configmap.yaml
   - services-cron.yaml
+  - services-deployment.yaml
 tests:
-  # FIXME: This test fails because bitnami's common subchart uses multiline helm/sprig snippet that does not work with current unittest version. 
-  # - it: gets exposed when enabled
-  #   template: services-deployment.yaml
-  #   set:
-  #     services.foo:
-  #       image: 'bar'
-  #       cron:
-  #         foo:
-  #           command: echo "Hello world"
-  #           schedule: '1 2 3 * *'
-  #     mongodb.enabled: true
-  #   asserts:
-  #     - contains:
-  #         path: spec.template.spec.containers[0].env
-  #         content:
-  #           name: MONGODB_HOST
-  #           value: RELEASE-NAME-mongodb
-  #     - template: services-cron.yaml
-  #       contains:
-  #         path: spec.jobTemplate.spec.template.spec.containers[0].env
-  #         content:
-  #           name: MONGODB_HOST
-  #           value: RELEASE-NAME-mongodb
+  - it: gets exposed when enabled
+    template: services-deployment.yaml
+    set:
+      services.foo:
+        image: 'bar'
+        cron:
+          foo:
+            command: echo "Hello world"
+            schedule: '1 2 3 * *'
+      mongodb.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MONGODB_HOST
+            value: RELEASE-NAME-mongodb
+      - template: services-cron.yaml
+        contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: MONGODB_HOST
+            value: RELEASE-NAME-mongodb

--- a/frontend/tests/nginx-hpa_test.yaml
+++ b/frontend/tests/nginx-hpa_test.yaml
@@ -1,5 +1,6 @@
 suite: HorizontalPodAutoscaler
 templates:
+  - configmap.yaml
   - nginx.yaml
 tests:
   - it: HPA resource is present when autoscaler is enabled

--- a/frontend/tests/rabbitmq_test.yaml
+++ b/frontend/tests/rabbitmq_test.yaml
@@ -1,7 +1,8 @@
 suite: RabbitMQ
 templates:
-  - services-deployment.yaml
+  - configmap.yaml
   - services-cron.yaml
+  - services-deployment.yaml
 tests:
   - it: gets exposed when enabled
     template: services-deployment.yaml

--- a/frontend/tests/redis_test.yaml
+++ b/frontend/tests/redis_test.yaml
@@ -6,30 +6,29 @@ capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
-# FIXME: This test fails because bitnami's common subchart uses multiline helm/sprig snippet that does not work with current unittest version.
-  #- it: sets redis hostname in environment if redis is enabled
-  #  template: services-deployment.yaml
-  #  set:
-  #    services.node.enabled: true
-  #    redis:
-  #      enabled: true
-  #      auth:
-  #        password: "foo"
-  #  asserts:
-  #    - contains:
-  #        path: spec.template.spec.containers[0].env
-  #        content:
-  #          name: REDIS_HOST
-  #          value: RELEASE-NAME-redis-master
-  #
-  #- it: sets no redis hostname in frontend environment if redis is disabled
-  #  template: services-deployment.yaml
-  #  set:
-  #    services.node.enabled: true
-  #    redis.enabled: false
-  #  asserts:
-  #    - notContains:
-  #        path: spec.template.spec.containers[0].env
-  #        content:
-  #          name: REDIS_HOST
-  #          value: RELEASE-NAME-redis-master
+  - it: sets redis hostname in environment if redis is enabled
+    template: services-deployment.yaml
+    set:
+      services.node.enabled: true
+      redis:
+        enabled: true
+        auth:
+          password: "foo"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master
+
+  - it: sets no redis hostname in frontend environment if redis is disabled
+    template: services-deployment.yaml
+    set:
+      services.node.enabled: true
+      redis.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -109,7 +109,7 @@ singleSubdomain: false
 
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:
-  image: 'wunderio/silta-nginx:1.24-v1'
+  image: 'wunderio/silta-nginx:1.26-v1'
 
   # Requires "X-Proxy-Auth" header from upstream when value is non-empty string.
   x_proxy_auth: ""

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.6.2
+version: 1.7.0
 # kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -46,7 +46,7 @@ spec:
       enableServiceLinks: false
       containers:
       - name: {{ .Release.Name }}-jumpserver
-        image: wunderio/sshd-gitauth:v0.2
+        image: wunderio/sshd-gitauth:v1.0
         imagePullPolicy: Always
         ports:
           - containerPort: 22

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 1.3.0
+version: 1.4.0
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/tests/deployment_test.yaml
+++ b/simple/tests/deployment_test.yaml
@@ -1,8 +1,10 @@
 suite: Site deployment
 templates:
+  - configmap.yaml
   - deployment.yaml
 tests:
   - it: is a deployment with default values
+    template: deployment.yaml
     asserts:
       - isKind:
           of: Deployment
@@ -14,6 +16,7 @@ tests:
           value: simple
 
   - it: uses the right docker images
+    template: deployment.yaml
     set:
       nginx.image: 'nginx-12345'
     asserts:
@@ -22,6 +25,7 @@ tests:
           value: 'nginx-12345'
 
   - it: sets the replica count correctly
+    template: deployment.yaml
     set:
       replicas: 3
     asserts:
@@ -30,6 +34,7 @@ tests:
           value: 3
 
   - it: takes resource requests and limits
+    template: deployment.yaml
     set:
       nginx.resources:
         requests:

--- a/simple/tests/hpa_test.yaml
+++ b/simple/tests/hpa_test.yaml
@@ -1,5 +1,6 @@
 suite: HorizontalPodAutoscaler
 templates:
+  - configmap.yaml
   - deployment.yaml
 tests:
   - it: HPA resource is present when autoscaler is enabled

--- a/simple/tests/ingress_test.yaml
+++ b/simple/tests/ingress_test.yaml
@@ -1,21 +1,26 @@
 suite: Site ingress
 templates:
+  - configmap.yaml
   - ingress.yaml
 tests:
   - it: is a ingress
+    template: ingress.yaml
     asserts:
       - isKind:
           of: Ingress
 
   - it: uses traefik ingress class (1.17)
+    template: ingress.yaml
     capabilities:
       majorVersion: 1
       minorVersion: 17
     asserts:
       - equal:
-          path: 'metadata.annotations.kubernetes\.io/ingress\.class'
+          path: metadata.annotations['kubernetes.io/ingress.class']
           value: 'traefik'
+
   - it: uses traefik ingress class (1.18+)
+    template: ingress.yaml
     capabilities:
       majorVersion: 1
       minorVersion: 18
@@ -25,19 +30,21 @@ tests:
           value: 'traefik'
 
   - it: sets correct hostname for deployment
+    template: ingress.yaml
     set:
       environmentName: 'foo'
-      projectName: 'bar' 
-      clusterDomain: 'baz' 
+      projectName: 'bar'
+      clusterDomain: 'baz'
     asserts:
       - equal:
           path: spec.rules[0].host
           value: 'foo.bar.baz'
-  
+
   - it: sets correct hostname for deployment when projectName is absent
+    template: ingress.yaml
     set:
       environmentName: 'foo'
-      clusterDomain: 'baz' 
+      clusterDomain: 'baz'
     asserts:
       - equal:
           path: spec.rules[0].host
@@ -66,7 +73,7 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
           value: 'RELEASE-NAME-simple'
-  
+
   - it: uses correct ingress api version (1.17)
     template: ingress.yaml
     capabilities:
@@ -88,6 +95,7 @@ tests:
           value: 'networking.k8s.io/v1'
 
   - it: shortens long project names
+    template: ingress.yaml
     set:
       projectName: 'client-fi-longclient-longproject-backend'
     asserts:
@@ -96,6 +104,7 @@ tests:
           value: 'release-name.client-fi-longclient-longpra6b.silta.wdr.io'
 
   - it: shortens long branch names
+    template: ingress.yaml
     set:
       environmentName: 'feature/my-project-shortname-12345-with-additional-description'
     asserts:
@@ -104,6 +113,7 @@ tests:
           value: 'feature-my-project-shortname-12345-witdb6.namespace.silta.wdr.io'
 
   - it: shortens branch names more when project name is already long
+    template: ingress.yaml
     set:
       projectName: 'client-fi-longclient-longproject-backend'
       environmentName: 'feature/my-project-shortname-12345-with-additional-description'
@@ -127,9 +137,9 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.kubernetes\.io/ingress\.class'
+          path: metadata.annotations['kubernetes.io/ingress.class']
           value: 'foo'
-  
+
   - it: exposeDomains - uses default ingress type and has correct hostname (1.18+)
     template: ingress.yaml
     capabilities:
@@ -147,7 +157,7 @@ tests:
         equal:
           path: 'spec.ingressClassName'
           value: 'foo'
-  
+
   - it: exposeDomains - has correct hostname
     template: ingress.yaml
     set:
@@ -159,6 +169,18 @@ tests:
         equal:
           path: spec.rules[0].host
           value: 'foo.bar'
+
+  - it: exposeDomains - ssl redirect is enabled by default
+    template: ingress.yaml
+    set:
+      exposeDomains:
+        foo:
+          hostname: foo.bar
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations['ingress.kubernetes.io/ssl-redirect']
+          value: 'true'
 
   - it: exposeDomains - can disable ssl for a certain ingress
     template: ingress.yaml
@@ -174,12 +196,11 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.traefik\.ingress\.kubernetes\.io\/frontend-entry-points'
+          path: metadata.annotations['traefik.ingress.kubernetes.io/frontend-entry-points']
           value: 'http'
       - documentIndex: 1
-        equal:
-          path: 'ingress\.kubernetes\.io\/ssl-redirect'
-          value: null
+        notExists:
+          path: ingress.kubernetes.io/ssl-redirect
 
   - it: exposeDomains - can disable ssl redirect
     template: ingress.yaml
@@ -193,11 +214,10 @@ tests:
           ingress: nossl
     asserts:
       - documentIndex: 1
-        equal:
-          path: 'metadata.annotations.ingress\.kubernetes\.io\/ssl-redirect'
-          value: null
+        notExists:
+          path: metadata.annotations['ingress.kubernetes.io/ssl-redirect']
 
-  - it: exposeDomains - multiple hostnames can use the same ingress 
+  - it: exposeDomains - multiple hostnames can use the same ingress
     template: ingress.yaml
     set:
       exposeDomains:
@@ -205,7 +225,6 @@ tests:
           hostname: foo.baz
         bar:
           hostname: bar.baz
-        
     asserts:
       - documentIndex: 1
         equal:
@@ -229,7 +248,7 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: 'metadata.annotations.kubernetes\.io\/ingress\.global-static-ip-name'
+          path: metadata.annotations['kubernetes.io/ingress.global-static-ip-name']
           value: 'baz'
 
 
@@ -242,12 +261,12 @@ tests:
     - matchRegex:
         path: data.nginx_conf
         pattern: 'set_real_ip_from *1.2.3.4'
- 
+
   - it: tests realipfrom nginx configuration (multivalue object)
     template: configmap.yaml
     set:
       nginx:
-        realipfrom: 
+        realipfrom:
           foo: '1.1.1.1'
           bar: '2.2.2.2'
     asserts:


### PR DESCRIPTION
## Blocked by https://github.com/wunderio/silta-images/pull/216

Charts repository:
- Run helm unit tests using latest version of the helm-unittest plugin ([PR](https://github.com/wunderio/charts/pull/435))

Drupal chart (1.11.0):
- SLT-1026: Update helm unit tests to work with latest version of the helm-unittest plugin ([PR](https://github.com/wunderio/drupal-project-k8s/pull/711))

Frontend chart (1.10.0):
- SLT-1026: Update helm unit tests to work with latest version of the helm-unittest plugin ([PR](https://github.com/wunderio/frontend-project-k8s/pull/129))

Simple chart (1.4.0):
- SLT-1026: Update helm unit tests to work with latest version of the helm-unittest plugin ([PR](https://github.com/wunderio/simple-project-k8s/pull/59))

CSI Rclone chart (0.5.0):
- SLT-1026: Update helm unit tests to work with latest version of the helm-unittest plugin ([PR](https://github.com/wunderio/charts/pull/435))

Silta cluster chart (1.7.0)
- Update wunderio/sshd-gitauth image to v1.0 in sshd-jumpserver.yaml ([PR](https://github.com/wunderio/charts/pull/441))