### PR TITLE
Improve varnish config, add support for URIBAN by regex

### DIFF
--- a/drupal/templates/varnish-configmap-vcl.yaml
+++ b/drupal/templates/varnish-configmap-vcl.yaml
@@ -439,6 +439,20 @@ data:
         return (pass);
       }
 
+      if (req.http.Accept-Encoding) {
+        if (req.url ~ "\.(bz2|eot|gif|gz|ico|jpg|mp3|ogg|pdf|png|svg|swf|tbz|tgz|tif|tiff|ttf|webp|woff|zip)(\?.*)?$") {
+          # No point in compressing these
+          unset req.http.Accept-Encoding;
+        } elsif (req.http.Accept-Encoding ~ "gzip") {
+          set req.http.Accept-Encoding = "gzip";
+        } elsif (req.http.Accept-Encoding ~ "deflate") {
+          set req.http.Accept-Encoding = "deflate";
+        } else {
+          # unknown algorithm
+          unset req.http.Accept-Encoding;
+        }
+      }
+
       if (req.url ~ "\.(bmp|bz2|css|doc|eot|gif|ico|jpg|js|pdf|png|ppt|svg|swf|tif|tiff|ttf|webp|woff|xls|zip)$") {
         # Static file request do not vary on cookies
         unset req.http.Cookie;
@@ -477,20 +491,6 @@ data:
         else {
           # Non-authenticated requests do not vary on cookies
           unset req.http.Cookie;
-        }
-      }
-
-      if (req.http.Accept-Encoding) {
-        if (req.url ~ "\.(jpg|png|gif|svg|tif|tiff|ico|webp|gz|tgz|bz2|tbz|mp3|ogg|swf|zip|pdf|woff|eot|ttf)(\?.*)?$") {
-          # No point in compressing these
-          unset req.http.Accept-Encoding;
-        } elsif (req.http.Accept-Encoding ~ "gzip") {
-            set req.http.Accept-Encoding = "gzip";
-        } elsif (req.http.Accept-Encoding ~ "deflate") {
-            set req.http.Accept-Encoding = "deflate";
-        } else {
-          # unknown algorithm
-          unset req.http.Accept-Encoding;
         }
       }
 

--- a/drupal/templates/varnish-configmap-vcl.yaml
+++ b/drupal/templates/varnish-configmap-vcl.yaml
@@ -439,7 +439,7 @@ data:
         return (pass);
       }
 
-      if (req.url ~ "\.(png|gif|jpg|svg|tif|tiff|ico|webp|swf|css|js|pdf|doc|xls|ppt|zip|woff|eot|ttf|bmp|bz2)$") {
+      if (req.url ~ "\.(bmp|bz2|css|doc|eot|gif|ico|jpg|js|pdf|png|ppt|svg|swf|tif|tiff|ttf|webp|woff|xls|zip)$") {
         # Static file request do not vary on cookies
         unset req.http.Cookie;
         return (hash);

--- a/drupal/templates/varnish-configmap-vcl.yaml
+++ b/drupal/templates/varnish-configmap-vcl.yaml
@@ -420,8 +420,9 @@ data:
         return (pass);
       }
 
-      if (req.url ~ "\.(png|gif|jpg|tif|tiff|ico|webp|swf|css|js|pdf|doc|xls|ppt|zip)(\?.*)?$") {
-        // Forcing a lookup with static file requests
+      if (req.url ~ "\.(png|gif|jpg|svg|tif|tiff|ico|webp|swf|css|js|pdf|doc|xls|ppt|zip|woff|eot|ttf|bmp|bz2)$") {
+        # Static file request do not vary on cookies
+        unset req.http.Cookie;
         return (hash);
       }
 
@@ -445,12 +446,7 @@ data:
       }
 
       if (req.http.Cookie) {
-        if (req.url ~ "\.(png|gif|jpg|svg|tif|tiff|ico|webp|swf|css|js|pdf|doc|xls|ppt|zip|woff|eot|ttf|bmp|bz2)$") {
-          # Static file request do not vary on cookies
-          unset req.http.Cookie;
-          return (hash);
-        }
-        elseif (req.http.Cookie ~ "(SESS[a-z0-9]+|SSESS[a-z0-9]+)") {
+        if (req.http.Cookie ~ "(SESS[a-z0-9]+|SSESS[a-z0-9]+)") {
           # Authenticated users should not be cached
           return (pass);
         }

--- a/drupal/templates/varnish-configmap-vcl.yaml
+++ b/drupal/templates/varnish-configmap-vcl.yaml
@@ -304,8 +304,8 @@ data:
         return(pipe);
       }
 
-      # Only allow BAN requests from IP addresses in the 'purge' ACL.
-      if (req.method == "BAN" || req.method == "URIBAN") {
+      # Only allow BAN requests from IP addressees in the 'internal' ACL.
+      if (req.method == "BAN") {
         # Admin port is only exposed to internal network
         if (!client.ip ~ purge) {
           return (synth(403, "Not allowed."));
@@ -319,11 +319,30 @@ data:
         elseif (req.http.Cache-Tags) {
           ban("obj.http.Cache-Tags ~ " + req.http.Cache-Tags);
         }
-        elseif (req.method == "URIBAN") {
-          ban("req.http.host == " + req.http.host + " && req.url == " + req.url);
-        }
         else {
-          return (synth(403, "Cache tags headers not present."));
+          # If there are no cache tags headers in a BAN request,
+          # it is a bad request, so indicate that to the client.
+          return (synth(400, "Cache tags headers not present."));
+        }
+        # Throw a synthetic page so the request won't go to the backend.
+        return (synth(200, "Ban added."));
+      }
+
+      # Only allow URIBAN requests from IP addressees in the 'internal' ACL.
+      if (req.method == "URIBAN") {
+        # Admin port is only exposed to internal network
+        if (!client.ip ~ purge) {
+          return (synth(403, "Not allowed."));
+        }
+
+        # If x-url-invalidate-pattern header is present,
+        # use it to match URLs in stored objects. (ban by regex pattern)
+        if (req.http.x-url-invalidate-pattern) {
+          ban("obj.http.x-url ~ " + req.http.x-url-invalidate-pattern);
+        }
+        # Without pattern, ban by matching host and URL exactly.
+        else {
+          ban("obj.http.host == " + req.http.host + " && obj.http.x-url == " + req.url);
         }
         # Throw a synthetic page so the request won't go to the backend.
         return (synth(200, "Ban added."));

--- a/drupal/templates/varnish-configmap-vcl.yaml
+++ b/drupal/templates/varnish-configmap-vcl.yaml
@@ -479,7 +479,7 @@ data:
       }
 
       if (req.http.Cookie) {
-        if (req.http.Cookie ~ "(SESS[a-z0-9]+|SSESS[a-z0-9]+)") {
+        if (req.http.Cookie ~ "S?SESS[a-z0-9]+=") {
           # Authenticated users should not be cached
           return (pass);
         }

--- a/drupal/templates/varnish-configmap-vcl.yaml
+++ b/drupal/templates/varnish-configmap-vcl.yaml
@@ -183,7 +183,7 @@ data:
         set beresp.http.x-ttl = "10m";
       }
 
-      if (bereq.url ~ "^[^?]*\.(jpg|jpeg|gif|png|svg|ico|webp|css|js|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|flv|swf|html|htm|otf)(\?.*)?$") {
+      if (bereq.url ~ "^[^?]*\.(?:jpg|jpeg|gif|png|svg|ico|webp|css|js|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|flv|swf|html|htm|otf)(?:\?.*)?$") {
         # Strip any cookies before static files are inserted into cache.
         unset beresp.http.set-cookie;
         if(beresp.status == 200){
@@ -199,7 +199,7 @@ data:
       # Large static files are delivered directly to the end-user without
       # waiting for Varnish to fully read the file first.
       # Varnish 4 fully supports Streaming, so use streaming here to avoid locking.
-      if (bereq.url ~ "^[^?]*\.(mp[34]|rar|tar|tgz|gz|pdf|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(\?.*)?$") {
+      if (bereq.url ~ "^[^?]*\.(?:mp[34]|rar|tar|tgz|gz|pdf|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(?:\?.*)?$") {
         unset beresp.http.set-cookie;
         set beresp.do_stream = true;  # Check memory usage it'll grow in fetch_chunksize blocks (128k by default) if the backend doesn't send a Content-Length header, so only enable it for big objects
         set beresp.do_gzip = false;   # Don't try to compress it for storage
@@ -425,7 +425,7 @@ data:
 
       {{- if .Values.mailpit.enabled }}
       // No varnish for mailpit
-      if (req.url ~ "^/mailpit(/|$)") {
+      if (req.url ~ "^/mailpit(?:/|$)") {
         return (pass);
       }
       {{- end }}
@@ -440,7 +440,7 @@ data:
       }
 
       if (req.http.Accept-Encoding) {
-        if (req.url ~ "\.(bz2|eot|gif|gz|ico|jpg|mp3|ogg|pdf|png|svg|swf|tbz|tgz|tif|tiff|ttf|webp|woff|zip)(\?.*)?$") {
+        if (req.url ~ "\.(?:bz2|eot|gif|gz|ico|jpg|mp3|ogg|pdf|png|svg|swf|tbz|tgz|tif|tiff|ttf|webp|woff|zip)(\?.*)?$") {
           # No point in compressing these
           unset req.http.Accept-Encoding;
         } elsif (req.http.Accept-Encoding ~ "gzip") {
@@ -453,14 +453,14 @@ data:
         }
       }
 
-      if (req.url ~ "\.(bmp|bz2|css|doc|eot|gif|ico|jpg|js|pdf|png|ppt|svg|swf|tif|tiff|ttf|webp|woff|xls|zip)$") {
+      if (req.url ~ "\.(?:bmp|bz2|css|doc|eot|gif|ico|jpg|js|pdf|png|ppt|svg|swf|tif|tiff|ttf|webp|woff|xls|zip)$") {
         # Static file request do not vary on cookies
         unset req.http.Cookie;
         return (hash);
       }
 
       # Do not allow public access to cron.php , update.php or install.php.
-      if (req.url ~ "^(|/core)/(cron|install|update)\.php$" && !client.ip ~ internal) {
+      if (req.url ~ "^(?:/core)?/(?:cron|install|update)\.php$" && !client.ip ~ internal) {
         # Have Varnish throw the error directly.
         return (synth( 404, "Page not found."));
       }
@@ -502,7 +502,7 @@ data:
       # Large static files are delivered directly to the end-user without
       # waiting for Varnish to fully read the file first.
       # Varnish 4 fully supports Streaming, so set do_stream in vcl_backend_response()
-      if (req.url ~ "^[^?]*\.(mp[34]|rar|tar|tgz|gz|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(\?.*)?$") {
+      if (req.url ~ "^[^?]*\.(?:mp[34]|rar|tar|tgz|gz|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(?:\?.*)?$") {
         unset req.http.Cookie;
         return (hash);
       }

--- a/frontend/templates/varnish-configmap-vcl.yaml
+++ b/frontend/templates/varnish-configmap-vcl.yaml
@@ -56,6 +56,45 @@ data:
         return (synth(400));
       }
 
+      # Only allow BAN requests from IP addressees in the 'internal' ACL.
+      if (req.method == "BAN") {
+        # Admin port is only exposed to internal network
+        if (!client.ip ~ internal) {
+          return (synth(403, "Not allowed."));
+        }
+
+        # Logic for the ban, using the cache tags headers.
+        if (req.http.Cache-Tags) {
+          ban("obj.http.Cache-Tags ~ " + req.http.Cache-Tags);
+        }
+        else {
+          # If there are no cache tags headers in a BAN request,
+          # it is a bad request, so indicate that to the client.
+          return (synth(400, "Cache tags headers not present."));
+        }
+        # Throw a synthetic page so the request won't go to the backend.
+        return (synth(200, "Ban added."));
+      }
+
+      # Only allow URIBAN requests from IP addressees in the 'internal' ACL.
+      if (req.method == "URIBAN") {
+        # Admin port is only exposed to internal network
+        if (!client.ip ~ internal) {
+          return (synth(403, "Not allowed."));
+        }
+
+        # If x-url-invalidate-pattern header is present,
+        # use it to match URLs in stored objects. (ban by regex pattern)
+        if (req.http.x-url-invalidate-pattern) {
+          ban("obj.http.x-url ~ " + req.http.x-url-invalidate-pattern);
+        }
+        else {
+          ban("obj.http.host == " + req.http.host + " && obj.http.x-url == " + req.url);
+        }
+        # Throw a synthetic page so the request won't go to the backend.
+        return (synth(200, "Ban added."));
+      }
+
       # Match upstream allowlist to supply headers containing real ip
       if (client.ip ~ upstream_proxy && req.http.X-Envoy-External-Address) {
         set req.http.X-Forwarded-For = req.http.X-Envoy-External-Address;
@@ -98,27 +137,6 @@ data:
       # Do not cache requests with Authorization header
       if (req.http.Authorization) {
         return (pass);
-      }
-
-      # Only allow BAN requests from IP addresses in the 'purge' ACL.
-      if (req.method == "BAN" || req.method == "URIBAN") {
-        # Admin port is only exposed to internal network
-        if (!client.ip ~ internal) {
-          return (synth(403, "Not allowed."));
-        }
-
-        # Logic for the ban, using the cache tags headers.
-        if (req.http.Cache-Tags) {
-          ban("obj.http.Cache-Tags ~ " + req.http.Cache-Tags);
-        }
-        elseif (req.method == "URIBAN") {
-          ban("req.http.host == " + req.http.host + " && req.url == " + req.url);
-        }
-        else {
-          return (synth(403, "Cache tags headers not present."));
-        }
-        # Throw a synthetic page so the request won't go to the backend.
-        return (synth(200, "Ban added."));
       }
 
       # Implementing websocket support (https://www.varnish-cache.org/docs/4.0/users-guide/vcl-example-websockets.html)

--- a/frontend/templates/varnish-configmap-vcl.yaml
+++ b/frontend/templates/varnish-configmap-vcl.yaml
@@ -158,13 +158,13 @@ data:
 
       {{- if .Values.mailpit.enabled }}
       // No varnish for mailpit
-      if (req.url ~ "^/mailpit(/|$)") {
+      if (req.url ~ "^/mailpit(?:/|$)") {
         return (pass);
       }
       {{- end }}
 
       if (req.http.Accept-Encoding) {
-        if (req.url ~ "\.(jpg|png|gif|svg|tif|tiff|ico|webp|gz|tgz|bz2|tbz|mp3|ogg|swf|zip|pdf|woff|eot|ttf)(\?.*)?$") {
+        if (req.url ~ "\.(?:jpg|png|gif|svg|tif|tiff|ico|webp|gz|tgz|bz2|tbz|mp3|ogg|swf|zip|pdf|woff|eot|ttf)(?:\?.*)?$") {
           # No point in compressing these
           unset req.http.Accept-Encoding;
         } elsif (req.http.Accept-Encoding ~ "gzip") {


### PR DESCRIPTION
# Changes

- (drupal/varnish): Fix issue with Varnish varying cached static files by cookies
- (drupal/varnish, frontend/varnish): Fix URIBAN behavior, add support for URIBAN by regex
  
# Notes

- Making a URIBAN request with a header like `x-url-invalidate-pattern: ^/sites/default/files/foo/bar\.pdf` will purge the cache from entries matching the pattern
- Making a URIBAN request with no such header will purge cache from entries which exactly match the Host header and the URL, just as before
- For the frontend chart, the BAN/URIBAN handling is moved before the allowed method checks (one would assume the previous placement made purging entirely non-functional)
