### PR TITLE
SLT-1136: Drupal chart: Use JSON as the default formatter for application logs when handled by monolog

### DIFF
--- a/drupal/files/silta.services.yml
+++ b/drupal/files/silta.services.yml
@@ -1,27 +1,27 @@
 parameters:
   monolog.channel_handlers:
-    # Log to stderr by default.
     default:
       handlers:
         - name: 'stream'
           formatter: 'json'
           processors:
-            - 'current_user'
-            - 'request_uri'
-            - 'server_host'
-            - 'referer'
-            - 'ip'
             - 'message_placeholder'
-            - 'drupal_message_placeholder'
+            - 'request_uri'
+            - 'referer'
+            - 'current_user'
+            - 'ip'
             - 'filter_backtrace'
-            - 'introspection'
-            - 'git'
-            - 'memory_usage'
-            - 'memory_peak_usage'
-            - 'process_id'
 
 services:
+  # Defines a 'stream' channel handler used above.
+  # Log to stderr by default.
+  # The minimum (also default) logging level is 100 (DEBUG), we set it here explicitly for better visibility.
   monolog.handler.stream:
     class: Monolog\Handler\StreamHandler
-    # The minimum logging level DEBUG = 100
-    arguments: ['php://stderr', 100]
+    arguments: [ 'php://stderr', 100 ]
+  # Override monolog's 'filter_backtrace' processor to remove some redundant data (thus reduce data ingest)
+  # Remove the 'link' from context data as it makes sense only in Drupal's admin UI.
+  monolog.processor.filter_backtrace:
+    class: Drupal\monolog\Logger\Processor\ContextKeyFilterProcessor
+    arguments: [ [ 'backtrace', 'link' ] ]
+    shared: false

--- a/drupal/files/silta.services.yml
+++ b/drupal/files/silta.services.yml
@@ -1,7 +1,24 @@
 parameters:
   monolog.channel_handlers:
-     # Log to stderr by default.
-     default: ['stream']
+    # Log to stderr by default.
+    default:
+      handlers:
+        - name: 'stream'
+          formatter: 'json'
+          processors:
+            - 'current_user'
+            - 'request_uri'
+            - 'server_host'
+            - 'referer'
+            - 'ip'
+            - 'message_placeholder'
+            - 'drupal_message_placeholder'
+            - 'filter_backtrace'
+            - 'introspection'
+            - 'git'
+            - 'memory_usage'
+            - 'memory_peak_usage'
+            - 'process_id'
 
 services:
   monolog.handler.stream:


### PR DESCRIPTION
Adjust the default monolog channel handler:
- set formater to JSON to have structured Drupal logs
- specify default log processors
- override monolog's `filter_backtrace` processor to remove redundant log data which makes sense in Drupal UI but not on stderr