### PR TITLE
Release 2025-06-03

### DIFF
--- a/drupal/templates/NOTES.txt
+++ b/drupal/templates/NOTES.txt
@@ -17,13 +17,15 @@ Your site is available at:
   {{- end }}
 
 {{- if .Values.mailhog.enabled }}
-  
+
 Mailhog available at:
 
   http://{{- template "drupal.domain" . }}/mailhog
   {{- range $index, $domain := .Values.exposeDomains }}
   http://{{ $domain.hostname }}/mailhog
   {{- end }}
+  ⚠️ **DEPRECATED** mailhog is deprecated and will be removed in the future, use mailpit instead
+  See: https://wunderio.github.io/silta/docs/silta-examples#sending-e-mail
 {{- end }}
 
 {{- if .Values.mailpit.enabled }}

--- a/frontend/templates/NOTES.txt
+++ b/frontend/templates/NOTES.txt
@@ -27,6 +27,8 @@ Mailhog available at:
   {{- range $index, $domain := .Values.exposeDomains }}
   http://{{ $domain.hostname }}/mailhog
   {{- end }}
+  ⚠️ **DEPRECATED** mailhog is deprecated and will be removed in the future, use mailpit instead
+  See: https://wunderio.github.io/silta/docs/silta-examples#sending-e-mail
 {{- end }}
 
 {{- if .Values.mailpit.enabled }}


### PR DESCRIPTION
Drupal chart:
- SLT-1193: Add deprecation warning for mailhog in release notes ([PR](https://github.com/wunderio/drupal-project-k8s/pull/749), credits @k4lv15)

Frontend chart:
- SLT-1193: Add deprecation warning for mailhog in release notes ([PR](https://github.com/wunderio/frontend-project-k8s/pull/148), credits @k4lv15)
- Use last non-trusted address sent in the request header field ([PR](https://github.com/wunderio/frontend-project-k8s/pull/147))