### PR TITLE
Release 2025-09-09

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
         # Available minikube kubernetes version list:
         # "minikube config defaults kubernetes-version"
         # and https://kubernetes.io/releases/patch-releases/
-        kubernetes-version: ["v1.22.17", "v1.23.17", "v1.24.17", "v1.25.16", "v1.26.15", "v1.27.16", "v1.28.13", "v1.29.8", "v1.30.4", "v1.31.0", "latest"]
+        kubernetes-version: ["v1.25.16", "v1.26.15", "v1.27.16", "v1.28.15", "v1.29.14", "v1.30.14", "v1.31.12", "v1.32.8", "latest"]
     env:
       CLUSTER_DOMAIN: minikube.local.wdr.io
       K8S_PROJECT_REPO_DIR: k8s-project-repositories
@@ -34,8 +34,7 @@ jobs:
           mkdir -p ~/.local/bin
 
           # Latest tagged release
-          latest_release_url=$(curl -s https://api.github.com/repos/wunderio/silta-cli/releases/latest | jq -r '.assets[] | .browser_download_url | select(endswith("linux-amd64.tar.gz"))')
-          curl -sL $latest_release_url | tar xz -C ~/.local/bin
+          curl -sL https://silta-cli.wdr.io/releases/latest/silta-latest-linux-amd64.tar.gz | tar xz -C ~/.local/bin
 
           silta version
       - name: Helm and repository setup

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.22.0
+version: 1.23.0
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -125,8 +125,8 @@ singleSubdomain: false
 # These variables are build-specific and should be passed via the --set parameter.
 nginx:
   # The nginx version, for example "1.28".
-  version: "1.26"
-  image: 'wunderio/silta-nginx:1.26-v1'
+  version: "1.28"
+  image: 'wunderio/silta-nginx:1.28-v1'
 
   # Requires "X-Proxy-Auth" header from upstream when value is non-empty string.
   x_proxy_auth: ""
@@ -690,7 +690,7 @@ mailhog:
 redis:
   enabled: false
   # https://hub.docker.com/r/bitnamilegacy/redis/tags
-  # https://hub.docker.com/r/wunderio/bitnami-redis/tags  
+  # https://hub.docker.com/r/wunderio/bitnami-redis/tags
   image:
     registry: docker.io
     repository: wunderio/bitnami-redis

--- a/silta-cluster/Chart.lock
+++ b/silta-cluster/Chart.lock
@@ -1,13 +1,13 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.10.6
+  version: 4.13.2
 - name: traefik
   repository: file://../legacy_traefik
   version: 1.87.7
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.10.6
+  version: 4.13.2
 - name: pxc-operator
   repository: https://percona.github.io/percona-helm-charts/
   version: 1.12.2
@@ -35,5 +35,5 @@ dependencies:
 - name: docker-registry
   repository: https://helm.twun.io
   version: 2.1.0
-digest: sha256:68c92a3e6911d09aa70e18d7ad3f0043940a9e3b7430b4b52b054bc709926099
-generated: "2025-08-18T10:40:23.132970146+03:00"
+digest: sha256:4d4ec59c0e83237f1b1a5da9620f5d63272f897830a7343864470cb86bf2a107
+generated: "2025-09-08T14:58:36.542861325+03:00"

--- a/silta-cluster/Chart.yaml
+++ b/silta-cluster/Chart.yaml
@@ -2,14 +2,14 @@ apiVersion: v2
 appVersion: "1.0"
 description: Setup a silta kubernetes cluster.
 name: silta-cluster
-version: 1.10.1
+version: 1.11.0
 # csi-rclone external provisioner requires kubernetes 1.20+
 # https://github.com/kubernetes-csi/external-provisioner?tab=readme-ov-file#compatibility
 kubeVersion: '>=1.20.0-0'
 dependencies:
 - name: ingress-nginx
   # check kubernetes version requirements here: https://github.com/kubernetes/ingress-nginx
-  version: 4.10.x
+  version: 4.13.x
   repository: https://kubernetes.github.io/ingress-nginx
   condition: ingress-nginx.enabled
 - name: traefik
@@ -18,7 +18,7 @@ dependencies:
   condition: traefik.enabled
 - name: ingress-nginx
   # check kubernetes version requirements here: https://github.com/kubernetes/ingress-nginx
-  version: 4.10.x
+  version: 4.13.x
   alias: nginx-traefik
   repository: https://kubernetes.github.io/ingress-nginx
   condition: nginx-traefik.enabled

--- a/silta-cluster/values.yaml
+++ b/silta-cluster/values.yaml
@@ -11,7 +11,7 @@ ingress:
 
 # Community ingress-nginx chart
 # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
-# https://github.com/kubernetes/ingress-nginx/blob/e4a66fd2f625de3bcc7aaa793b31f529a0662009/charts/ingress-nginx/values.yaml
+# https://github.com/kubernetes/ingress-nginx/blob/106e633655e7e5799ccf28d747b07d78833cd860/charts/ingress-nginx/values.yaml
 ingress-nginx:
   enabled: false
   controller:
@@ -133,7 +133,7 @@ ssl:
 
 # Community ingress-nginx chart
 # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/
-# https://github.com/kubernetes/ingress-nginx/blob/e4a66fd2f625de3bcc7aaa793b31f529a0662009/charts/ingress-nginx/values.yaml
+# https://github.com/kubernetes/ingress-nginx/blob/106e633655e7e5799ccf28d747b07d78833cd860/charts/ingress-nginx/values.yaml
 # This is a duplicate of the ingress-nginx chart, but with a different name, meant to immitate traefik ingress class and replace it.
 nginx-traefik:
   enabled: false
@@ -191,7 +191,6 @@ nginx-traefik:
       # Different error codes to distinguish rate limit states
       limit-req-status-code: 420
       limit-conn-status-code:  529
-      global-rate-limit-status-code: 429
       # ModSecurity https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-modsecurity
       # Off by default, enable using ingress annotations
       enable-modsecurity: false


### PR DESCRIPTION
Frontend chart:
- Upgrade default nginx version to 1.28 ([PR](https://github.com/wunderio/frontend-project-k8s/pull/159))

Silta cluster chart:
- ingress-nginx update ([PR](https://github.com/wunderio/charts/pull/501))