### PR TITLE
activeDeadlineSeconds to Drupal and Frontend charts

### DIFF
--- a/drupal/Chart.yaml
+++ b/drupal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: drupal
-version: 1.31.0
+version: 1.31.1
 dependencies:
 - name: mariadb
   version: 7.5.x

--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -25,9 +25,9 @@ spec:
   suspend: false
   jobTemplate:
     spec:
-      # This is a fallback for sidecar termination failure.
-      # Two hours should be enough for any cron actions.
-      activeDeadlineSeconds: 7200
+      {{- if or $job.activeDeadlineSeconds ($.Values.php.cronJobDefaults).activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ $job.activeDeadlineSeconds | default $.Values.php.cronJobDefaults.activeDeadlineSeconds }}
+      {{- end }}
       backoffLimit: {{ $job.backoffLimit | default 1 }}
       template:
         metadata:

--- a/drupal/templates/drupal-cron.yaml
+++ b/drupal/templates/drupal-cron.yaml
@@ -25,6 +25,9 @@ spec:
   suspend: false
   jobTemplate:
     spec:
+      # This is a fallback for sidecar termination failure.
+      # Two hours should be enough for any cron actions.
+      activeDeadlineSeconds: 7200
       backoffLimit: {{ $job.backoffLimit | default 1 }}
       template:
         metadata:

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -283,6 +283,7 @@ php:
       enabled: true
 
   cronJobDefaults:
+    # activeDeadlineSeconds: 7200
     # resources:
     #   requests:
     #     cpu: 500m
@@ -316,6 +317,10 @@ php:
 
       # Specify a how many attempts should be made before considering a cron job as failed.
       backoffLimit: 1
+
+      # Set activeDeadlineSeconds for this specific cron job.
+      # If not set, the cronJobDefaults value is used. If neither is set, no deadline is applied.
+      # activeDeadlineSeconds: 7200
 
       # Set resources specifically for cron jobs. If not set, they will be
       # inherited from php.resources.

--- a/drupal/values.yaml
+++ b/drupal/values.yaml
@@ -319,7 +319,6 @@ php:
       backoffLimit: 1
 
       # Set activeDeadlineSeconds for this specific cron job.
-      # If not set, the cronJobDefaults value is used. If neither is set, no deadline is applied.
       # activeDeadlineSeconds: 7200
 
       # Set resources specifically for cron jobs. If not set, they will be

--- a/frontend/Chart.yaml
+++ b/frontend/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: frontend
-version: 1.27.0
+version: 1.27.1
 dependencies:
 - name: mariadb
   version: 7.10.x

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -20,9 +20,9 @@ spec:
   suspend: false
   jobTemplate:
     spec:
-      # This is a fallback for sidecar termination failure.
-      # Two hours should be enough for cron actions.
-      activeDeadlineSeconds: 7200
+      {{- if or $job.activeDeadlineSeconds ($.Values.cronJobDefaults).activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ $job.activeDeadlineSeconds | default $.Values.cronJobDefaults.activeDeadlineSeconds }}
+      {{- end }}
       parallelism: {{ default 1 $job.parallelism }}
       template:
         metadata:

--- a/frontend/templates/services-cron.yaml
+++ b/frontend/templates/services-cron.yaml
@@ -20,6 +20,9 @@ spec:
   suspend: false
   jobTemplate:
     spec:
+      # This is a fallback for sidecar termination failure.
+      # Two hours should be enough for cron actions.
+      activeDeadlineSeconds: 7200
       parallelism: {{ default 1 $job.parallelism }}
       template:
         metadata:

--- a/frontend/values.yaml
+++ b/frontend/values.yaml
@@ -280,6 +280,7 @@ services: {}
   #      command: echo "hello world"
   #      schedule: "~ 1 * * *"
   #      parallelism: 1
+  #      # activeDeadlineSeconds: 7200
   #      nodeSelector:
   #        cloud.google.com/gke-nodepool: static-ip
   #      tolerations: []
@@ -438,6 +439,7 @@ serviceDefaults:
               - "{{ $.serviceLabel }}"
 # Provide defaults for all cron jobs. This will override serviceDefaults when defined.
 cronJobDefaults:
+  # activeDeadlineSeconds: 7200
   # resources:
   #   requests:
   #     cpu: 100m


### PR DESCRIPTION
drupal/templates/drupal-cron.yaml:
activeDeadlineSeconds is only rendered when `$job.activeDeadlineSeconds` or `$.Values.php.cronJobDefaults.activeDeadlineSeconds` is set.
Per-job value takes precedence over the cronJobDefaults.

frontend/templates/services-cron.yaml:
Only rendered when `$job.activeDeadlineSeconds` or `$.Values.cronJobDefaults.activeDeadlineSeconds` is set.
Per-job value takes precedence over the cronJobDefaults.


```
# Per-job (drupal)
php:
  cron:
    drupal:
      activeDeadlineSeconds: 7200

# Or as a default for all cron jobs (drupal)
php:
  cronJobDefaults:
    activeDeadlineSeconds: 7200

# Per-job (frontend)
services:
  node:
    cron:
      myjob:
        activeDeadlineSeconds: 7200

# Or as a default for all cron jobs (frontend)
cronJobDefaults:
  activeDeadlineSeconds: 7200
```

No value set - no activeDeadlineSeconds in the rendered manifest.