### PR TITLE
Narrowed down deployment remover rbac

### DIFF
--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.8.2
+version: 1.9.0
 # csi-rclone external provisioner requires kubernetes 1.20+
 # https://github.com/kubernetes-csi/external-provisioner?tab=readme-ov-file#compatibility
 kubeVersion: '>=1.20.0-0'

--- a/silta-cluster/templates/deployment-remover-sa.yaml
+++ b/silta-cluster/templates/deployment-remover-sa.yaml
@@ -13,15 +13,210 @@ metadata:
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
-  - '*'
+  - ""
   resources:
-  - '*'
+  - configmaps
+  - services
+  - persistentvolume
+  - persistentvolumeclaims
+  - serviceaccounts
+  - pods
+  - pods/log
+  - pods/exec
+  - pods/portforward
+  - secrets
   verbs:
-  - '*'
-- nonResourceURLs:
-  - '*'
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
   verbs:
-  - '*'
+  - list
+  - get
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  - limitranges
+  - endpoints
+  - events
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - deployments
+  - replicasets
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - certificates
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - acme.cert-manager.io
+  resources:
+  - challenges
+  - orders
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificaterequests
+  - issuers
+  - clusterissuers
+  - certificates
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - cloud.google.com
+  resources:
+  - backendconfigs
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - pxc.percona.com
+  resources:
+  - perconaxtradbclusterbackups
+  - perconaxtradbclusterrestores
+  - perconaxtradbclusters
+  - perconaxtradbbackups
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Set of policy rules tested with drupal, frontend and simple charts. This should be enough to remove deployments and avoid having wildcard access.

Removal on test cluster is only set up for drupal chart, tested with that, but it should work with frontend and simple charts too.