### PR TITLE
kyverno rule for disabling allowPrivilegeEscalation

### DIFF
--- a/silta-cluster/docs/kyverno-policies/disallow-privilege-escalation.yaml
+++ b/silta-cluster/docs/kyverno-policies/disallow-privilege-escalation.yaml
@@ -1,0 +1,62 @@
+# Name: 
+#   Validate Pod Security Context
+# Description:
+#     Disallow Privilege Escalation
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-pod-policy
+  annotations:
+    policies.kyverno.io/title: Disallow Privilege Escalation
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/description: >-
+      Privilege escalation is disallowed. The fields
+      spec.containers[*].securityContext.allowPrivilegeEscalation,
+      spec.initContainers[*].securityContext.allowPrivilegeEscalation,
+      and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation
+      can't be set to `true`.
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+  - name: containers-user-privileges-validation
+    match:
+      any:
+      - resources:
+          kinds:
+            - Pod
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+          - silta-cluster
+          - kubecost
+          - sumologic
+          - logging
+    validate:
+      message: >-
+        Privilege escalation is disallowed. The fields
+        spec.containers[*].securityContext.allowPrivilegeEscalation,
+        spec.initContainers[*].securityContext.allowPrivilegeEscalation,
+        and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation
+        can't be set to `true`.
+      foreach:
+        - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+          deny:
+            conditions:
+              any:
+              - key: "{{ element.securityContext.privileged || '' }}"
+                operator: Equals
+                value: true
+                message: >-
+                  non-privileged-containers may not set securityContext.privileged to true
+              - key: "{{ element.securityContext.allowPrivilegeEscalation || '' }}"
+                operator: Equals
+                value: true
+                message: >-
+                  non-privileged-containers may not set securityContext.allowPrivilegeEscalation to true

--- a/silta-cluster/docs/kyverno-policies/disallow-privileged-containers.yaml
+++ b/silta-cluster/docs/kyverno-policies/disallow-privileged-containers.yaml
@@ -39,6 +39,7 @@ spec:
             - silta-cluster
             - kubecost
             - sumologic
+            - logging
       validate:
         message: >-
           Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged,

--- a/silta-cluster/docs/kyverno-policies/restrict-adding-capabilities.yaml
+++ b/silta-cluster/docs/kyverno-policies/restrict-adding-capabilities.yaml
@@ -1,0 +1,71 @@
+# Name: 
+#   Restrict Adding Capabilities
+# Description:
+#   Adding capabilities is a way for containers in a Pod to request higher levels
+#   of ability than those with which they may be provisioned. Many capabilities
+#   allow system-level control and should be prevented. Pod Security Policies (PSP)
+#   allowed a list of "good" capabilities to be added. This policy checks
+#   ephemeralContainers, initContainers, and containers to ensure the only
+#   capabilities that can be added are either NET_BIND_SERVICE or CAP_CHOWN.    
+# Source: 
+#   https://raw.githubusercontent.com/kyverno/policies/main/psp-migration/restrict-adding-capabilities/restrict-adding-capabilities.yaml
+# Modification: 
+#   audit -> enforce
+#   namespace exclusion
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: psp-restrict-adding-capabilities
+  annotations:
+    policies.kyverno.io/title: Restrict Adding Capabilities
+    policies.kyverno.io/category: PSP Migration
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Adding capabilities is a way for containers in a Pod to request higher levels
+      of ability than those with which they may be provisioned. Many capabilities
+      allow system-level control and should be prevented. Pod Security Policies (PSP)
+      allowed a list of "good" capabilities to be added. This policy checks
+      ephemeralContainers, initContainers, and containers to ensure the only
+      capabilities that can be added are either NET_BIND_SERVICE or CAP_CHOWN.      
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: allowed-capabilities
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      exclude:
+        any:
+        - resources:
+            namespaces:
+            - kube-system
+            - silta-cluster
+            - kubecost
+            - sumologic
+            - logging
+      preconditions:
+        all:
+        - key: "{{ request.operation || 'BACKGROUND' }}"
+          operator: NotEquals
+          value: DELETE
+      validate:
+        message: >-
+          Any capabilities added other than NET_BIND_SERVICE or CAP_CHOWN are disallowed.          
+        foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            deny:
+              conditions:
+                all:
+                - key: "{{ element.securityContext.capabilities.add[] || '' }}"
+                  operator: AnyNotIn
+                  value:
+                  - NET_BIND_SERVICE
+                  - CAP_CHOWN
+                  - ''

--- a/silta-cluster/docs/kyverno-policies/restrict-seccomp.yaml
+++ b/silta-cluster/docs/kyverno-policies/restrict-seccomp.yaml
@@ -1,0 +1,64 @@
+# Name: 
+#   Restrict Seccomp
+# Description:
+#   Use of custom Seccomp profiles is disallowed. The fields
+#   spec.securityContext.seccompProfile.type,
+#   spec.containers[*].securityContext.seccompProfile.type,
+#   spec.initContainers[*].securityContext.seccompProfile.type, and
+#   spec.ephemeralContainers[*].securityContext.seccompProfile.type
+#   must be unset or set to `RuntimeDefault`.
+# Source: 
+#   https://raw.githubusercontent.com/kyverno/policies/main/pod-security/baseline/restrict-seccomp/restrict-seccomp.yaml
+# Modification: 
+#   audit -> enforce
+#   RuntimeDefault & Localhost -> RuntimeDefault
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-seccomp
+  annotations:
+    policies.kyverno.io/title: Restrict Seccomp
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/description: >-
+      The seccomp profile must not be explicitly set to Unconfined. This policy, 
+      requiring Kubernetes v1.19 or later, ensures that seccomp is unset or 
+      set to `RuntimeDefault`.      
+spec:
+  background: true
+  validationFailureAction: Enforce
+  rules:
+    - name: check-seccomp
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Use of custom Seccomp profiles is disallowed. The fields
+          spec.securityContext.seccompProfile.type,
+          spec.containers[*].securityContext.seccompProfile.type,
+          spec.initContainers[*].securityContext.seccompProfile.type, and
+          spec.ephemeralContainers[*].securityContext.seccompProfile.type
+          must be unset or set to `RuntimeDefault`.          
+        pattern:
+          spec:
+            =(securityContext):
+              =(seccompProfile):
+                =(type): "RuntimeDefault"
+            =(ephemeralContainers):
+            - =(securityContext):
+                =(seccompProfile):
+                  =(type): "RuntimeDefault"
+            =(initContainers):
+            - =(securityContext):
+                =(seccompProfile):
+                  =(type): "RuntimeDefault"
+            containers:
+            - =(securityContext):
+                =(seccompProfile):
+                  =(type): "RuntimeDefault"

--- a/silta-cluster/docs/kyverno-policies/restrict-volume-types.yaml
+++ b/silta-cluster/docs/kyverno-policies/restrict-volume-types.yaml
@@ -37,7 +37,9 @@ spec:
             namespaces:
             - kube-system
             - silta-cluster
+            - kubecost
             - sumologic
+            - logging
       preconditions:
         all:
         - key: "{{ request.operation || 'BACKGROUND' }}"


### PR DESCRIPTION
Tested in production cluster:
 - prevents `securityContext.allowPrivilegeEscalation`
 - prevents `securityContext.capabilities` added other than NET_BIND_SERVICE or CAP_CHOWN 

\* some namespaces are added to exceptions
