### PR TITLE
Minikube tests for 1.29 and 1.30

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         # Available minikube kubernetes version list:
         # "minikube config defaults kubernetes-version"
         # and https://kubernetes.io/releases/patch-releases/
-        kubernetes-version: ["v1.22.17", "v1.23.17", "v1.24.17", "v1.25.16", "1.26.11", "1.27.8", "1.28.4", "latest"]
+        kubernetes-version: ["v1.22.17", "v1.23.17", "v1.24.17", "v1.25.16", "v1.26.15", "v1.27.13", "v1.28.9", "v1.29.4", "v1.30.0", "latest"]
     env:
       CLUSTER_DOMAIN: minikube.local.wdr.io
       K8S_PROJECT_REPO_DIR: k8s-project-repositories


### PR DESCRIPTION
Tests for 1.29 and 1.30. These were tested with latest, but now pinned in tests. Also, some patch versions were updated too.