### PR TITLE
Release 2025-04-01

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 1.18.0
+version: 1.19.0
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/files/silta.services.yml
+++ b/drupal/files/silta.services.yml
@@ -1,10 +1,27 @@
 parameters:
   monolog.channel_handlers:
-     # Log to stderr by default.
-     default: ['stream']
+    default:
+      handlers:
+        - name: 'stream'
+          formatter: 'json'
+          processors:
+            - 'message_placeholder'
+            - 'request_uri'
+            - 'referer'
+            - 'current_user'
+            - 'ip'
+            - 'filter_backtrace'
 
 services:
+  # Defines a 'stream' channel handler used above.
+  # Log to stderr by default.
+  # The minimum (also default) logging level is 100 (DEBUG), we set it here explicitly for better visibility.
   monolog.handler.stream:
     class: Monolog\Handler\StreamHandler
-    # The minimum logging level DEBUG = 100
-    arguments: ['php://stderr', 100]
+    arguments: [ 'php://stderr', 100 ]
+  # Override monolog's 'filter_backtrace' processor to remove some redundant data (thus reduce data ingest)
+  # Remove the 'link' from context data as it makes sense only in Drupal's admin UI.
+  monolog.processor.filter_backtrace:
+    class: Drupal\monolog\Logger\Processor\ContextKeyFilterProcessor
+    arguments: [ [ 'backtrace', 'link' ] ]
+    shared: false

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.14.0
+version: 1.14.1
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -383,7 +383,7 @@ cronJobDefaults:
 
 # Override the default values of the MariaDB subchart.
 # These settings are optimised for development environments.
-# see: https://github.com/wunderio/charts/blob/master/mariadb/values.yaml
+# see: https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml
 mariadb:
   enabled: false
   image:


### PR DESCRIPTION
Drupal chart:
- SLT-1136: Drupal chart: Use JSON as the default formatter for application logs when handled by monolog ([PR](https://github.com/wunderio/drupal-project-k8s/pull/736), credits @k4lv15)
- Backup improvements ([PR](https://github.com/wunderio/drupal-project-k8s/pull/740))

Frontend chart:
- Update MariaDB values.yaml reference to our forked chart values ([PR](https://github.com/wunderio/charts/pull/468))