### PR TITLE
Add storage.silta/storage-path annotation to Solr's volumeClaimTemplates

### DIFF
--- a/drupal/templates/solr-statefulset.yaml
+++ b/drupal/templates/solr-statefulset.yaml
@@ -88,7 +88,7 @@ spec:
         storage.silta/storage-path: {{ .Values.environmentName | default .Release.Name }}/solr-data
       {{- end }}
     spec:
-      accessModes: [ "ReadWriteOnce" ]
+      accessModes: {{ .Values.solr.persistence.data.accessModes }}
       {{- if .Values.solr.persistence.data.storageClassName }}
       storageClassName: {{ .Values.solr.persistence.data.storageClassName }}
       {{- else if eq .Values.cluster.type "gke" }}
@@ -100,5 +100,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.solr.persistence.data.size }}
-      accessModes: {{ .Values.solr.persistence.data.accessModes }}
 {{- end }}

--- a/drupal/templates/solr-statefulset.yaml
+++ b/drupal/templates/solr-statefulset.yaml
@@ -83,6 +83,10 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: {{ .Release.Name }}-solr-data
+      {{- if or (eq .Values.solr.persistence.data.storageClassName "silta-shared") (eq .Values.solr.persistence.data.storageClassName "nfs-shared") }}
+      annotations:
+        storage.silta/storage-path: {{ .Values.environmentName | default .Release.Name }}/solr-data
+      {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.solr.persistence.data.storageClassName }}

--- a/drupal/tests/solr_test.yaml
+++ b/drupal/tests/solr_test.yaml
@@ -1,0 +1,38 @@
+suite: solr
+templates:
+  - solr-statefulset.yaml
+  - solr-service.yaml
+capabilities:
+  apiVersions:
+    - pxc.percona.com/v1
+tests:
+  - it: storage path annotation is not set by default
+    template: solr-statefulset.yaml
+    set:
+      solr:
+        enabled: true
+    asserts:
+      - notExists:
+          path: spec.volumeClaimTemplates[0].metadata.annotations['storage.silta/storage-path']
+  - it: storage path annotation set if silta-shared storage class used
+    template: solr-statefulset.yaml
+    set:
+      solr:
+        enabled: true
+        persistence:
+          data:
+            storageClassName: silta-shared
+    asserts:
+      - exists:
+          path: spec.volumeClaimTemplates[0].metadata.annotations['storage.silta/storage-path']
+  - it: storage path annotation set if nfs-shared storage class used
+    template: solr-statefulset.yaml
+    set:
+      solr:
+        enabled: true
+        persistence:
+          data:
+            storageClassName: nfs-shared
+    asserts:
+      - exists:
+          path: spec.volumeClaimTemplates[0].metadata.annotations['storage.silta/storage-path']


### PR DESCRIPTION
**Motivation:**
Solr allows to override the storageClassName in helm chart values but is missing the storage.silta/storage-path annotation. If storage class is overridden to silta-shared or nfs-shared, this will map Solr's data volume at {server}/{namespace-x} rather {server}/{namespace-x}/{release-x}/solr-data (i.e., similar to what shell’s volume would do: https://github.com/wunderio/charts/blob/e6613fcc83a28b1d5366efecf0446e44875cdbf3/drupal/templates/shell-volume.yaml#L41
Mapping Solr's data volume to project's namespace folder can cause major issues on a project level, i.e.:
- If there are multiple releases per namespace using Solr, all will use the same storage thus causing potential confusion (if one environment gets indexes flushed, it will cause search to not work on any other env as well)
- If a Solr-enabled release gets uninstalled, most likely it will delete the entire {namespace-x} folder from the server associated with the overridden storage class due to persistentVolumeReclaimPolicy: Delete set on the PV, causing major data loss.

**Changes proposed:**
- Add storage.silta/storage-path annotation to Solr's volumeClaimTemplates if storage class is either silta-shared or nfs-shared
- Add helm unit tests verifying that the annotation is present if applicable. Remove the duplicate accessModes property from volumeClaimTemplate as unit tests were complaining about it.
