### PR TITLE
feature/mariadb11 server

### DIFF
--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -563,7 +563,7 @@ mariadb:
   enabled: true
   image:
     # https://hub.docker.com/r/bitnami/mariadb/tags
-    tag: 10.6-debian-12
+    tag: 11.4-debian-12
   replication:
     enabled: false
   db:

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -388,7 +388,7 @@ mariadb:
   enabled: false
   image:
     # https://hub.docker.com/r/bitnami/mariadb/tags
-    tag: 10.6.15-debian-11-r24
+    tag: 11.4-debian-12
   replication:
     enabled: false
   db:


### PR DESCRIPTION
- **Bump mariadb image version from 10.6-debian-12 to 11.4-debian-12**
- **Also bump mariadb image version for frontend chart**
