### PR TITLE
SLT-1008: Increase nginx shutdown delay from 5s to 15s on both simple and frontend charts

### DIFF
--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.12.0
+version: 1.12.1
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/nginx.yaml
+++ b/frontend/templates/nginx.yaml
@@ -68,7 +68,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sleep", "5"]
+              command: ["/bin/sleep", "15"]
         resources:
           {{ .Values.nginx.resources | toYaml | nindent 10 }}
 

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 1.5.0
+version: 1.5.1
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sleep", "5"]
+              command: ["/bin/sleep", "15"]
         resources:
           {{- .Values.nginx.resources | toYaml | nindent 10 }}
 


### PR DESCRIPTION
- **Increase nginx shutdown delay from 5s to 15s on both simple and frontend charts**
- **Increased chart.yaml version**
