### PR TITLE
Release 2024-11-26

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 1.14.0
+version: 1.15.0
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/backup-cron.yaml
+++ b/drupal/templates/backup-cron.yaml
@@ -63,6 +63,10 @@ spec:
             resources:
               {{- .Values.backup.resources | toYaml | nindent 14 }}
           restartPolicy: Never
+          nodeSelector:
+            {{- .Values.backup.nodeSelector | toYaml | nindent 12 }}
+          tolerations:
+            {{- include "drupal.tolerations" .Values.backup.nodeSelector | nindent 12 }}
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}
             - name: {{ .Release.Name }}-backup

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -471,10 +471,10 @@
         }
       }
     },
-    "silta-hub": { 
+    "silta-hub": {
       "type": "object",
       "properties": {
-        "sync": { 
+        "sync": {
           "type": "object",
           "properties": {
             "resources": {
@@ -519,6 +519,7 @@
         "csiDriverName": { "type": "string" },
         "ignoreTableContent": { "type": "string" },
         "skipFiles": { "type": "boolean" },
+        "nodeSelector": { "type": "object" },
         "resources": {
           "type": "object",
           "additionalProperties": false,

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -24,7 +24,7 @@ environmentName: ""
 # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 
-# Custom imagePullSecret for the containers. Base64 encoded. This will create a secret and append it to the imagePullSecrets. 
+# Custom imagePullSecret for the containers. Base64 encoded. This will create a secret and append it to the imagePullSecrets.
 imagePullSecret: ""
 
 # The app label added to our Kubernetes resources.
@@ -540,6 +540,9 @@ backup:
 
   #  Do not backup files
   #skipFiles: true
+
+  # Set a nodeSelector specifically for backup jobs.
+  nodeSelector: {}
 
   # Resources for the backup cron job.
   resources:


### PR DESCRIPTION
Drupal chart (1.15.0):
- Add nodeSelector support for backup jobs ([PR](https://github.com/wunderio/drupal-project-k8s/pull/726))