### PR TITLE
Release 2025-01-21

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -150,8 +150,8 @@ jobs:
             cert-manager jetstack/cert-manager \
             --namespace cert-manager \
             --create-namespace \
-            --version v1.8.0 \
-            --set installCRDs=true \
+            --version v1.16.2 \
+            --set crds.enabled=true \
             --set global.logLevel=1 \
             --wait
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         # Available minikube kubernetes version list:
         # "minikube config defaults kubernetes-version"
         # and https://kubernetes.io/releases/patch-releases/
-        kubernetes-version: ["v1.22.17", "v1.23.17", "v1.24.17", "v1.25.16", "v1.26.15", "v1.27.13", "v1.28.9", "v1.29.4", "v1.30.0", "latest"]
+        kubernetes-version: ["v1.22.17", "v1.23.17", "v1.24.17", "v1.25.16", "v1.26.15", "v1.27.16", "v1.28.13", "v1.29.8", "v1.30.4", "v1.31.0", "latest"]
     env:
       CLUSTER_DOMAIN: minikube.local.wdr.io
       K8S_PROJECT_REPO_DIR: k8s-project-repositories
@@ -41,7 +41,7 @@ jobs:
       - name: Helm and repository setup
         run: |
           # Install Helm 3
-          HELM_VERSION=v3.14.0
+          HELM_VERSION=v3.16.3
           curl -o /tmp/helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz \
             && tar -zxvf /tmp/helm.tar.gz -C /tmp \
             && mv /tmp/linux-amd64/helm ~/.local/bin/helm \

--- a/drupal/Chart.lock
+++ b/drupal/Chart.lock
@@ -19,6 +19,6 @@ dependencies:
   version: 8.5.1
 - name: silta-release
   repository: file://../silta-release
-  version: 1.0.0
-digest: sha256:74ab4b2e06e75563a3838c0a20311d052e2d7aeb6e00b4602fae6e9a2fd77fa0
-generated: "2023-10-03T12:07:07.444943085+03:00"
+  version: 1.0.1
+digest: sha256:b7f96b2faca0716d5dd2b8d4a21f053cea6c0fdd8c7391f463e9c677c7c00196
+generated: "2025-01-21T14:03:49.041107+02:00"

--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 1.16.0
+version: 1.17.0
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/_helpers.tpl
+++ b/drupal/templates/_helpers.tpl
@@ -331,7 +331,7 @@ imagePullSecrets:
 {{- define "drupal.wait-for-db-command" }}
 TIME_WAITING=0
 echo "Waiting for database.";
-until mysqladmin status --connect_timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST -P ${DB_PORT:-3306} --silent; do
+until mysqladmin status --connect-timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST -P ${DB_PORT:-3306} --silent; do
   echo -n "."
   sleep 5
   TIME_WAITING=$((TIME_WAITING+5))
@@ -655,7 +655,7 @@ fi
   TIME_WAITING=0
   echo "Waiting for database.";
 
-  until mysqladmin status --connect_timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST --protocol=tcp --silent; do
+  until mysqladmin status --connect-timeout=2 -u $DB_USER -p$DB_PASS -h $DB_HOST --protocol=tcp --silent; do
     echo -n "."
     sleep 1s
     TIME_WAITING=$((TIME_WAITING+1))
@@ -730,5 +730,13 @@ autoscaling/v2beta1
 {{- define "silta-cluster.rclone.has-provisioner" }}
 {{- if ( $.Capabilities.APIVersions.Has "silta.wdr.io/v1" ) }}true
 {{- else }}false
+{{- end }}
+{{- end }}
+
+{{- define "drupal.serviceAccountName" }}
+{{- if .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
+{{- else }}
+{{- .Release.Name }}-sa
 {{- end }}
 {{- end }}

--- a/drupal/templates/backup-cron.yaml
+++ b/drupal/templates/backup-cron.yaml
@@ -76,7 +76,7 @@ spec:
                 {{- else }}
                 claimName: {{ .Release.Name }}-backup
                 {{- end }}
-          {{- include "drupal.imagePullSecrets" . | nindent 10 }}
+          serviceAccountName: {{ include "drupal.serviceAccountName" . }}
 {{- end }}
 
 ---

--- a/drupal/templates/clamav-deployment.yaml
+++ b/drupal/templates/clamav-deployment.yaml
@@ -76,4 +76,5 @@ spec:
       - name: avdata
         source:
           emptyDir: {}
+      serviceAccountName: {{ include "drupal.serviceAccountName" . }}
 {{- end }}

--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -159,7 +159,7 @@ spec:
           volumes:
             {{- include "drupal.volumes" $ | nindent 12 }}
 
-          {{- include "drupal.imagePullSecrets" $ | nindent 10 }}
+          serviceAccountName: {{ include "drupal.serviceAccountName" $ }}
 ---
 {{- end }}
 {{- end }}

--- a/drupal/templates/drupal-deployment.yaml
+++ b/drupal/templates/drupal-deployment.yaml
@@ -166,7 +166,7 @@ spec:
         - name: sigsci-tmp
           emptyDir: {}
         {{- end }}
-      {{- include "drupal.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "drupal.serviceAccountName" . }}
       nodeSelector:
         {{- .Values.php.nodeSelector | toYaml | nindent 8 }}
       tolerations:

--- a/drupal/templates/post-release.yaml
+++ b/drupal/templates/post-release.yaml
@@ -40,7 +40,7 @@ spec:
           {{- end }}
         resources:
           {{- .Values.php.postinstall.resources | toYaml | nindent 10 }}
-      {{- include "drupal.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "drupal.serviceAccountName" . }}
       volumes:
         {{- include "drupal.volumes" . | nindent 8 }}
         {{- if .Values.referenceData.enabled -}}

--- a/drupal/templates/reference-data-cron.yaml
+++ b/drupal/templates/reference-data-cron.yaml
@@ -53,7 +53,7 @@ spec:
                 {{- else }}
                 claimName: {{ include "drupal.referenceEnvironment" . }}-reference-data
                 {{- end }}
-          {{- include "drupal.imagePullSecrets" . | nindent 10 }}
+          serviceAccountName: {{ include "drupal.serviceAccountName" . }}
 {{- end }}
 {{- end }}
 ---

--- a/drupal/templates/serviceaccount.yaml
+++ b/drupal/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-sa
+  labels:
+    {{- include "drupal.release_labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+{{- include "drupal.imagePullSecrets" . }}
+  

--- a/drupal/templates/shell-deployment.yaml
+++ b/drupal/templates/shell-deployment.yaml
@@ -100,6 +100,6 @@ spec:
           claimName: {{ .Release.Name }}-backup
           {{- end }}
       {{- end }}
-      {{- include "drupal.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "drupal.serviceAccountName" . }}
 {{- end }}
 ---

--- a/drupal/templates/silta-hub.yaml
+++ b/drupal/templates/silta-hub.yaml
@@ -35,7 +35,7 @@ data:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
             resources:
               {{- .Values.php.postinstall.resources | toYaml | nindent 14 }}
-          {{- include "drupal.imagePullSecrets" . | nindent 10 }}
+          serviceAccountName: {{ include "drupal.serviceAccountName" . }}
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}
   syncPullJob: |
@@ -63,6 +63,6 @@ data:
               {{- include "drupal.volumeMounts" . | nindent 14 }}
             resources:
               {{- .Values.php.postinstall.resources | toYaml | nindent 14 }}
-          {{- include "drupal.imagePullSecrets" . | nindent 10 }}
+          serviceAccountName: {{ .Release.Name }}-sa
           volumes:
             {{- include "drupal.volumes" . | nindent 12 }}

--- a/drupal/templates/solr-statefulset.yaml
+++ b/drupal/templates/solr-statefulset.yaml
@@ -79,7 +79,7 @@ spec:
       volumes:
       - name: {{ .Release.Name }}-core-dir
         emptyDir: {}
-      
+      serviceAccountName: {{ include "drupal.serviceAccountName" . }}
   volumeClaimTemplates:
   - metadata:
       name: {{ .Release.Name }}-solr-data

--- a/drupal/templates/varnish-deployment.yaml
+++ b/drupal/templates/varnish-deployment.yaml
@@ -74,4 +74,5 @@ spec:
       - name: varnish-secret
         secret:
           secretName: {{ .Release.Name }}-secrets-varnish
+      serviceAccountName: {{ include "drupal.serviceAccountName" . }}
 {{- end }}

--- a/drupal/tests/private_docker_image_test.yaml
+++ b/drupal/tests/private_docker_image_test.yaml
@@ -1,47 +1,21 @@
 suite: private docker image
 templates:
-  - drupal-configmap.yaml
-  - drupal-cron.yaml
-  - drupal-deployment.yaml
-  - drupal-secret.yaml
-  - post-release.yaml
-capabilities:
-  apiVersions:
-    - pxc.percona.com/v1
+  - serviceaccount.yaml
+
 tests:
   - it: has no image pull secret by default
-    template: drupal-deployment.yaml
+    template: serviceaccount.yaml
     asserts:
       - isNull:
           path: spec.template.spec.imagePullSecrets
-      - template: drupal-cron.yaml
-        isNull:
-          path: spec.jobTemplate.spec.template.spec.imagePullSecrets
-      - template: post-release.yaml
-        isNull:
-          path: spec.template.spec.imagePullSecrets
 
   - it: sets the image pull secret
-    template: drupal-deployment.yaml
+    template: serviceaccount.yaml
     set:
       imagePullSecrets:
         - name: gcr
     asserts:
      - contains:
-         path: spec.template.spec.imagePullSecrets
+         path: imagePullSecrets
          content:
            name: gcr
-
-     - template: drupal-cron.yaml
-       contains:
-         path: spec.jobTemplate.spec.template.spec.imagePullSecrets
-         content:
-           name: gcr
-
-     - template: post-release.yaml
-       contains:
-         path: spec.template.spec.imagePullSecrets
-         content:
-           name: gcr
-
-

--- a/drupal/tests/serviceaccount_test.yaml
+++ b/drupal/tests/serviceaccount_test.yaml
@@ -1,0 +1,56 @@
+suite: service account test
+templates:
+  - drupal-configmap.yaml
+  - drupal-cron.yaml
+  - drupal-deployment.yaml
+  - drupal-secret.yaml
+  - post-release.yaml
+  - backup-cron.yaml
+tests:
+  - it: has default release serviceaccount by default
+    template: drupal-deployment.yaml
+    set:
+      backup:
+        enabled: true
+    asserts:
+      - template: drupal-deployment.yaml
+        equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-sa
+      - template: drupal-cron.yaml
+        equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-sa
+      - template: post-release.yaml
+        equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-sa
+      - template: backup-cron.yaml
+        equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-sa
+
+  - it: can set a custom serviceaccount
+    template: drupal-deployment.yaml
+    set:
+      serviceAccount:
+        name: foo
+      backup:
+        enabled: true
+    asserts:
+      - template: drupal-deployment.yaml
+        equal:
+          path: spec.template.spec.serviceAccountName
+          value: foo
+      - template: drupal-cron.yaml
+        equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: foo
+      - template: post-release.yaml
+        equal:
+          path: spec.template.spec.serviceAccountName
+          value: foo
+      - template: backup-cron.yaml
+        equal:
+          path: spec.jobTemplate.spec.template.spec.serviceAccountName
+          value: foo

--- a/drupal/values.schema.json
+++ b/drupal/values.schema.json
@@ -8,6 +8,14 @@
     "branchName": { "type": "string" },
     "imagePullSecrets": { "type": "array" },
     "imagePullSecret": { "type": "string" },
+    "serviceAccount": { 
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
     "app": { "type": "string" },
     "webRoot": { "type": "string" },
 

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -355,6 +355,7 @@ php:
 
   # Set whether Drupal errors are displayed.
   # This is a useful override for development environments.
+  # Set to "hide" for Production environment.
   errorLevel: "verbose"
 
   # PHP settings
@@ -366,6 +367,8 @@ php:
     # Custom php settings block. May override parameters previously defined.
     # Note: include correct php ini section, i.e. "[PHP]" or "[Date]".
     extraConfig: |
+    # Uncomment next line to disable error verbosity for PHP completely
+    #  display_errors = off
 
   # Define the location of the Drupal config files relative to the composer root.
   # This variable is exposed as $DRUPAL_CONFIG_PATH in the container.

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -27,6 +27,12 @@ imagePullSecrets: []
 # Custom imagePullSecret for the containers. Base64 encoded. This will create a secret and append it to the imagePullSecrets.
 imagePullSecret: ""
 
+serviceAccount:
+  # Default value: [Release.Name]-sa
+  name: ""
+  # Mount service account token to the containers.
+  automountServiceAccountToken: false
+
 # The app label added to our Kubernetes resources.
 app: drupal
 
@@ -355,7 +361,6 @@ php:
 
   # Set whether Drupal errors are displayed.
   # This is a useful override for development environments.
-  # Set to "hide" for Production environment.
   errorLevel: "verbose"
 
   # PHP settings
@@ -367,8 +372,6 @@ php:
     # Custom php settings block. May override parameters previously defined.
     # Note: include correct php ini section, i.e. "[PHP]" or "[Date]".
     extraConfig: |
-    # Uncomment next line to disable error verbosity for PHP completely
-    #  display_errors = off
 
   # Define the location of the Drupal config files relative to the composer root.
   # This variable is exposed as $DRUPAL_CONFIG_PATH in the container.
@@ -596,6 +599,8 @@ mariadb:
               operator: NotIn
               values:
               - static-ip
+  serviceAccount:
+    create: true
   enableServiceLinks: false
 
 varnish:
@@ -660,6 +665,10 @@ elasticsearch:
   # Disable service links that cause a slow startup.
   enableServiceLinks: false
 
+  rbac:
+    create: true
+    automountToken: false
+
   # This value should be slightly less than 50% of the requested memory.
   esJavaOpts: -Xmx220m -Xms220m
   xpack:
@@ -690,6 +699,9 @@ elasticsearch:
 memcached:
   enabled: false
   replicaCount: 1
+  serviceAccount:
+    create: true
+  automountServiceAccountToken: false
   resources:
     requests:
       cpu: 10m
@@ -703,7 +715,7 @@ memcached:
     # MaxItemSize
     - -I 4M
 
-# https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
+# https://github.com/bitnami/charts/blob/d4dba2b393167d79b8c8f65b46c48b70ee3a9662/bitnami/redis/values.yaml
 redis:
   enabled: false
   architecture: standalone
@@ -722,6 +734,8 @@ redis:
       requests:
         cpu: 50m
         memory: 256Mi
+  serviceAccount:
+    automountServiceAccountToken: false
 
 # Mailhog service overrides
 # see: https://github.com/codecentric/helm-charts/blob/master/charts/mailhog/values.yaml

--- a/frontend/Chart.lock
+++ b/frontend/Chart.lock
@@ -19,9 +19,9 @@ dependencies:
   version: 13.2.24
 - name: silta-release
   repository: file://../silta-release
-  version: 1.0.0
+  version: 1.0.1
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 19.1.5
-digest: sha256:b494e7a5c8be4e2c9478ba2af95fa91830a6f537bdafc30c1c1399b4024168c3
-generated: "2024-05-02T08:45:24.766124978+03:00"
+digest: sha256:17f6538177ebf6ba9e5688e9f5cc9b36598746144336ffc44bbd4a3ecc062c25
+generated: "2025-01-21T14:04:37.839887+02:00"

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.12.0
+version: 1.12.1
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.12.1
+version: 1.13.0
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/_helpers.tpl
+++ b/frontend/templates/_helpers.tpl
@@ -250,3 +250,11 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- define "frontend.serviceAccountName" }}
+{{- if .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
+{{- else }}
+{{- .Release.Name }}-sa
+{{- end }}
+{{- end }}

--- a/frontend/templates/backup-cron.yaml
+++ b/frontend/templates/backup-cron.yaml
@@ -140,6 +140,7 @@ spec:
           {{- end }}
           {{- end }}
           restartPolicy: Never
+          serviceAccountName: {{ include "frontend.serviceAccountName" . }}
           volumes:
             - name: shared-data
               emptyDir:
@@ -167,5 +168,4 @@ spec:
                 {{- else }}
                 claimName: {{ .Release.Name }}-backup
                 {{- end }}
-          {{- include "frontend.imagePullSecrets" $ | nindent 10 }}
 {{- end }}

--- a/frontend/templates/ingress.yaml
+++ b/frontend/templates/ingress.yaml
@@ -76,6 +76,9 @@ metadata:
     auto-downscale/last-update: {{ dateInZone "2006-01-02T15:04:05.999Z" (now) "UTC" }}
     auto-downscale/label-selector: "release={{ .Release.Name }}"
     auto-downscale/services: {{ include "frontend.servicename" $ }}
+    {{- if and (index .Values "silta-release").downscaler.releaseMinAge (ne (index .Values "silta-release").downscaler.releaseMinAge "") }}
+    auto-downscale/min-age: {{(index .Values "silta-release").downscaler.releaseMinAge}}
+    {{- end }}
     {{- end }}
   labels:
     {{- include "frontend.release_labels" $ | nindent 4 }}
@@ -233,6 +236,9 @@ metadata:
     auto-downscale/last-update: {{ dateInZone "2006-01-02T15:04:05.999Z" (now) "UTC" }}
     auto-downscale/label-selector: "release={{ $.Release.Name }}"
     auto-downscale/services: {{ include "frontend.servicename" $ }}
+    {{- if and (index $.Values "silta-release").downscaler.releaseMinAge (ne (index $.Values "silta-release").downscaler.releaseMinAge "") }}
+    auto-downscale/min-age: {{(index $.Values "silta-release").downscaler.releaseMinAge}}
+    {{- end }}
     {{- end }}
   labels:
     {{ include "frontend.release_labels" $ | indent 4 }}

--- a/frontend/templates/nginx.yaml
+++ b/frontend/templates/nginx.yaml
@@ -68,7 +68,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sleep", "15"]
+              command: ["/bin/sleep", "5"]
         resources:
           {{ .Values.nginx.resources | toYaml | nindent 10 }}
 
@@ -100,7 +100,7 @@ spec:
         resources:
             {{- .Values.signalsciences.resources | toYaml | nindent 10 }}
         {{- end }}
-
+      serviceAccountName: {{ include "frontend.serviceAccountName" . }}
       volumes:
         - name: nginx-conf
           configMap:

--- a/frontend/templates/nginx.yaml
+++ b/frontend/templates/nginx.yaml
@@ -68,7 +68,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sleep", "5"]
+              command: ["/bin/sleep", "15"]
         resources:
           {{ .Values.nginx.resources | toYaml | nindent 10 }}
 

--- a/frontend/templates/serviceaccount.yaml
+++ b/frontend/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-sa
+  labels:
+    {{- include "frontend.release_labels" . | nindent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- include "frontend.imagePullSecrets" . }}

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -84,6 +84,7 @@ spec:
               {{- $.Values.serviceDefaults.resources | toYaml | nindent 14 }}
               {{- end }}
               {{- end }}
+          serviceAccountName: {{ include "frontend.serviceAccountName" $ }}
           volumes:
             {{- if $service.mounts }}
             {{- range $index, $mountName := $service.mounts -}}
@@ -99,7 +100,6 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-          {{- include "frontend.imagePullSecrets" $ | nindent 10 }}
           restartPolicy: OnFailure
           {{- if or $job.nodeSelector $service.nodeSelector ($.Values.cronJobDefaults).nodeSelector }}
           nodeSelector:

--- a/frontend/templates/services-deployment.yaml
+++ b/frontend/templates/services-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- include "frontend.release_labels" $ | nindent 8 }}
         deployment: frontend-{{ $index }}
         silta-frontend: service
-        {{ if $.Values.shell.enabled -}}
+        {{- if $.Values.shell.enabled }}
         silta-ingress: allow
         {{- end }}
       annotations:
@@ -37,22 +37,24 @@ spec:
         - containerPort: {{ default $.Values.serviceDefaults.port $service.port }}
           name: {{ $index }}
         volumeMounts:
-          {{ if $service.mounts }}
-          {{- range $index, $mountName := $service.mounts -}}
-          {{ $mount := (index $.Values.mounts $mountName) }}
+          {{- if $service.mounts }}
+          {{- range $index, $mountName := $service.mounts }}
+          {{- $mount := (index $.Values.mounts $mountName) }}
           {{- if eq $mount.enabled true }}
           - name: frontend-{{ $mountName }}
             mountPath: {{ $mount.mountPath }}
           {{- end }}
           {{- end }}
           {{- end }}
-          {{ if $.Values.shell.enabled -}}
+          {{- if $.Values.shell.enabled }}
           - name: shell-keys
             mountPath: /etc/ssh/keys
           {{- end }}
-        {{- if $service.lifecycle }}
         lifecycle:
-        {{- toYaml $service.lifecycle | nindent 10 }}
+        {{- if $service.lifecycle }}
+          {{ toYaml $service.lifecycle | nindent 10 }}
+        {{- else }}
+          {{ toYaml $.Values.serviceDefaults.lifecycle | nindent 10 }}
         {{- end }}
         livenessProbe:
         {{- if $service.livenessProbe }}
@@ -79,14 +81,15 @@ spec:
         {{- end }}
         {{- end }}
         resources:
-          {{- if $service.resources -}}
+          {{- if $service.resources }}
           {{ merge $service.resources $.Values.serviceDefaults.resources | toYaml | nindent 10 }}
-          {{ else -}}
-          {{ $.Values.serviceDefaults.resources | toYaml | nindent 10 }}
+          {{- else }}
+          {{- $.Values.serviceDefaults.resources | toYaml | nindent 10 }}
           {{- end }}
+      serviceAccountName: {{ include "frontend.serviceAccountName" $ }}
       volumes:
         {{ if $service.mounts }}
-        {{- range $index, $mountName := $service.mounts -}}
+        {{- range $index, $mountName := $service.mounts }}
         {{ $mount := (index $.Values.mounts $mountName) }}
         {{- if eq $mount.enabled true }}
         - name: frontend-{{ $mountName }}
@@ -107,7 +110,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{ if $.Values.shell.enabled -}}
+        {{- if $.Values.shell.enabled }}
         - name: shell-keys
           persistentVolumeClaim:
             {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
@@ -116,11 +119,13 @@ spec:
             claimName: {{ $.Release.Name }}-shell-keys
             {{- end }}
         {{- end }}
-      {{ if $service.nodeSelector -}}
+      terminationGracePeriodSeconds: {{ default $.Values.serviceDefaults.terminationGracePeriodSeconds $service.terminationGracePeriodSeconds }}
+      {{- $nodeSelector := default $.Values.serviceDefaults.nodeSelector $service.nodeSelector }}
+      {{- if $nodeSelector }}
       nodeSelector:
-        {{- $service.nodeSelector | toYaml | nindent 8 }}
+        {{ $nodeSelector | toYaml | nindent 8 }}
       tolerations:
-        {{- include "frontend.tolerations" $service.nodeSelector | nindent 8 }}
+        {{ include "frontend.tolerations" $nodeSelector | nindent 8 }}
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -168,7 +173,6 @@ spec:
                   values:
                   - frontend-{{ $index }}
       {{- end }}
-      {{- include "frontend.imagePullSecrets" $ | nindent 6 }}
 {{- if or $service.postupgrade $service.postinstall }}
 ---
 apiVersion: batch/v1
@@ -209,7 +213,7 @@ spec:
             {{- end }}
         volumeMounts:
           {{ if $service.mounts }}
-          {{- range $index, $mountName := $service.mounts -}}
+          {{- range $index, $mountName := $service.mounts }}
           {{ $mount := (index $.Values.mounts $mountName) }}
           {{- if eq $mount.enabled true }}
           - name: frontend-{{ $mountName }}
@@ -217,7 +221,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
-          {{ if $.Values.shell.enabled -}}
+          {{- if $.Values.shell.enabled }}
           - name: shell-keys
             mountPath: /etc/ssh/keys
           {{- end }}
@@ -233,8 +237,8 @@ spec:
         {{- end }}
       volumes:
         {{ if $service.mounts }}
-        {{- range $index, $mountName := $service.mounts -}}
-        {{ $mount := (index $.Values.mounts $mountName) }}
+        {{- range $index, $mountName := $service.mounts }}
+        {{- $mount := (index $.Values.mounts $mountName) }}
         {{- if eq $mount.enabled true }}
         - name: frontend-{{ $mountName }}
         {{- if hasKey $mount "secretName" }}
@@ -254,7 +258,7 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{ if $.Values.shell.enabled -}}
+        {{- if $.Values.shell.enabled }}
         - name: shell-keys
           persistentVolumeClaim:
             {{- if and ( eq $.Values.shell.mount.storageClassName "silta-shared" ) ( eq ( include "silta-cluster.rclone.has-provisioner" $ ) "true" ) }}
@@ -263,7 +267,6 @@ spec:
             claimName: {{ $.Release.Name }}-shell-keys
             {{- end }}
         {{- end }}
-      {{- include "frontend.imagePullSecrets" $ | nindent 6 }}
 {{- end }}
 
 {{- if $service.autoscaling }}

--- a/frontend/templates/varnish-deployment.yaml
+++ b/frontend/templates/varnish-deployment.yaml
@@ -72,6 +72,7 @@ spec:
           mountPath: "/etc/varnish/secret"
           subPath: control_key
           readOnly: true
+      serviceAccountName: {{ include "frontend.serviceAccountName" . }}
       volumes:
       - name: varnish-vcl
         configMap:

--- a/frontend/tests/backup-cron_test.yaml
+++ b/frontend/tests/backup-cron_test.yaml
@@ -30,32 +30,3 @@ tests:
           content:
             name: TZ
             value: Foo/Bar
-        
-  - it: adds imagePullSecrets
-    template: backup-cron.yaml
-    set:
-      services.foo:
-        image: 'bar'
-      backup:
-        enabled: true
-      imagePullSecrets:
-        - name: foo
-    asserts:
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.imagePullSecrets
-          value: 
-            - name: foo
-
-  - it: adds custom imagePullSecret
-    template: backup-cron.yaml
-    set:
-      services.foo:
-        image: 'bar'
-      backup:
-        enabled: true
-      imagePullSecret: 'foo'
-    asserts:
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.imagePullSecrets
-          value: 
-            - name: RELEASE-NAME-registry

--- a/frontend/tests/serviceaccount_test.yaml
+++ b/frontend/tests/serviceaccount_test.yaml
@@ -1,0 +1,76 @@
+suite: serviceaccount
+templates:
+  - serviceaccount.yaml
+  - image-secrets.yaml
+tests:
+
+  - it: can enable automountServiceAccountToken
+    template: serviceaccount.yaml
+    set:
+      serviceAccount:
+        automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
+  - it: can disable automountServiceAccountToken
+    template: serviceaccount.yaml
+    set:
+      serviceAccount:
+        automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: can add imagePullSecrets
+    template: serviceaccount.yaml
+    set:
+      imagePullSecrets:
+        - name: foo
+    asserts:
+      - equal:
+          path: imagePullSecrets
+          value: 
+            - name: foo
+
+  - it: can add custom imagePullSecret
+    template: serviceaccount.yaml
+    set:
+      imagePullSecret: 'foo'
+    asserts:
+      - equal:
+          path: imagePullSecrets
+          value: 
+            - name: RELEASE-NAME-registry
+
+  - it: imagePullSecrets and custom imagePullSecret merged
+    template: serviceaccount.yaml
+    set:
+      imagePullSecret: 'foo'
+      imagePullSecrets: 
+        - name: bar1
+        - name: bar2
+    asserts:
+      - equal:
+          path: imagePullSecrets
+          value:
+            - name: bar1
+            - name: bar2
+            - name: RELEASE-NAME-registry
+
+  - it: Creates a docker secret when imagePullSecret is set
+    template: image-secrets.yaml
+    set:
+      imagePullSecret: 'foo'
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: data
+          value:
+            .dockerconfigjson: foo
+
+
+

--- a/frontend/tests/services-cron_test.yaml
+++ b/frontend/tests/services-cron_test.yaml
@@ -196,36 +196,3 @@ tests:
           content:
             name: TZ
             value: Foo/Bar
-        
-  - it: adds imagePullSecrets
-    template: services-cron.yaml
-    set:
-      services.foo:
-        image: 'bar'
-        cron:
-          foo:
-            command: echo "Hello world"
-            schedule: '1 2 3 * *'
-      imagePullSecrets:
-        - name: foo
-    asserts:
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.imagePullSecrets
-          value: 
-            - name: foo
-
-  - it: adds custom imagePullSecret
-    template: services-cron.yaml
-    set:
-      services.foo:
-        image: 'bar'
-        cron:
-          foo:
-            command: echo "Hello world"
-            schedule: '1 2 3 * *'
-      imagePullSecret: 'foo'
-    asserts:
-      - equal:
-          path: spec.jobTemplate.spec.template.spec.imagePullSecrets
-          value: 
-            - name: RELEASE-NAME-registry

--- a/frontend/tests/services-deployment_test.yaml
+++ b/frontend/tests/services-deployment_test.yaml
@@ -181,13 +181,34 @@ tests:
           path: spec.template.spec.containers[0].resources.limits.memory
           value: 4G
 
-  - it: can set nodeSelectors
+  - it: can set nodeSelector via serviceDefaults
+    template: services-deployment.yaml
+    set:
+      services.foo:
+        image: 'bar'
+      serviceDefaults.nodeSelector:
+        foo: bar
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            foo: bar
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: foo
+            operator: Equal
+            value: bar
+
+  - it: can override nodeSelector in service
     template: services-deployment.yaml
     set:
       services.foo:
         image: 'bar'
         nodeSelector:
           bar: baz
+      serviceDefaults.nodeSelector:
+        foo: bar
     asserts:
       - equal:
           path: spec.template.spec.nodeSelector
@@ -268,60 +289,96 @@ tests:
           path: spec.strategy.foo
           value: BAR
 
-  - it: adds imagePullSecrets
+  - it: can set terminationGracePeriodSeconds
     template: services-deployment.yaml
     set:
-      services:
-        foo:
-          image: 'bar'
-      imagePullSecrets:
-        - name: foo
+      services.foo:
+        image: 'bar'
+        terminationGracePeriodSeconds: 123
     asserts:
       - equal:
-          path: spec.template.spec.imagePullSecrets
-          value: 
-            - name: foo
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 123
 
-  - it: adds custom imagePullSecret
+  - it: Uses serviceDefaults lifecycle hook
     template: services-deployment.yaml
     set:
       services:
-        foo:
+        service1:
+          image: 'foo'
+        service2:
           image: 'bar'
-      imagePullSecret: 'foo'
+      serviceDefaults:
+        lifecycle:
+          postStart: 
+            exec:
+              command: ['/bin/echo', 'foo']
+          preStop: 
+            exec:
+              command: ['/bin/echo', 'bar']
     asserts:
-      - equal:
-          path: spec.template.spec.imagePullSecrets
-          value: 
-            - name: RELEASE-NAME-registry
-
-  - it: imagePullSecrets and custom imagePullSecret merged
-    template: services-deployment.yaml
-    set:
-      services:
-        foo:
-          image: 'bar'
-      imagePullSecret: 'foo'
-      imagePullSecrets: 
-        - name: bar1
-        - name: bar2
-    asserts:
-      - equal:
-          path: spec.template.spec.imagePullSecrets
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].lifecycle
           value:
-            - name: bar1
-            - name: bar2
-            - name: RELEASE-NAME-registry
-
-  - it: Creates a docker secret when imagePullSecret is set
-    template: image-secrets.yaml
-    set:
-      imagePullSecret: 'foo'
-    asserts:
-      - isKind:
-          of: Secret
-      - equal:
-          path: data
+            postStart:
+              exec:
+                command: ['/bin/echo', 'foo']
+            preStop:
+              exec:
+                command: ['/bin/echo', 'bar']
+      - documentIndex: 1
+        equal:
+          path: spec.template.spec.containers[0].lifecycle
           value:
-            .dockerconfigjson: foo
+            postStart:
+              exec:
+                command: ['/bin/echo', 'foo']
+            preStop:
+              exec:
+                command: ['/bin/echo', 'bar']
 
+  - it: Allows override of lifecycle hook
+    template: services-deployment.yaml
+    set:
+      services:
+        service1:
+          image: 'foo'
+        service2:
+          image: 'bar'
+          lifecycle:
+            postStart: 
+              exec:
+                command: ['/bin/echo', 'baz']
+            preStop: 
+              exec:
+                command: ['/bin/echo', 'qux']
+      serviceDefaults:
+        lifecycle:
+          postStart: 
+            exec:
+              command: ['/bin/echo', 'foo']
+          preStop: 
+            exec:
+              command: ['/bin/echo', 'bar']
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].lifecycle
+          value:
+            postStart:
+              exec:
+                command: ['/bin/echo', 'foo']
+            preStop:
+              exec:
+                command: ['/bin/echo', 'bar']
+      - documentIndex: 1
+        equal:
+          path: spec.template.spec.containers[0].lifecycle
+          value:
+            postStart:
+              exec:
+                command: ['/bin/echo', 'baz']
+            preStop:
+              exec:
+                command: ['/bin/echo', 'qux']

--- a/frontend/values.schema.json
+++ b/frontend/values.schema.json
@@ -8,6 +8,14 @@
     "branchName": { "type": "string" },
     "imagePullSecrets": { "type": "array" },
     "imagePullSecret": { "type": "string" },
+    "serviceAccount": { 
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
     "app": { "type": "string" },
     "exposeDomains": {
       "type": "object",
@@ -212,6 +220,7 @@
               "preStop": { "type": "object" }
             }
           },
+          "terminationGracePeriodSeconds": { "type": "integer" },
           "readinessProbe": { "type": "object" },
           "livenessProbe": { "type": "object" },
           "strategy": { "type": "object" },
@@ -363,6 +372,19 @@
             "maxReplicas": { "type": "integer" },
             "metrics": { "type": "array" }
           }
+        },
+        "lifecycle": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "postStart": { "type": "object" },
+            "preStop": { "type": "object" }
+          }
+        },
+        "terminationGracePeriodSeconds": { "type": "integer" },
+        "nodeSelector": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
         }
       }
     },

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -3,6 +3,8 @@
 silta-release:
   downscaler:
     enabled: true
+    # value examples: 10y, 4w, 1h Defaults to values used in silta-downscaler chart.
+    releaseMinAge: ''
 
 # Main domain of the cluster.
 # Subdomains of this domain will be created automatically for each environment.
@@ -23,6 +25,12 @@ imagePullSecrets: []
 
 # Custom imagePullSecret for the containers. Base64 encoded. This will create a secret and append it to the imagePullSecrets. 
 imagePullSecret: ""
+
+serviceAccount:
+  # Default value: [Release.Name]-sa
+  name: ""
+  # Mount service account token to the containers.
+  automountServiceAccountToken: false
 
 # The app label added to our Kubernetes resources.
 app: frontend
@@ -345,6 +353,11 @@ serviceDefaults:
   # https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
   strategy:
     type: RollingUpdate
+  terminationGracePeriodSeconds: 30
+  lifecycle:
+    preStop:
+      exec:
+        command: ['/bin/sleep', '15']
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -354,6 +367,8 @@ serviceDefaults:
       resource:
         name: cpu
         targetAverageUtilization: 80
+  # nodeSelector:
+  #   cloud.google.com/gke-nodepool: static-ip
 
 # Provide defaults for all cron jobs. This will override serviceDefaults when defined.
 cronJobDefaults:
@@ -400,6 +415,8 @@ mariadb:
               operator: NotIn
               values:
               - static-ip
+  serviceAccount:
+    create: true
   enableServiceLinks: false
 
 varnish:
@@ -466,6 +483,13 @@ elasticsearch:
     - name: xpack.security.enabled
       value: "false"
 
+  # Disable service links that cause a slow startup.
+  enableServiceLinks: false
+
+  rbac:
+    create: true
+    automountToken: false
+
   # This value should be slightly less than 50% of the requested memory.
   esJavaOpts: -Xmx220m -Xms220m
   xpack:
@@ -517,7 +541,11 @@ postgresql:
   # Use a low default to prevent unnecessary storage use.
   persistence:
     size: 1Gi
+  serviceAccount:
+    create: true
+    automountServiceAccountToken: false
 
+# https://github.com/wunderio/charts/blob/master/rabbitmq/values.yaml
 rabbitmq:
   enabled: false
 
@@ -582,4 +610,6 @@ redis:
       requests:
         cpu: 50m
         memory: 256Mi
+  serviceAccount:
+    automountServiceAccountToken: false
 

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.8.2
+version: 1.9.0
 # csi-rclone external provisioner requires kubernetes 1.20+
 # https://github.com/kubernetes-csi/external-provisioner?tab=readme-ov-file#compatibility
 kubeVersion: '>=1.20.0-0'

--- a/silta-cluster/README.md
+++ b/silta-cluster/README.md
@@ -35,8 +35,8 @@ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.8.0 \
-  --set installCRDs=true \
+  --version v1.16.2 \
+  --set crds.enabled=true \
   --set global.logLevel=1
 ```
 
@@ -157,6 +157,7 @@ helm upgrade --install --wait silta-cluster silta-cluster \
 ```
 
 ## Upgrade path for older versions:
+ - Upgrading silta-cluster chart to 1.9.0 ([docs/Upgrading-to-1.9.0.md](docs/Upgrading-to-1.9.0.md))
 
  - Upgrading silta-cluster chart to 1.8.0 ([docs/Upgrading-to-1.8.0.md](docs/Upgrading-to-1.8.0.md))
 

--- a/silta-cluster/docs/Upgrading-to-1.9.0.md
+++ b/silta-cluster/docs/Upgrading-to-1.9.0.md
@@ -1,0 +1,32 @@
+# Upgrading silta-cluster chart to 1.9.0
+
+## Cert-manager upgrade to v1.16.2
+
+It is important to do upgrade in steps, doing an upgrade for every major version. For example - if You are upgrading from v1.8.0 to v1.16.2, You should do upgrade to v1.9.0, then v1.10.0, then v1.11.0, and so on.
+
+The single most important change for upgrades from v1.8.0 to v1.16.2 is in version v1.15 helm chart, where `installCRDs: true` helm value is replaced with `crds.enabled: true`. 
+This means, You carry out the upgrade in two steps: first upgrade to v1.15.0 and then to v1.16.2.
+
+For upgrading from v1.8.0 to v1.14.x, use the following commands:
+
+```bash
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.9.0 --set installCRDs=true --set global.logLevel=1
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.10.0 --set installCRDs=true --set global.logLevel=1
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.11.0 --set installCRDs=true --set global.logLevel=1
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.12.0 --set installCRDs=true --set global.logLevel=1
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.13.0 --set installCRDs=true --set global.logLevel=1
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.14.0 --set installCRDs=true --set global.logLevel=1
+```
+
+For upgrading from v1.15.4 to v1.16.2, use the following commands:
+
+```bash
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.15.0 --set crds.enabled=true --set global.logLevel=1
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.15.4 --set crds.enabled=true --set global.logLevel=1
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.16.2 --set crds.enabled=true --set global.logLevel=1
+```
+
+Skipping some versions is possible, but it is not recommended. 
+Related documentation: 
+- [https://cert-manager.io/docs/installation/upgrading/](https://cert-manager.io/docs/installation/upgrading/)
+- [https://cert-manager.io/docs/releases/](https://cert-manager.io/docs/releases/)

--- a/silta-cluster/docs/kyverno-policies/disallow-privilege-escalation.yaml
+++ b/silta-cluster/docs/kyverno-policies/disallow-privilege-escalation.yaml
@@ -1,0 +1,62 @@
+# Name: 
+#   Validate Pod Security Context
+# Description:
+#     Disallow Privilege Escalation
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-pod-policy
+  annotations:
+    policies.kyverno.io/title: Disallow Privilege Escalation
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/description: >-
+      Privilege escalation is disallowed. The fields
+      spec.containers[*].securityContext.allowPrivilegeEscalation,
+      spec.initContainers[*].securityContext.allowPrivilegeEscalation,
+      and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation
+      can't be set to `true`.
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+  - name: containers-user-privileges-validation
+    match:
+      any:
+      - resources:
+          kinds:
+            - Pod
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - kube-system
+          - silta-cluster
+          - kubecost
+          - sumologic
+          - logging
+    validate:
+      message: >-
+        Privilege escalation is disallowed. The fields
+        spec.containers[*].securityContext.allowPrivilegeEscalation,
+        spec.initContainers[*].securityContext.allowPrivilegeEscalation,
+        and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation
+        can't be set to `true`.
+      foreach:
+        - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+          deny:
+            conditions:
+              any:
+              - key: "{{ element.securityContext.privileged || '' }}"
+                operator: Equals
+                value: true
+                message: >-
+                  non-privileged-containers may not set securityContext.privileged to true
+              - key: "{{ element.securityContext.allowPrivilegeEscalation || '' }}"
+                operator: Equals
+                value: true
+                message: >-
+                  non-privileged-containers may not set securityContext.allowPrivilegeEscalation to true

--- a/silta-cluster/docs/kyverno-policies/disallow-privileged-containers.yaml
+++ b/silta-cluster/docs/kyverno-policies/disallow-privileged-containers.yaml
@@ -39,6 +39,7 @@ spec:
             - silta-cluster
             - kubecost
             - sumologic
+            - logging
       validate:
         message: >-
           Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged,

--- a/silta-cluster/docs/kyverno-policies/restrict-adding-capabilities.yaml
+++ b/silta-cluster/docs/kyverno-policies/restrict-adding-capabilities.yaml
@@ -1,0 +1,71 @@
+# Name: 
+#   Restrict Adding Capabilities
+# Description:
+#   Adding capabilities is a way for containers in a Pod to request higher levels
+#   of ability than those with which they may be provisioned. Many capabilities
+#   allow system-level control and should be prevented. Pod Security Policies (PSP)
+#   allowed a list of "good" capabilities to be added. This policy checks
+#   ephemeralContainers, initContainers, and containers to ensure the only
+#   capabilities that can be added are either NET_BIND_SERVICE or CAP_CHOWN.    
+# Source: 
+#   https://raw.githubusercontent.com/kyverno/policies/main/psp-migration/restrict-adding-capabilities/restrict-adding-capabilities.yaml
+# Modification: 
+#   audit -> enforce
+#   namespace exclusion
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: psp-restrict-adding-capabilities
+  annotations:
+    policies.kyverno.io/title: Restrict Adding Capabilities
+    policies.kyverno.io/category: PSP Migration
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23"
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Adding capabilities is a way for containers in a Pod to request higher levels
+      of ability than those with which they may be provisioned. Many capabilities
+      allow system-level control and should be prevented. Pod Security Policies (PSP)
+      allowed a list of "good" capabilities to be added. This policy checks
+      ephemeralContainers, initContainers, and containers to ensure the only
+      capabilities that can be added are either NET_BIND_SERVICE or CAP_CHOWN.      
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: allowed-capabilities
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      exclude:
+        any:
+        - resources:
+            namespaces:
+            - kube-system
+            - silta-cluster
+            - kubecost
+            - sumologic
+            - logging
+      preconditions:
+        all:
+        - key: "{{ request.operation || 'BACKGROUND' }}"
+          operator: NotEquals
+          value: DELETE
+      validate:
+        message: >-
+          Any capabilities added other than NET_BIND_SERVICE or CAP_CHOWN are disallowed.          
+        foreach:
+          - list: request.object.spec.[ephemeralContainers, initContainers, containers][]
+            deny:
+              conditions:
+                all:
+                - key: "{{ element.securityContext.capabilities.add[] || '' }}"
+                  operator: AnyNotIn
+                  value:
+                  - NET_BIND_SERVICE
+                  - CAP_CHOWN
+                  - ''

--- a/silta-cluster/docs/kyverno-policies/restrict-seccomp.yaml
+++ b/silta-cluster/docs/kyverno-policies/restrict-seccomp.yaml
@@ -1,0 +1,64 @@
+# Name: 
+#   Restrict Seccomp
+# Description:
+#   Use of custom Seccomp profiles is disallowed. The fields
+#   spec.securityContext.seccompProfile.type,
+#   spec.containers[*].securityContext.seccompProfile.type,
+#   spec.initContainers[*].securityContext.seccompProfile.type, and
+#   spec.ephemeralContainers[*].securityContext.seccompProfile.type
+#   must be unset or set to `RuntimeDefault`.
+# Source: 
+#   https://raw.githubusercontent.com/kyverno/policies/main/pod-security/baseline/restrict-seccomp/restrict-seccomp.yaml
+# Modification: 
+#   audit -> enforce
+#   RuntimeDefault & Localhost -> RuntimeDefault
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-seccomp
+  annotations:
+    policies.kyverno.io/title: Restrict Seccomp
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/description: >-
+      The seccomp profile must not be explicitly set to Unconfined. This policy, 
+      requiring Kubernetes v1.19 or later, ensures that seccomp is unset or 
+      set to `RuntimeDefault`.      
+spec:
+  background: true
+  validationFailureAction: Enforce
+  rules:
+    - name: check-seccomp
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+      validate:
+        message: >-
+          Use of custom Seccomp profiles is disallowed. The fields
+          spec.securityContext.seccompProfile.type,
+          spec.containers[*].securityContext.seccompProfile.type,
+          spec.initContainers[*].securityContext.seccompProfile.type, and
+          spec.ephemeralContainers[*].securityContext.seccompProfile.type
+          must be unset or set to `RuntimeDefault`.          
+        pattern:
+          spec:
+            =(securityContext):
+              =(seccompProfile):
+                =(type): "RuntimeDefault"
+            =(ephemeralContainers):
+            - =(securityContext):
+                =(seccompProfile):
+                  =(type): "RuntimeDefault"
+            =(initContainers):
+            - =(securityContext):
+                =(seccompProfile):
+                  =(type): "RuntimeDefault"
+            containers:
+            - =(securityContext):
+                =(seccompProfile):
+                  =(type): "RuntimeDefault"

--- a/silta-cluster/docs/kyverno-policies/restrict-volume-types.yaml
+++ b/silta-cluster/docs/kyverno-policies/restrict-volume-types.yaml
@@ -37,7 +37,9 @@ spec:
             namespaces:
             - kube-system
             - silta-cluster
+            - kubecost
             - sumologic
+            - logging
       preconditions:
         all:
         - key: "{{ request.operation || 'BACKGROUND' }}"

--- a/silta-cluster/templates/deployment-remover-sa.yaml
+++ b/silta-cluster/templates/deployment-remover-sa.yaml
@@ -13,15 +13,210 @@ metadata:
   namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
-  - '*'
+  - ""
   resources:
-  - '*'
+  - configmaps
+  - services
+  - persistentvolume
+  - persistentvolumeclaims
+  - serviceaccounts
+  - pods
+  - pods/log
+  - pods/exec
+  - pods/portforward
+  - secrets
   verbs:
-  - '*'
-- nonResourceURLs:
-  - '*'
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
   verbs:
-  - '*'
+  - list
+  - get
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  - limitranges
+  - endpoints
+  - events
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - deployments
+  - replicasets
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - certificates
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - acme.cert-manager.io
+  resources:
+  - challenges
+  - orders
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificaterequests
+  - issuers
+  - clusterissuers
+  - certificates
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - cloud.google.com
+  resources:
+  - backendconfigs
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+- apiGroups:
+  - pxc.percona.com
+  resources:
+  - perconaxtradbclusterbackups
+  - perconaxtradbclusterrestores
+  - perconaxtradbclusters
+  - perconaxtradbbackups
+  verbs:
+  - update
+  - create
+  - patch
+  - watch
+  - delete
+  - list
+  - get
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/silta-release/Chart.yaml
+++ b/silta-release/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: silta-release
 description: A library chart to provide generic functionality for a silta Helm release.
-version: 1.0.0
+version: 1.0.1

--- a/silta-release/templates/_networkPolicy.tpl
+++ b/silta-release/templates/_networkPolicy.tpl
@@ -23,7 +23,7 @@ spec:
     {{ else }}
     - namespaceSelector:
         matchLabels:
-          name: {{ .Release.Namespace }}
+          kubernetes.io/metadata.name: {{ .Release.Namespace }}
     {{ end }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -49,6 +49,6 @@ spec:
     {{ else }}
     - namespaceSelector:
         matchLabels:
-          name: {{ .Release.Namespace }}
+          kubernetes.io/metadata.name: {{ .Release.Namespace }}
     {{ end }}
 {{ end }}

--- a/silta-release/tests/network_policy_test.yaml
+++ b/silta-release/tests/network_policy_test.yaml
@@ -11,7 +11,7 @@ tests:
           value: "RELEASE-NAME"
       - documentIndex: 0
         equal:
-          path: spec.ingress[0].from[0].namespaceSelector.matchLabels.name
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels['kubernetes.io/metadata.name']
           value: "NAMESPACE"
 
   - it: specified exceptions are added
@@ -24,7 +24,7 @@ tests:
           from:
             - namespaceSelector:
                 matchLabels:
-                  name: other-namespace
+                  kubernetes.io/metadata.name: other-namespace
     asserts:
       - documentIndex: 4
         equal:
@@ -32,5 +32,5 @@ tests:
           value: "RELEASE-NAME"
       - documentIndex: 4
         equal:
-          path: spec.ingress[0].from[0].namespaceSelector.matchLabels.name
+          path: spec.ingress[0].from[0].namespaceSelector.matchLabels['kubernetes.io/metadata.name']
           value: "other-namespace"

--- a/silta-release/values.yaml
+++ b/silta-release/values.yaml
@@ -15,7 +15,7 @@ branchName: ""
 #    from:
 #      - namespaceSelector:
 #          matchLabels:
-#            name: other-namespace
+#            kubernetes.io/metadata.name: other-namespace
 ingressAccess: {}
 
 # Add information regarding an HTTP proxy.

--- a/simple/Chart.lock
+++ b/simple/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: silta-release
   repository: file://../silta-release
-  version: 1.0.0
-digest: sha256:c60bc1d25e01cc614aa774e746610bf07af55cecd8335636ad01752baab0f1e8
-generated: "2023-10-03T12:05:07.676971983+03:00"
+  version: 1.0.1
+digest: sha256:a91a79784408bbe14716ab20f64b6e0e5e39840fa5579d48dec22edc2247194e
+generated: "2025-01-21T14:04:29.979508+02:00"

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 1.5.1
+version: 1.6.0
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,5 +1,5 @@
 name: simple
-version: 1.5.0
+version: 1.5.1
 apiVersion: v2
 dependencies:
 - name: silta-release

--- a/simple/templates/_helpers.tpl
+++ b/simple/templates/_helpers.tpl
@@ -79,3 +79,11 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- define "simple.serviceAccountName" }}
+{{- if .Values.serviceAccount.name }}
+{{- .Values.serviceAccount.name }}
+{{- else }}
+{{- .Release.Name }}-sa
+{{- end }}
+{{- end }}

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sleep", "5"]
+              command: ["/bin/sleep", "15"]
         resources:
           {{- .Values.nginx.resources | toYaml | nindent 10 }}
 

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sleep", "15"]
+              command: ["/bin/sleep", "5"]
         resources:
           {{- .Values.nginx.resources | toYaml | nindent 10 }}
 
@@ -101,7 +101,7 @@ spec:
         resources:
           {{- .Values.signalsciences.resources | toYaml | nindent 10 }}
       {{- end }}
-
+      serviceAccountName: {{ include "simple.serviceAccountName" . }}
       volumes:
         - name: nginx-conf
           configMap:
@@ -131,7 +131,6 @@ spec:
         - name: sigsci-tmp
           emptyDir: { }
         {{- end }}
-      {{- include "simple.imagePullSecrets" . | nindent 6 }}
 ---
 {{- if .Values.autoscaling.enabled }}
 apiVersion: {{ include "simple.autoscaling.api-version" . | trim }}

--- a/simple/templates/serviceaccount.yaml
+++ b/simple/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-sa
+  labels:
+    {{ include "simple.release_labels" . | indent 4 }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- include "simple.imagePullSecrets" . }}

--- a/simple/values.schema.json
+++ b/simple/values.schema.json
@@ -8,6 +8,14 @@
     "branchName": { "type": "string" },
     "imagePullSecrets": { "type": "array" },
     "imagePullSecret": { "type": "string" },
+    "serviceAccount": { 
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
     "app": { "type": "string" },
     "silta-release": { "type": "object" },
     "replicas": { "type": "integer" },

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -19,6 +19,12 @@ imagePullSecrets: []
 # Custom imagePullSecret for the containers. Base64 encoded. This will create a secret and append it to the imagePullSecrets. 
 imagePullSecret: ""
 
+serviceAccount:
+  # Default value: [Release.Name]-sa
+  name: ""
+  # Mount service account token to the containers.
+  automountServiceAccountToken: false
+
 # The app label added to our Kubernetes resources.
 app: simple
 


### PR DESCRIPTION
Drupal chart:
- pod SA, disable automount SA tokens ([PR](https://github.com/wunderio/drupal-project-k8s/pull/730))
- mysqladmin connect-timeout typo fix ([PR](https://github.com/wunderio/drupal-project-k8s/pull/728))
- SLT-954: example how to disable PHP error output ([PR](https://github.com/wunderio/charts/pull/460))

Frontend chart:
- lifecycle hooks, nodeSelector for serviceDefaults ([PR](https://github.com/wunderio/frontend-project-k8s/pull/136))
- pod SA, disable automount SA tokens ([PR](https://github.com/wunderio/frontend-project-k8s/pull/137))
- SLT-1008: Increase nginx shutdown delay from 5s to 15s on both simple and frontend charts ([PR](https://github.com/wunderio/charts/pull/461))
- releaseMinAge support ([PR](https://github.com/wunderio/frontend-project-k8s/pull/138))

Simple chart:
​​- pod SA, disable automount SA tokens ([PR](https://github.com/wunderio/simple-project-k8s/pull/62))
- SLT-1008: Increase nginx shutdown delay from 5s to 15s on both simple and frontend charts ([PR](https://github.com/wunderio/charts/pull/461))

Silta release chart:
- Immutable namespace selector ([PR](https://github.com/wunderio/drupal-project-k8s/pull/729))

Silta cluster chart:
- kyverno rule for disabling allowPrivilegeEscalation ([PR](https://github.com/wunderio/charts/pull/457))
- Narrowed down deployment remover rbac ([PR](https://github.com/wunderio/charts/pull/457))
- cert-manager version update - v1.16.2 ([PR](https://github.com/wunderio/charts/pull/458))

Charts repository:
- Test with Helm v3.16.3, minikube tests with kubernetes 1.31 ([PR](https://github.com/wunderio/charts/pull/455))