### PR TITLE
Updated image that fixes deleted pvc file removal

### DIFF
--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -407,7 +407,7 @@ nfs-subdir-external-provisioner:
     onDelete: delete
   image:
     repository: docker.io/wunderio/nfs-subdir-external-provisioner
-    tag: v4.0
+    tag: v5.0
 
 # Uses nfs-subdir-external-provisioner. 
 # see: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/blob/master/charts/nfs-subdir-external-provisioner/values.yaml
@@ -422,6 +422,9 @@ silta-shared-nfs:
     volumeBindingMode: WaitForFirstConsumer
     pathPattern: "${.PVC.namespace}/${.PVC.annotations.storage.silta/storage-path}"
     onDelete: delete
+  image:
+    repository: docker.io/wunderio/nfs-subdir-external-provisioner
+    tag: v5.0
 
 nfs-server:
   enabled: false


### PR DESCRIPTION
Related commit: https://github.com/wunderio/silta-nfs-subdir-external-provisioner/commit/d58bae39cbb2cafe95722d06bfe3bd16dd23bb92
~chart version is not updated, let's use the 1.9.0 from https://github.com/wunderio/charts/pull/458~