### PR TITLE
Silta cluster chart: Use new rclone provisioner, add daemonset for setting max_map_count

### DIFF
--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.10.0
+  version: 4.10.4
 - name: nginx-ingress
   repository: https://helm.nginx.com/stable
   version: 0.17.1
@@ -10,7 +10,7 @@ dependencies:
   version: 1.87.7
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.10.0
+  version: 4.10.4
 - name: pxc-operator
   repository: https://percona.github.io/percona-helm-charts/
   version: 1.12.2
@@ -18,8 +18,8 @@ dependencies:
   repository: file://../forked/minio/minio-6.0.5
   version: 6.0.5
 - name: csi-rclone
-  repository: https://storage.googleapis.com/charts.wdr.io
-  version: 0.3.1
+  repository: file://../csi-rclone
+  version: 1.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io/
   version: v0.10.1
@@ -28,7 +28,7 @@ dependencies:
   version: 1.0.0
 - name: instana-agent
   repository: https://agents.instana.io/helm
-  version: 1.2.71
+  version: 1.2.73
 - name: nfs-subdir-external-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
   version: 4.0.18
@@ -38,5 +38,5 @@ dependencies:
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.0
-digest: sha256:a5b82b04cb36e9c55428cb7c1b860c62abae5175c08d6b99a7a5934ea6f8e906
-generated: "2024-03-14T13:57:48.971718393+02:00"
+digest: sha256:c7ff69f37389d474c7449b4458c727c634e7529ce9fda4aed60c13fa9643b798
+generated: "2024-08-27T13:59:48.177657684+03:00"

--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -18,7 +18,7 @@ dependencies:
   repository: file://../forked/minio/minio-6.0.5
   version: 6.0.5
 - name: csi-rclone
-  repository: file://../csi-rclone
+  repository: https://storage.googleapis.com/charts.wdr.io
   version: 1.0.0
 - name: cert-manager
   repository: https://charts.jetstack.io/
@@ -38,5 +38,5 @@ dependencies:
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.0
-digest: sha256:c7ff69f37389d474c7449b4458c727c634e7529ce9fda4aed60c13fa9643b798
-generated: "2024-08-27T13:59:48.177657684+03:00"
+digest: sha256:4b1c653905617945db382d2b950ba0b860f1c90dd12261bb5e1840c46f77e27f
+generated: "2024-09-03T09:52:29.859928636+03:00"

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,8 +2,10 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.7.0
-# kubeVersion: '>=1.20.0-0'
+version: 1.8.0
+# csi-rclone external provisioner requires kubernetes 1.20+
+# https://github.com/kubernetes-csi/external-provisioner?tab=readme-ov-file#compatibility
+kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx
   # check kubernetes version requirements here: https://github.com/kubernetes/ingress-nginx
@@ -35,8 +37,9 @@ dependencies:
   repository: file://../forked/minio/minio-6.0.5
   condition: minio.enabled
 - name: csi-rclone
-  version: 0.3.x
+  version: 1.0.x
   repository: https://storage.googleapis.com/charts.wdr.io
+  # repository: file://../csi-rclone
   condition: csi-rclone.enabled
 - name: cert-manager
   version: 0.10.x

--- a/silta-cluster/README.md
+++ b/silta-cluster/README.md
@@ -146,6 +146,8 @@ helm upgrade --install --wait silta-cluster silta-cluster \
 
 ## Upgrade path for older versions:
 
+ - Upgrading silta-cluster chart to 1.8.0 ([docs/Upgrading-to-1.8.0.md](docs/Upgrading-to-1.8.0.md))
+
  - Upgrading silta-cluster chart to 0.2.43 ([docs/Upgrading-to-0.2.43.md](docs/Upgrading-to-0.2.43.md))
 
  - Upgrading silta-cluster chart to 0.2.36 ([docs/Upgrading-to-0.2.36.md](docs/Upgrading-to-0.2.36.md))

--- a/silta-cluster/docs/Upgrading-to-1.8.0.md
+++ b/silta-cluster/docs/Upgrading-to-1.8.0.md
@@ -1,0 +1,13 @@
+# Upgrading silta-cluster chart to 1.8.0
+
+This upgrade requires csi-rclone image upgrade to v3.0.0 or later.
+
+## csi-rclone upgrade
+
+csi-rclone (v3.0.0) implements PersistentVolume provisioner and requires changes to storage class configuration. Since storage class is immutable resource, it is necessary to remove the old storage class and do a silta-cluster chart deployment to create a new one.
+
+```bash
+kubectl delete storageclass silta-shared
+```
+
+Existing PersistentVolume definitions and PersistentVolumeClaims with selector will keep working with the updated driver.

--- a/silta-cluster/templates/csi-rclone-upgrade-check.yaml
+++ b/silta-cluster/templates/csi-rclone-upgrade-check.yaml
@@ -1,0 +1,7 @@
+{{- $rclone := index .Values "csi-rclone" }}
+{{- if $rclone.enabled }}
+{{- $imgversion := semver $rclone.version }}
+{{- if semverCompare "<3.0.0" ( printf "%d.%d.%d" $imgversion.Major $imgversion.Minor $imgversion.Patch ) }}
+{{- fail (printf "csi-rclone image (csi-rclone.version) upgrade required. Current image: %s, parsed version: %s, required minimum version: %s" $rclone.version (printf "%d.%d.%d" $imgversion.Major $imgversion.Minor $imgversion.Patch) "3.0.0" ) }}
+{{- end }}
+{{- end }}

--- a/silta-cluster/templates/daemonset.yaml
+++ b/silta-cluster/templates/daemonset.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.daemonset.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}-ds
+spec:
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-ds
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}-ds
+    spec:
+      initContainers:
+        {{- if .Values.daemonset.maxMapCountSetter.enabled }}
+        - name: max-map-count-setter
+          image: docker.io/bash:5
+          resources:
+            limits:
+              cpu: 100m
+              memory: 32Mi
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          command: ['/usr/local/bin/bash', '-e', '-c', 'echo 262144 > /proc/sys/vm/max_map_count']
+        {{- end }}
+      containers:
+        - name: sleep
+          image: docker.io/bash:5
+          command: ['sleep', 'infinity']
+{{- end }}

--- a/silta-cluster/templates/silta-cluster-crd.yaml
+++ b/silta-cluster/templates/silta-cluster-crd.yaml
@@ -1,0 +1,36 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: releases.silta.wdr.io
+spec:
+  group: silta.wdr.io
+  scope: Namespaced
+  names:
+    kind: Release
+    singular: release
+    plural: releases
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+      - name: Release
+        type: string
+        description: Name of the release
+        jsonPath: .spec.releaseName
+      - name: Branch
+        type: string
+        description: Branch name of the release
+        jsonPath: .spec.branchName
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+            properties:
+              branchName:
+                type: string
+              releaseName:
+                type: string

--- a/silta-cluster/templates/sshd-jumpserver.yaml
+++ b/silta-cluster/templates/sshd-jumpserver.yaml
@@ -75,7 +75,7 @@ spec:
       volumes:
       - name: shell-keys
         persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-shell-keys
+          claimName: {{ .Release.Name }}-shell-key
       - name: sshd-jumphost-configmap
         configMap:
           name: {{ .Release.Name }}-sshd-jumphost
@@ -83,9 +83,12 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Release.Name }}-shell-keys
+  name: {{ .Release.Name }}-shell-key
   labels:
     name: {{ .Release.Name }}-jumpserver
+  annotations:
+    storage.silta/storage-path: jumpserver
+    csi-rclone/umask: "077"
 spec:
   {{- if .Values.gitAuth.persistence.storageClassName }}
   storageClassName: {{ .Values.gitAuth.persistence.storageClassName }}
@@ -95,37 +98,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.gitAuth.persistence.size }}
-  {{- if .Values.gitAuth.persistence.storageClassName }}
-  {{- if eq .Values.gitAuth.persistence.storageClassName "silta-shared" }}
-  selector:
-    matchLabels:
-      name: {{ $.Release.Name }}-shell-keys-pv
-  {{- end }}
-  {{- end }}
-{{- end }}
-# silta-shared volume definition if its storage is selected
-{{- if .Values.gitAuth.persistence.storageClassName }}
-{{- if eq .Values.gitAuth.persistence.storageClassName "silta-shared" }}
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: {{ $.Release.Name }}-shell-keys-pv
-  labels:
-    name: {{ $.Release.Name }}-shell-keys-pv
-spec:
-  accessModes:
-    - {{ .Values.gitAuth.persistence.accessMode }}
-  capacity:
-    storage: {{ .Values.gitAuth.persistence.size }}
-  storageClassName: {{ .Values.gitAuth.persistence.storageClassName }}
-  {{- if .Values.gitAuth.persistence.csiDriverName }}
-  csi:
-    driver: {{ .Values.gitAuth.persistence.csiDriverName }}
-    volumeHandle: {{ $.Release.Name }}-shell-keys-pv
-    volumeAttributes:
-      remotePathSuffix: /{{ $.Release.Namespace }}/jumpserver
-      umask: "077"
-  {{- end }}
-{{- end }}
 {{- end }}

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -514,3 +514,9 @@ docker-registry:
     htpasswd: |
       broken:auth
 
+daemonset:
+  enabled: true
+  # Required by elasticsearch
+  # https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-virtual-memory.html#k8s_using_a_daemonset_to_set_virtual_memory
+  maxMapCountSetter:
+    enabled: true

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -280,6 +280,7 @@ csi-rclone:
   defaultParams: false
   storageClass:
     name: "silta-shared"
+    pathPattern: "${.PVC.namespace}/${.PVC.annotations.storage.silta/storage-path}"
   # params:
   #   remote: "s3"
   #   remotePath: "projectname"


### PR DESCRIPTION
Blocked by https://github.com/wunderio/charts/pull/443

- Uses and requires updated csi-rclone
- Implements `releases.silta.wdr.io` crd to store release info (in the future) and allow conditional PV creation using `.Capabilities.APIVersions.Has "silta.wdr.io/v1"`. 
- Implements daemonset that adjusts shared memory allocation (`max_map_count`) on each node so that each deployment does not have to do it via privileged container. 

Note: there is an upgrade instruction which requires removal of `silta-storage` storageclass (`kubectl delete storageclass silta-shared`) before silta-cluster upgrade due to `provisioner` field being immutable (see `Upgrade path for older versions` in readme.md) 