### PR TITLE
Release 2024-09-10

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         # Available minikube kubernetes version list:
         # "minikube config defaults kubernetes-version"
         # and https://kubernetes.io/releases/patch-releases/
-        kubernetes-version: ["v1.22.17", "v1.23.17", "v1.24.17", "v1.25.16", "1.26.11", "1.27.8", "1.28.4", "latest"]
+        kubernetes-version: ["v1.22.17", "v1.23.17", "v1.24.17", "v1.25.16", "v1.26.15", "v1.27.13", "v1.28.9", "v1.29.4", "v1.30.0", "latest"]
     env:
       CLUSTER_DOMAIN: minikube.local.wdr.io
       K8S_PROJECT_REPO_DIR: k8s-project-repositories

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 1.11.0
+version: 1.12.0
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/backup-cron.yaml
+++ b/drupal/templates/backup-cron.yaml
@@ -67,7 +67,11 @@ spec:
             {{- include "drupal.volumes" . | nindent 12 }}
             - name: {{ .Release.Name }}-backup
               persistentVolumeClaim:
+                {{- if and ( eq $.Values.backup.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+                claimName: {{ .Release.Name }}-backup2
+                {{- else }}
                 claimName: {{ .Release.Name }}-backup
+                {{- end }}
           {{- include "drupal.imagePullSecrets" . | nindent 10 }}
 {{- end }}
 

--- a/drupal/templates/backup-volume.yaml
+++ b/drupal/templates/backup-volume.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.backup.enabled }}
 {{- if eq .Values.backup.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -23,10 +24,15 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if and ( eq $.Values.backup.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+  name: {{ .Release.Name }}-backup2
+  {{- else }}
   name: {{ .Release.Name }}-backup
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
   annotations:
@@ -39,8 +45,10 @@ spec:
     requests:
       storage: {{ .Values.backup.storage }}
 {{- if eq .Values.backup.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+{{- end }}
 {{- end }}
 {{- end }}

--- a/drupal/templates/drupal-volumes.yaml
+++ b/drupal/templates/drupal-volumes.yaml
@@ -4,6 +4,7 @@
 {{- if eq $mount.enabled true }}
 {{- if and (not (hasKey $mount "configMapName")) (not (hasKey $mount "secretName")) -}}
 {{- if eq $mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 # Mount-enabled: {{ $mount.enabled  }}
 apiVersion: v1
 kind: PersistentVolume
@@ -27,10 +28,15 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+  name: {{ $.Release.Name }}-{{ $index }}2
+  {{- else }}
   name: {{ $.Release.Name }}-{{ $index }}
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" $ | nindent 4 }}
   annotations:
@@ -43,9 +49,11 @@ spec:
     requests:
       storage: {{ $mount.storage }}
 {{- if eq $mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ $releaseNameTrimmed }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-{{ $index }}
+{{- end }}
 {{- end }}
 ---
 {{- end -}}
@@ -55,6 +63,7 @@ spec:
 {{- if .Values.referenceData.enabled }}
 {{- if eq .Values.referenceData.referenceEnvironment .Values.environmentName }}
 {{- if eq .Values.referenceData.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -77,10 +86,15 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if and ( eq $.Values.referenceData.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+  name: {{ include "drupal.referenceEnvironment" . }}-reference
+  {{- else }}
   name: {{ include "drupal.referenceEnvironment" . }}-reference-data
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
   annotations:
@@ -93,9 +107,11 @@ spec:
     requests:
       storage: {{ .Values.referenceData.storage }}
 {{- if eq .Values.referenceData.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ .Release.Name }}-{{ .Release.Namespace | sha256sum | trunc 7 }}-reference-data
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/drupal/templates/post-release.yaml
+++ b/drupal/templates/post-release.yaml
@@ -47,6 +47,21 @@ spec:
         {{- if or (eq .Values.referenceData.referenceEnvironment .Values.environmentName) (not .Values.referenceData.skipMount) }}
         - name: reference-data-volume
           persistentVolumeClaim:
+            {{- if 
+              and 
+                ( and 
+                  (eq $.Values.shell.mount.storageClassName "silta-shared" ) 
+                  ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" )
+                ) 
+                (
+                  or
+                    (eq .Values.referenceData.referenceEnvironment .Values.environmentName) 
+                    (lookup "v1" "PersistentVolumeClaim" .Release.Namespace (printf "%s-reference" (include "drupal.referenceEnvironment" $ )))
+                ) 
+            }}
+            claimName: {{ include "drupal.referenceEnvironment" . }}-reference
+            {{- else }}
             claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
+            {{- end }}
         {{- end -}}
         {{- end }}

--- a/drupal/templates/reference-data-cron.yaml
+++ b/drupal/templates/reference-data-cron.yaml
@@ -48,8 +48,11 @@ spec:
             {{- include "drupal.volumes" . | nindent 12 }}
             - name: reference-data-volume
               persistentVolumeClaim:
+                {{- if and ( eq $.Values.referenceData.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+                claimName: {{ include "drupal.referenceEnvironment" . }}-reference
+                {{- else }}
                 claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
-
+                {{- end }}
           {{- include "drupal.imagePullSecrets" . | nindent 10 }}
 {{- end }}
 {{- end }}

--- a/drupal/templates/shell-deployment.yaml
+++ b/drupal/templates/shell-deployment.yaml
@@ -83,14 +83,22 @@ spec:
       {{- include "drupal.volumes" . | nindent 6 }}
       - name: ssh-keys
         persistentVolumeClaim:
+          {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+          claimName: {{ .Release.Name }}-ssh-keys2
+          {{- else }}
           claimName: {{ .Release.Name }}-ssh-keys
+          {{- end }}
       - name: shell-configmap
         configMap:
           name: {{ .Release.Name }}-shell
       {{- if .Values.backup.enabled }}
       - name: {{ .Release.Name }}-backup
         persistentVolumeClaim:
+          {{- if and ( eq $.Values.backup.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+          claimName: {{ .Release.Name }}-backup2
+          {{- else }}
           claimName: {{ .Release.Name }}-backup
+          {{- end }}
       {{- end }}
       {{- include "drupal.imagePullSecrets" . | nindent 6 }}
 {{- end }}

--- a/drupal/templates/shell-volume.yaml
+++ b/drupal/templates/shell-volume.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.shell.enabled }}
 {{- $releaseNameTrimmed := substr 0 (int (sub 54 (len "ssh-keys"))) $.Release.Name }}
 {{- if eq .Values.shell.mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -24,15 +25,21 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
 
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+  name: {{ .Release.Name }}-ssh-keys2
+  {{- else }}
   name: {{ .Release.Name }}-ssh-keys
+  {{- end }}
   labels:
     {{- include "drupal.release_labels" . | nindent 4 }}
   annotations:
     storage.silta/storage-path: {{ .Values.environmentName | default .Release.Name }}/ssh-keys    
+    csi-rclone/umask: "077"
 spec:
   accessModes:
     - ReadWriteMany
@@ -41,8 +48,10 @@ spec:
     requests:
       storage: {{ .Values.shell.mount.storage }}
 {{- if eq .Values.shell.mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ $releaseNameTrimmed }}-{{ .Release.Namespace | sha256sum | trunc 7 }}-ssh-keys
+{{- end }}
 {{- end }}
 {{- end }}

--- a/drupal/tests/drupal_cron_test.yaml
+++ b/drupal/tests/drupal_cron_test.yaml
@@ -64,8 +64,38 @@ tests:
             name: foo
             value: bar
 
-  - it: has public files mounted
+  - it: has public files mounted (without provisioner)
     template: drupal-cron.yaml
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: "drupal-public-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-public-files
+
+  - it: has public files mounted (silta-shared storageclass, with provisioner)
+    template: drupal-cron.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.public-files.storageClassName: silta-shared
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: "drupal-public-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-public-files2
+
+  - it: has public files mounted (non-silta-shared storageclass, with provisioner)
+    template: drupal-cron.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.public-files.storageClassName: foo
     asserts:
       - contains:
           path: spec.jobTemplate.spec.template.spec.volumes

--- a/drupal/tests/drupal_postinstall_test.yaml
+++ b/drupal/tests/drupal_postinstall_test.yaml
@@ -71,8 +71,38 @@ tests:
             name: foo
             value: bar
 
-  - it: has public files mounted
+  - it: has public files mounted (without provisioner)
     template: post-release.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-public-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-public-files
+              
+  - it: has public files mounted (silta-shared storageclass, with provisioner)
+    template: post-release.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.public-files.storageClassName: silta-shared
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-public-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-public-files2
+              
+  - it: has public files mounted (non-silta-shared storageclass, with provisioner)
+    template: post-release.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.public-files.storageClassName: foo
     asserts:
       - contains:
           path: spec.template.spec.volumes

--- a/drupal/tests/private_files_test.yaml
+++ b/drupal/tests/private_files_test.yaml
@@ -10,7 +10,7 @@ capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
-  - it: private files should be disabled by default
+  - it: private files should be disabled by default (without provisioner)
     template: drupal-deployment.yaml
     asserts:
       # No private files volume is mounted.
@@ -25,7 +25,47 @@ tests:
           count: 2
         template: drupal-volumes.yaml
 
-  - it: private files should work when enabled
+  - it: private files should be disabled by default (silta-shared storageclass, with provisioner)
+    template: drupal-deployment.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.private-files.storageClassName: silta-shared
+    asserts:
+      # No private files volume is mounted.
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-private-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-private-files2
+      # Only one volume is defined.
+      - hasDocuments:
+          count: 1
+        template: drupal-volumes.yaml
+
+  - it: private files should be disabled by default (non-silta-shared storageclass, with provisioner)
+    template: drupal-deployment.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts.private-files.storageClassName: foo
+    asserts:
+      # No private files volume is mounted.
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-private-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-private-files
+      # Only one volume is defined.
+      - hasDocuments:
+          count: 1
+        template: drupal-volumes.yaml
+
+  - it: private files should work when enabled (without provisioner)
     template: drupal-deployment.yaml
     set:
       mounts:
@@ -55,6 +95,39 @@ tests:
         hasDocuments:
           count: 4
 
+  - it: private files should work when enabled (with provisioner)
+    template: drupal-deployment.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts:
+        private-files:
+          enabled: true
+          storage: 123Gi
+          storageClassName: silta-shared
+          mountPath: /foo/bar/private
+    asserts:
+      # A private files volume is mounted
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: "drupal-private-files"
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-private-files2
+
+      # The environment variable is set
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PRIVATE_FILES_PATH
+            value: '/foo/bar/private'
+
+      # There are two volumes defined.
+      - template: drupal-volumes.yaml
+        hasDocuments:
+          count: 2
+
       # Private files are available for cron jobs.
       - template: drupal-cron.yaml
         contains:
@@ -62,7 +135,7 @@ tests:
           content:
             name: "drupal-private-files"
             persistentVolumeClaim:
-              claimName: RELEASE-NAME-private-files
+              claimName: RELEASE-NAME-private-files2
 
       # Private files are available for in the post-install hooks.
       - template: post-release.yaml
@@ -71,17 +144,23 @@ tests:
           content:
             name: "drupal-private-files"
             persistentVolumeClaim:
-              claimName: RELEASE-NAME-private-files
+              claimName: RELEASE-NAME-private-files2
 
       - template: drupal-volumes.yaml
-        documentIndex: 3
+        documentIndex: 1
         equal:
           path: spec.storageClassName
           value: silta-shared
       - template: drupal-volumes.yaml
+        documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-private-files2
+      - template: drupal-volumes.yaml
         # Note that object attributes are iterated alphabetically, so "private-files" comes before "public-files"
-        documentIndex: 1
+        documentIndex: 0
         equal:
           path: spec.resources.requests.storage
           value: 123Gi
+
 

--- a/drupal/tests/reference_data_test.yaml
+++ b/drupal/tests/reference_data_test.yaml
@@ -10,7 +10,7 @@ capabilities:
   apiVersions:
     - pxc.percona.com/v1
 tests:
-  - it: By default no reference data PVC or CronJob is created, but the reference volume is mounted for the post-release job
+  - it: By default no reference data PVC or CronJob is created, but the reference volume is mounted for the post-release job (without provisioner)
     template: post-release.yaml
     set:
       referenceData:
@@ -37,6 +37,66 @@ tests:
           name: "reference-data-volume"
           mountPath: "/app/reference-data"
           readOnly: true
+
+  - it: By default no reference data PVC or CronJob is created, but the reference volume is mounted for the post-release job (with provisioner)
+    template: post-release.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      referenceData:
+        referenceEnvironment: 'FOO'
+    asserts:
+    # Only public files PVC is defined.
+    - hasDocuments:
+        count: 1
+      template: drupal-volumes.yaml
+    - hasDocuments:
+        count: 0
+      template: reference-data-cron.yaml
+
+    # Reference data volume is mounted in post-release job
+    - contains:
+        path: spec.template.spec.volumes
+        content:
+          name: "reference-data-volume"
+          persistentVolumeClaim:
+            claimName: foo-reference-data
+    - contains:
+        path: spec.template.spec.containers[0].volumeMounts
+        content:
+          name: "reference-data-volume"
+          mountPath: "/app/reference-data"
+          readOnly: true
+  
+  - it: Uses new reference data PVC when found via lookup
+    template: post-release.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            version:  "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: foo-reference
+            namespace: NAMESPACE
+    set:
+      referenceData:
+        referenceEnvironment: 'FOO'
+    asserts:
+    - contains:
+        path: spec.template.spec.volumes
+        content:
+          name: "reference-data-volume"
+          persistentVolumeClaim:
+            claimName: foo-reference
 
   - it: is not mounted on the main deployment
     template: post-release.yaml
@@ -166,6 +226,9 @@ tests:
 
   - it: does not skip mounting on the reference environments
     template: post-release.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
     set:
       environmentName: 'FOO'
       referenceData:
@@ -174,13 +237,13 @@ tests:
     asserts:
     - template: drupal-volumes.yaml
       hasDocuments:
-        count: 4
+        count: 2
     - contains:
         path: spec.template.spec.volumes
         content:
           name: "reference-data-volume"
           persistentVolumeClaim:
-            claimName: foo-reference-data
+            claimName: foo-reference
     - contains:
         path: spec.template.spec.containers[0].volumeMounts
         content:

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -470,6 +470,36 @@
         }
       }
     },
+    "silta-hub": { 
+      "type": "object",
+      "properties": {
+        "sync": { 
+          "type": "object",
+          "properties": {
+            "resources": {
+              "type": "object",
+              "properties": {
+                "requests": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": { "type": ["integer", "string"] },
+                    "memory": { "type": "string" }
+                  }
+                },
+                "limits": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": { "type": ["integer", "string"] },
+                    "memory": { "type": "string" }
+                  }
+                }
+              }
+            },
+            "storage": { "type": "string" }
+          }
+        }
+      }
+    },
     "gdprDump": {
       "type": "object",
       "additionalProperties": {

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -468,6 +468,11 @@ referenceData:
     limits:
       memory: 488Mi
 
+# Release sync configuration. Storage is used for data synchronization and process is handled by the Silta HUB.
+silta-hub:
+  sync:
+    storage: 10G
+
 # Parameters for sanitizing reference data with github.com/Smile-SA/gdpr-dump
 # Uses formatters from fakerphp.github.io/formatters
 gdprDump:
@@ -546,7 +551,7 @@ mariadb:
   enabled: true
   image:
     # https://hub.docker.com/r/bitnami/mariadb/tags
-    tag: 10.6.15-debian-11-r24
+    tag: 10.6-debian-12
   replication:
     enabled: false
   db:

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.10.0
+version: 1.11.0
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/_helpers.tpl
+++ b/frontend/templates/_helpers.tpl
@@ -232,3 +232,9 @@ autoscaling/v2
 autoscaling/v2beta1
 {{- end }}
 {{- end }}
+
+{{- define "silta-cluster.rclone.has-provisioner" }}
+{{- if ( $.Capabilities.APIVersions.Has "silta.wdr.io/v1" ) }}true
+{{- else }}false
+{{- end }}
+{{- end }}

--- a/frontend/templates/backup-cron.yaml
+++ b/frontend/templates/backup-cron.yaml
@@ -59,7 +59,15 @@ spec:
             command: ["/bin/bash", "-c"]
             args:
               - |
+                {{- $mounts_enabled := false }}
+                {{- range $index, $mount := $.Values.mounts }}
+                {{- if eq $mount.enabled true }}
+                {{- $mounts_enabled = true }}
+                {{- end }}
+                {{- end }}
+                {{- if eq $mounts_enabled true }}
                 {{- include "frontend.backup.copy-mounts" . | nindent 16 }}
+                {{- end }}
 
                 # Delete old backups
                 echo "Removing backups older than {{ .Values.backup.retention }} days"
@@ -136,12 +144,20 @@ spec:
             {{- if eq $mount.enabled true }}
             - name: frontend-{{ $mountName }}
               persistentVolumeClaim:
+                {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+                claimName: {{ $.Release.Name }}-{{ $mountName }}2
+                {{- else }}
                 claimName: {{ $.Release.Name }}-{{ $mountName }}
+                {{- end }}
             {{- end }}
             {{- end }}
             {{- end }}
             {{- end }}
             - name: {{ .Release.Name }}-backup
               persistentVolumeClaim:
+                {{- if and ( eq $.Values.backup.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+                claimName: {{ .Release.Name }}-backup2
+                {{- else }}
                 claimName: {{ .Release.Name }}-backup
+                {{- end }}
 {{- end }}

--- a/frontend/templates/backup-volume.yaml
+++ b/frontend/templates/backup-volume.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.backup.enabled }}
+{{- if eq .Values.backup.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" . ) "false" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -20,10 +22,16 @@ spec:
       remotePathSuffix: /{{ .Release.Namespace }}/backup/{{ .Values.environmentName }}
   {{- end }}
 ---
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if and ( eq $.Values.backup.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+  name: {{ .Release.Name }}-backup2
+  {{- else }}
   name: {{ .Release.Name }}-backup
+  {{- end }}
   labels:
     name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
     {{- include "frontend.release_labels" $ | nindent 4 }}
@@ -37,8 +45,10 @@ spec:
     requests:
       storage: {{ .Values.backup.storage }}
 {{- if eq .Values.backup.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" . ) "false" }}
   selector:
     matchLabels:
       name: {{ .Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-backup
+{{- end }}
 {{- end }}
 {{- end }}

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -91,7 +91,11 @@ spec:
             {{- if eq $mount.enabled true }}
             - name: frontend-{{ $mountName }}
               persistentVolumeClaim:
+                {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+                claimName: {{ $.Release.Name }}-{{ $mountName }}2
+                {{- else }}
                 claimName: {{ $.Release.Name }}-{{ $mountName }}
+                {{- end }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -98,7 +98,11 @@ spec:
             name: {{ $mount.configMapName }}
         {{- else }}
           persistentVolumeClaim:
+            {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+            claimName: {{ $.Release.Name }}-{{ $mountName }}2
+            {{- else }}
             claimName: {{ $.Release.Name }}-{{ $mountName }}
+            {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -106,7 +110,11 @@ spec:
         {{ if $.Values.shell.enabled -}}
         - name: shell-keys
           persistentVolumeClaim:
+            {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+            claimName: {{ $.Release.Name }}-shell-keys2
+            {{- else }}
             claimName: {{ $.Release.Name }}-shell-keys
+            {{- end }}
         {{- end }}
       {{ if $service.nodeSelector -}}
       nodeSelector:
@@ -236,7 +244,11 @@ spec:
             name: {{ $mount.configMapName }}
         {{- else }}
           persistentVolumeClaim:
+            {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+            claimName: {{ $.Release.Name }}-{{ $mountName }}2
+            {{- else }}
             claimName: {{ $.Release.Name }}-{{ $mountName }}
+            {{- end }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -244,7 +256,11 @@ spec:
         {{ if $.Values.shell.enabled -}}
         - name: shell-keys
           persistentVolumeClaim:
+            {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+            claimName: {{ $.Release.Name }}-shell-keys2
+            {{- else }}
             claimName: {{ $.Release.Name }}-shell-keys
+            {{- end }}
         {{- end }}
 {{- end }}
 

--- a/frontend/templates/volumes.yaml
+++ b/frontend/templates/volumes.yaml
@@ -2,6 +2,7 @@
 {{- if $mount.enabled }}
 {{- if and (not (hasKey $mount "configMapName")) (not (hasKey $mount "secretName")) -}}
 {{- if eq $mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 # Mount-enabled: {{ $mount.enabled  }}
 apiVersion: v1
 kind: PersistentVolume
@@ -24,10 +25,15 @@ spec:
   {{- end }}
 ---
 {{- end }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if and ( eq $mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+  name: {{ $.Release.Name }}-{{ $index }}2
+  {{- else }}
   name: {{ $.Release.Name }}-{{ $index }}
+  {{- end }}
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
   annotations:
@@ -40,9 +46,11 @@ spec:
     requests:
       storage: {{ $mount.storage }}
 {{- if eq $mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ $.Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-{{ $index }}
+{{- end }}
 {{- end }}
 ---
 {{- end -}}
@@ -51,6 +59,7 @@ spec:
 
 {{- if $.Values.shell.enabled }}
 {{- if eq $.Values.shell.mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -72,15 +81,21 @@ spec:
       umask: "077"
   {{- end }}
 {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
+  name: {{ $.Release.Name }}-shell-keys2
+  {{- else }}
   name: {{ $.Release.Name }}-shell-keys
+  {{- end }}
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
   annotations:
     storage.silta/storage-path: {{ $.Values.environmentName | default $.Release.Name }}/shell-keys
+    csi-rclone/umask: "077"
 spec:
   storageClassName: {{ $.Values.shell.mount.storageClassName }}
   accessModes:
@@ -89,9 +104,11 @@ spec:
     requests:
       storage: 50M
 {{- if eq $.Values.shell.mount.storageClassName "silta-shared" }}
+{{- if eq ( include "silta-cluster.rclone.has-provisioner" $ ) "false" }}
   selector:
     matchLabels:
       name: {{ $.Release.Name }}-{{ $.Release.Namespace | sha256sum | trunc 7 }}-shell-keys
+{{- end }}
 {{- end }}
 ---
 {{- end }}

--- a/frontend/tests/volumes_test.yaml
+++ b/frontend/tests/volumes_test.yaml
@@ -1,6 +1,7 @@
 suite: Data volumes
 templates:
   - volumes.yaml
+  - backup-volume.yaml
 tests:
   - it: public files volume should be configurable
     template: volumes.yaml
@@ -20,3 +21,229 @@ tests:
         equal:
           path: spec.resources.requests.storage
           value: 123Gi
+  
+  - it: backup pv creation when csi-rclone provisioner is unavailable
+    template: backup-volume.yaml
+    set:
+      backup:
+        enabled: true
+        storage: 123Gi
+        storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolume
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-b6b6854-backup
+      - documentIndex: 1
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-backup
+      - documentIndex: 1
+        exists:
+          path: spec.selector
+      - documentIndex: 1
+        equal:
+          path: spec.selector.matchLabels.name
+          value: RELEASE-NAME-b6b6854-backup
+  - it: backup pv creation when csi-rclone provisioner is available (silta-shared storage class)
+    template: backup-volume.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      backup:
+        enabled: true
+        storage: 123Gi
+        storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-backup2
+      - documentIndex: 0
+        notExists:
+          path: spec.selector
+  - it: backup pv creation when csi-rclone provisioner is available (non-silta-shared storage class)
+    template: backup-volume.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      backup:
+        enabled: true
+        storage: 123Gi
+        storageClassName: foo
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-backup
+      - documentIndex: 0
+        notExists:
+          path: spec.selector
+  - it: shell key pv creation when csi-rclone provisioner is not available
+    template: volumes.yaml
+    set:
+      shell:
+        enabled: true
+        mount:
+          storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolume
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-b6b6854-shell-keys
+      - documentIndex: 1
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-shell-keys
+      - documentIndex: 1
+        exists:
+          path: spec.selector
+      - documentIndex: 1
+        equal:
+          path: spec.selector.matchLabels.name
+          value: RELEASE-NAME-b6b6854-shell-keys
+  - it: shell key pv creation when csi-rclone provisioner is available (silta-shared storage class)
+    template: volumes.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      shell:
+        enabled: true
+        mount:
+          storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-shell-keys2
+      - documentIndex: 0
+        notExists:
+          path: spec.selector
+  - it: shell key pv creation when csi-rclone provisioner is available (non-silta-shared storage class)
+    template: volumes.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      shell:
+        enabled: true
+        mount:
+          storageClassName: foo
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-shell-keys
+      - documentIndex: 0
+        notExists:
+          path: spec.selector
+  - it: custom mount pv creation when csi-rclone provisioner is not available
+    template: volumes.yaml
+    set:
+      mounts:
+        foo:
+          enabled: true
+          storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolume
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-b6b6854-foo
+      - documentIndex: 1
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-foo
+      - documentIndex: 1
+        exists:
+          path: spec.selector
+      - documentIndex: 1
+        equal:
+          path: spec.selector.matchLabels.name
+          value: RELEASE-NAME-b6b6854-foo
+  - it: custom mount pv creation when csi-rclone provisioner is available (silta-shared storage class)
+    template: volumes.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts:
+        foo:
+          enabled: true
+          storageClassName: silta-shared
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-foo2
+      - documentIndex: 0
+        notExists:
+          path: spec.selector
+  - it: custom mount pv creation when csi-rclone provisioner is available (non-silta-shared storage class)
+    template: volumes.yaml
+    capabilities:
+      apiVersions:
+        - silta.wdr.io/v1
+    set:
+      mounts:
+        foo:
+          enabled: true
+          storageClassName: foo
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: PersistentVolumeClaim
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-foo
+      - documentIndex: 0
+        notExists:
+          path: spec.selector


### PR DESCRIPTION
Drupal chart (1.12.0)
- silta-shared PV adjustments for new csi-rclone provisioner ([PR 1](https://github.com/wunderio/drupal-project-k8s/pull/717), [PR 2](https://github.com/wunderio/drupal-project-k8s/pull/719), [PR 3](https://github.com/wunderio/drupal-project-k8s/pull/718))
- WNDR-281: Unpin patch version of mariadb, pin only major.minor versions ([PR](https://github.com/wunderio/drupal-project-k8s/pull/708))
- When extracting reference data files, ignoredFolders do not get deleted ([PR](https://github.com/wunderio/drupal-project-k8s/pull/716))
- job definitions for data sync via silta hub ([PR](https://github.com/wunderio/drupal-project-k8s/pull/712))

Frontend chart (1.11.0)
- silta-shared PV adjustments for new csi-rclone provisioner ([PR](https://github.com/wunderio/frontend-project-k8s/pull/132))
- conditional mounts backup ([PR](https://github.com/wunderio/frontend-project-k8s/pull/131))

Charts repository:
- Minikube tests for 1.29 and 1.30 ([PR](https://github.com/wunderio/charts/pull/445))