### PR TITLE
skip sumologic namespace for volume restriction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
               helm lint $CHART
               helm unittest $CHART
               if [ -f "$CHART/test.values.yaml" ]; then
-                helm install --dry-run --generate-name --values "$CHART/test.values.yaml" $CHART
+                helm template --generate-name --values "$CHART/test.values.yaml" $CHART
               fi
               helm package $CHART --destination /tmp/charts
             done

--- a/silta-cluster/docs/kyverno-policies/restrict-volume-types.yaml
+++ b/silta-cluster/docs/kyverno-policies/restrict-volume-types.yaml
@@ -37,6 +37,7 @@ spec:
             namespaces:
             - kube-system
             - silta-cluster
+            - sumologic
       preconditions:
         all:
         - key: "{{ request.operation || 'BACKGROUND' }}"


### PR DESCRIPTION
- Skip sumologic namespace for volume restriction
- Use `helm template` instead of `helm install` to prevent cluster connection as we test charts on various versions in k8s repositories beforehand.